### PR TITLE
fix: resolve manual seeding editor bugs in Tabulator 6

### DIFF
--- a/src/components/tables/common/editors/numericEditor.ts
+++ b/src/components/tables/common/editors/numericEditor.ts
@@ -39,8 +39,8 @@ export const numericEditor =
         const previousRow = row?.previousSibling;
         const editableCells = previousRow && getChildrenByClassName(previousRow, 'tabulator-editable');
         if (editableCells) {
-          for (cell of editableCells) {
-            if (cell.getAttribute('tabulator-field') === field) cell.focus();
+          for (const editableCell of editableCells) {
+            if (editableCell.getAttribute('tabulator-field') === field) editableCell.focus();
           }
         }
       } else if ((e.key === 'Enter' || e.key === 'Tab') && field) {
@@ -48,8 +48,8 @@ export const numericEditor =
         const nextRow = row?.nextSibling;
         const editableCells = nextRow && getChildrenByClassName(nextRow, 'tabulator-editable');
         if (editableCells) {
-          for (cell of editableCells) {
-            if (cell.getAttribute('tabulator-field') === field) cell.focus();
+          for (const editableCell of editableCells) {
+            if (editableCell.getAttribute('tabulator-field') === field) editableCell.focus();
           }
         }
       }

--- a/src/components/tables/common/editors/numericEditor.ts
+++ b/src/components/tables/common/editors/numericEditor.ts
@@ -33,7 +33,7 @@ export const numericEditor =
 
     editor.addEventListener('keyup', (e: any) => {
       const allNumeric = e.target.value.replace(regex, '') || '';
-      e.target.value = allNumeric > maxValue ? '' : allNumeric;
+      e.target.value = maxValue > 0 && allNumeric > maxValue ? '' : allNumeric;
       if (e.key === 'Tab' && e.shiftKey && field) {
         const row = findAncestor(e.target, 'tabulator-row');
         const previousRow = row?.previousSibling;

--- a/src/components/tables/eventsTable/getEntriesColumns.ts
+++ b/src/components/tables/eventsTable/getEntriesColumns.ts
@@ -5,9 +5,11 @@
  */
 import { formatParticipant } from '../common/formatters/participantFormatter';
 import { flightsFormatter } from '../common/formatters/flightsFormatter';
+import { isSeedingEnabled } from './seeding/seedingState';
 import { getRatingColumns } from '../common/getRatingColumns';
 import { teamsFormatter } from '../common/formatters/teamsFormatter';
 import { numericEditor } from '../common/editors/numericEditor';
+import { cellBorder } from '../common/formatters/cellBorder';
 import { navigateToEvent } from '../common/navigateToEvent';
 import { threeDots } from '../common/formatters/threeDots';
 import { entryActions } from '../../popovers/entryActions';
@@ -105,13 +107,18 @@ export function getEntriesColumns(
     },
     {
       editor: numericEditor({ maxValue: entries?.length || 0, decimals: false, field: 'seedNumber' }),
+      formatter: (cell: any) => {
+        if (isSeedingEnabled(cell.getTable())) return cellBorder(cell);
+        const value = cell.getValue();
+        return value ?? '';
+      },
+      editable: (cell: any) => isSeedingEnabled(cell.getTable()),
       sorterParams: { alignEmptyValues: 'bottom' },
       visible: !!seeding,
       field: 'seedNumber',
       hozAlign: CENTER,
       resizable: false,
       sorter: 'number',
-      editable: false,
       title: t('tables.entries.seed'),
       maxWidth: 70,
     },

--- a/src/components/tables/eventsTable/seeding/enableManualSeeding.ts
+++ b/src/components/tables/eventsTable/seeding/enableManualSeeding.ts
@@ -1,13 +1,21 @@
-import { toggleEditVisibility } from 'components/tables/common/toggleEditVisibility';
+import { findAncestor } from 'services/dom/parentAndChild';
+import { setSeedingEnabled } from './seedingState';
+
+import { NONE } from 'constants/tmxConstants';
+
+const SEEDING_BUTTON_CLASSES = ['saveSeeding', 'cancelManualSeeding'];
 
 export function enableManualSeeding(e: any, table: any): void {
-  toggleEditVisibility({
-    classNames: ['saveSeeding', 'cancelManualSeeding'],
-    columns: ['seedNumber'],
-    visible: true,
-    table,
-    e,
-  });
+  setSeedingEnabled(table, true);
+
+  const optionsRight = findAncestor(e.target, 'options_right');
+  if (optionsRight) {
+    for (const child of optionsRight.children) {
+      const isTarget = Array.from(child.classList).some((c) => SEEDING_BUTTON_CLASSES.includes(c as string));
+      (child as HTMLElement).style.display = isTarget ? '' : NONE;
+    }
+  }
+
   table.showColumn('seedNumber');
   table.redraw(true);
 }

--- a/src/components/tables/eventsTable/seeding/hideSaveSeeding.ts
+++ b/src/components/tables/eventsTable/seeding/hideSaveSeeding.ts
@@ -1,11 +1,20 @@
-import { toggleEditVisibility } from 'components/tables/common/toggleEditVisibility';
+import { findAncestor } from 'services/dom/parentAndChild';
+import { setSeedingEnabled } from './seedingState';
+
+import { NONE } from 'constants/tmxConstants';
+
+const SEEDING_BUTTON_CLASSES = ['saveSeeding', 'cancelManualSeeding'];
 
 export function hideSaveSeeding(e: any, table: any): void {
-  toggleEditVisibility({
-    classNames: ['saveSeeding', 'cancelManualSeeding'],
-    columns: ['seedNumber'],
-    visible: false,
-    table,
-    e
-  });
+  setSeedingEnabled(table, false);
+
+  const optionsRight = findAncestor(e.target, 'options_right');
+  if (optionsRight) {
+    for (const child of optionsRight.children) {
+      const isTarget = Array.from(child.classList).some((c) => SEEDING_BUTTON_CLASSES.includes(c as string));
+      (child as HTMLElement).style.display = isTarget ? NONE : '';
+    }
+  }
+
+  table.redraw(true);
 }

--- a/src/components/tables/eventsTable/seeding/seedingState.ts
+++ b/src/components/tables/eventsTable/seeding/seedingState.ts
@@ -1,0 +1,21 @@
+/**
+ * Module-level state for tracking which tables have manual seeding enabled.
+ * Uses a WeakSet so table references can be garbage collected.
+ *
+ * This avoids Tabulator 6's async `updateColumnDefinition` (which deletes
+ * and recreates the column) and instead lets the column's `editable`
+ * function check this state synchronously on each cell click.
+ */
+const enabledTables = new WeakSet<object>();
+
+export function isSeedingEnabled(table: object): boolean {
+  return enabledTables.has(table);
+}
+
+export function setSeedingEnabled(table: object, enabled: boolean): void {
+  if (enabled) {
+    enabledTables.add(table);
+  } else {
+    enabledTables.delete(table);
+  }
+}


### PR DESCRIPTION
## Summary

- **Fix variable shadowing in `numericEditor`** — the `for/of` loops reused the outer `cell` parameter name, corrupting the Tabulator CellComponent reference after Tab/Shift+Tab navigation
- **Guard against `maxValue <= 0` in `numericEditor`** — when maxValue is 0 (e.g. no entries), every keystroke cleared the input
- **Replace async `updateColumnDefinition` with synchronous state check** — Tabulator 6's `updateColumnDefinition()` deletes and recreates the column asynchronously, causing a race condition where typed seed values vanished. The `editable` and `formatter` column properties now check a `WeakSet`-backed module state synchronously instead

## Approach

The core fix introduces `seedingState.ts` — a module-level `WeakSet<object>` that tracks which table instances have manual seeding enabled. The `seedNumber` column's `editable` and `formatter` functions query this state on each cell interaction, completely avoiding the async column recreation that caused the race.

`enableManualSeeding` and `hideSaveSeeding` now toggle this state and manage button visibility directly via DOM traversal, removing the dependency on `toggleEditVisibility`.

## Test plan

- [ ] Open an event with entries, click "Manual Seeding" — seed column becomes editable
- [ ] Type seed values, Tab between rows — values persist (no disappearing)
- [ ] Shift+Tab navigates to previous row correctly
- [ ] Click "Save Seeding" — column becomes read-only, values saved
- [ ] Click "Cancel" — column becomes read-only, values reverted
- [ ] Open an event with 0 entries — numeric editor doesn't clear input on keystroke
- [ ] `npx tsc --noEmit` passes