### PR TITLE
fix: 🧑‍💻 add tmxToast to doubles unpairing failure

### DIFF
--- a/src/components/tables/eventsTable/destroyPairs.js
+++ b/src/components/tables/eventsTable/destroyPairs.js
@@ -7,6 +7,7 @@ import { context } from 'services/context';
 
 import { DESTROY_PAIR_ENTRIES } from 'constants/mutationConstants';
 import { OVERLAY } from 'constants/tmxConstants';
+import { tmxToast } from 'services/notifications/tmxToast';
 
 const { UNGROUPED } = entryStatusConstants;
 const { DOUBLES } = eventConstants;
@@ -38,6 +39,7 @@ export const destroySelected = (eventId, drawId) => (table) => {
         context.tables[UNGROUPED].updateOrAddData(entries);
       } else {
         table.deselectRow();
+        tmxToast({ message: result.error[0]?.message ?? 'Error destroying pair', intent: 'is-danger' });
       }
     };
     const params = {


### PR DESCRIPTION
When unpairing alternate doubles pairings, and a pair has already been to a draw, it results in nothing being displayed to the user.

Following on from patterns seen in the codebase, when using callbacks to the `mutationRequest` and encountering an error, it's up to you to display a toast.

Hope this is the right way to do it!

This was a real issue I saw Conrad doing and it seeming very broken.