### PR TITLE
fix(login): set type='email' on email input

### DIFF
--- a/src/components/modals/loginModal.ts
+++ b/src/components/modals/loginModal.ts
@@ -36,6 +36,7 @@ export function loginModal(callback?: () => void): void {
           autocomplete: 'email',
           label: t('modals.login.emailLabel'),
           field: 'email',
+          type: 'email',
         },
         {
           placeholder: t('modals.login.passwordPlaceholder'),


### PR DESCRIPTION
## The bug

On mobile (iOS Safari, Android Chrome) `<input type="text">` auto-capitalizes the first character by default. The login form's email field uses the default text type, so users get e.g. `Amber@example.com` instead of `amber@example.com` after a routine tap-and-type.

The backend `usersService.findOne` does a byte-exact LevelDB lookup, so the capitalized variant doesn't match the stored lowercase email. Login silently fails with what looks to the user like "wrong password" — but it's actually a 401 from a missing user.

## The fix

Add `type: 'email'` to the email field in `loginModal.ts`. This:
- Suppresses auto-capitalization on iOS and Android
- Surfaces the @-keyboard on mobile
- Hints to password managers about the field's purpose

One-line change, no behavioral impact for desktop users.

## Reproduce before the fix

1. Open the login modal on a phone (or DevTools with mobile UA)
2. Tap the email field, type a lowercase email
3. Note the first letter is capitalized
4. Submit → 401, even with correct password

## Related

A complementary backend fix that normalizes emails to lowercase before lookup is in flight on competition-factory-server (defense in depth — handles already-capitalized emails in storage).