### PR TITLE
feat(auth): provider-admin from scoped role + provisioner, not global admin

### DIFF
--- a/src/components/popovers/providerSwitcher.ts
+++ b/src/components/popovers/providerSwitcher.ts
@@ -17,6 +17,7 @@ import {
   clearActiveProvider,
   getActiveProvider,
   getProviderAssociations,
+  getProvisionerProviders,
 } from 'services/provider/providerState';
 import { selectProviderModal } from 'components/modals/selectProviderModal';
 import { getLoginState } from 'services/authentication/loginState';
@@ -63,6 +64,32 @@ export function openProviderSwitcher({ target }: OpenProviderSwitcherParams): vo
     };
   });
 
+  // Provisioner-managed providers. These have no user_providers row, so the
+  // server would reject persisting them as last-selected — set locally only
+  // (persistServer: false). Deduped against direct associations.
+  const associationIds = new Set(associations.map((assoc) => assoc.providerId));
+  const provisionerItems = getProvisionerProviders()
+    .filter((prov) => !associationIds.has(prov.providerId))
+    .map((prov) => {
+      const isActive = current?.organisationId === prov.providerId;
+      return {
+        text: isActive ? `${prov.organisationName} ✓` : prov.organisationName,
+        hide: false,
+        onClick: () => {
+          if (isActive) return;
+          setActiveProvider(
+            {
+              organisationId: prov.providerId,
+              organisationName: prov.organisationName,
+              organisationAbbreviation: prov.organisationAbbreviation,
+            } as ProviderValue,
+            { persistServer: false },
+          );
+          refreshAfterSwitch();
+        },
+      };
+    });
+
   // Super-admin keeps the "any provider in the system" path on top so
   // they can impersonate beyond their own associations.
   const superAdminItems = isSuperAdmin
@@ -87,6 +114,7 @@ export function openProviderSwitcher({ target }: OpenProviderSwitcherParams): vo
   const items = [
     ...superAdminItems,
     ...associationItems,
+    ...provisionerItems,
     {
       text: t('providerSwitcher.clearImpersonation'),
       // Only super-admins get "Clear" — returning to "no impersonation"

--- a/src/constants/tmxConstants.ts
+++ b/src/constants/tmxConstants.ts
@@ -41,6 +41,11 @@ export const SYNC_INDICATOR = 'syncIndicator';
 
 export const SUPER_ADMIN = 'superadmin';
 export const ADMIN = 'admin';
+// Provider-scoped role (from user_providers.provider_role, present in the JWT's
+// providerAssociations). Distinct from the deprecated global `admin` role above.
+export const PROVIDER_ADMIN = 'PROVIDER_ADMIN';
+// Global role: the user represents a provisioner (Phase 2A).
+export const PROVISIONER = 'provisioner';
 
 export const COMPETITION_ENGINE = 'competitionEngine';
 export const TOURNAMENT_ENGINE = 'tournamentEngine';

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -6,6 +6,7 @@ import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { editTournamentImage } from 'components/modals/tournamentImage';
 import { enterMatchUpScore } from 'services/transitions/scoreMatchUp';
 import { mutationRequest } from 'services/mutation/mutationRequest';
+import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { getLoginState } from 'services/authentication/loginState';
 import { printFactSheet } from 'components/modals/printFactSheet';
 import { openModal } from 'components/modals/baseModal/baseModal';
@@ -26,7 +27,7 @@ import { t } from 'i18n';
 
 // constants
 import { ADD_TOURNAMENT_TIMEITEM, SET_TOURNAMENT_NOTES } from 'constants/mutationConstants';
-import { ADMIN, FORMAT_WIZARD_ACTION_BUTTON, SUPER_ADMIN, TOURNAMENT } from 'constants/tmxConstants';
+import { FORMAT_WIZARD_ACTION_BUTTON, TOURNAMENT } from 'constants/tmxConstants';
 
 const ICON_BTN_STYLE =
   'background:var(--tmx-bg-primary); border:1px solid var(--tmx-border-primary); border-radius:4px; padding:4px 8px; cursor:pointer; font-size:14px; color:var(--tmx-text-primary);';
@@ -426,8 +427,7 @@ export function createActionsPanel(): HTMLElement {
   const provider = tournamentRecord?.parentOrganisation;
   const providerId = provider?.organisationId;
   const state = getLoginState();
-  const superAdmin = state?.roles?.includes(SUPER_ADMIN);
-  const admin = superAdmin || state?.roles?.includes(ADMIN);
+  const admin = isActiveProviderAdmin();
   const activeProvider = context.provider || state?.provider;
 
   if (tournamentRecord && admin) {

--- a/src/pages/tournament/tabs/overviewTab/renderOverview.ts
+++ b/src/pages/tournament/tabs/overviewTab/renderOverview.ts
@@ -1,4 +1,4 @@
-import { getLoginState } from 'services/authentication/loginState';
+import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { removeAllChildNodes } from 'services/dom/transformers';
 import { tournamentEngine } from 'services/factory/engine';
 import { openCategoriesEditorModal } from './categoriesEditorModal';
@@ -25,13 +25,11 @@ import {
 
 // constants
 import {
-  ADMIN,
   EVENTS_TAB,
   FORMAT_WIZARD_LAUNCHER,
   MATCHUPS_TAB,
   PARTICIPANTS,
   PUBLISHING_TAB,
-  SUPER_ADMIN,
   TOURNAMENT,
   TOURNAMENT_OVERVIEW,
 } from 'constants/tmxConstants';
@@ -278,9 +276,7 @@ export function renderOverview(): void {
   statsContainer.appendChild(publishingCard);
   leftColumn.appendChild(statsContainer);
 
-  const state = getLoginState();
-  const isAdmin =
-    state?.roles?.includes(SUPER_ADMIN) || (state?.roles?.includes(ADMIN) && state?.provider?.organisationId);
+  const isAdmin = isActiveProviderAdmin();
 
   // Format Wizard launcher — NOT admin-gated. Visible whenever the
   // wizard's visibility conditions are met (no events, or

--- a/src/services/authentication/isProviderAdmin.test.ts
+++ b/src/services/authentication/isProviderAdmin.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mocks must be declared before importing the module under test.
+vi.mock('services/context', () => ({ context: { provider: undefined } }));
+vi.mock('services/authentication/loginState', () => ({ getLoginState: vi.fn() }));
+
+import { isActiveProviderAdmin } from './isProviderAdmin';
+import { getLoginState } from 'services/authentication/loginState';
+import { context } from 'services/context';
+
+import type { LoginState } from 'types/tmx';
+
+const mockedGetLoginState = vi.mocked(getLoginState);
+const BOBOCA = 'boboca-id';
+const ION = 'ion-id';
+
+const login = (overrides: Partial<LoginState> = {}): LoginState =>
+  ({ email: 'u@x.com', roles: [], permissions: [], services: [], exp: 0, ...overrides }) as LoginState;
+
+const providerAdminAt = (providerId: string) => ({
+  providerId,
+  providerRole: 'PROVIDER_ADMIN',
+  organisationName: providerId,
+  organisationAbbreviation: providerId,
+});
+
+beforeEach(() => {
+  context.provider = undefined;
+  mockedGetLoginState.mockReset();
+});
+
+describe('isActiveProviderAdmin', () => {
+  it('is false when not logged in', () => {
+    mockedGetLoginState.mockReturnValue(undefined);
+    expect(isActiveProviderAdmin()).toBe(false);
+  });
+
+  it('is true for super-admin even with no active provider', () => {
+    mockedGetLoginState.mockReturnValue(login({ roles: ['superadmin'] }));
+    expect(isActiveProviderAdmin()).toBe(true);
+  });
+
+  it('is true for a provisioner whose managed provider is active', () => {
+    context.provider = { organisationId: BOBOCA };
+    mockedGetLoginState.mockReturnValue(
+      login({
+        roles: ['provisioner'],
+        provisionerProviders: [{ providerId: BOBOCA, organisationName: 'BOBOCA', organisationAbbreviation: 'BOBOCA' }],
+      }),
+    );
+    expect(isActiveProviderAdmin()).toBe(true);
+  });
+
+  it('is false for a provisioner when the active provider is NOT one they manage', () => {
+    context.provider = { organisationId: ION };
+    mockedGetLoginState.mockReturnValue(
+      login({
+        roles: ['provisioner'],
+        provisionerProviders: [{ providerId: BOBOCA, organisationName: 'BOBOCA', organisationAbbreviation: 'BOBOCA' }],
+      }),
+    );
+    expect(isActiveProviderAdmin()).toBe(false);
+  });
+
+  it('is true for a PROVIDER_ADMIN at the active provider (no global admin role)', () => {
+    context.provider = { organisationId: BOBOCA };
+    mockedGetLoginState.mockReturnValue(login({ roles: ['client'], providerAssociations: [providerAdminAt(BOBOCA)] }));
+    expect(isActiveProviderAdmin()).toBe(true);
+  });
+
+  it('is false when PROVIDER_ADMIN is at a different provider than the active one', () => {
+    context.provider = { organisationId: ION };
+    mockedGetLoginState.mockReturnValue(login({ roles: ['client'], providerAssociations: [providerAdminAt(BOBOCA)] }));
+    expect(isActiveProviderAdmin()).toBe(false);
+  });
+
+  it('is false for a DIRECTOR at the active provider', () => {
+    context.provider = { organisationId: BOBOCA };
+    mockedGetLoginState.mockReturnValue(
+      login({
+        roles: ['client'],
+        providerAssociations: [
+          { providerId: BOBOCA, providerRole: 'DIRECTOR', organisationName: 'BOBOCA', organisationAbbreviation: 'BOBOCA' },
+        ],
+      }),
+    );
+    expect(isActiveProviderAdmin()).toBe(false);
+  });
+
+  it('honors the deprecated global admin role when a provider is active', () => {
+    context.provider = { organisationId: ION };
+    mockedGetLoginState.mockReturnValue(login({ roles: ['client', 'admin'] }));
+    expect(isActiveProviderAdmin()).toBe(true);
+  });
+
+  it('does NOT grant the deprecated global admin role with no active provider', () => {
+    mockedGetLoginState.mockReturnValue(login({ roles: ['client', 'admin'] }));
+    expect(isActiveProviderAdmin()).toBe(false);
+  });
+});

--- a/src/services/authentication/isProviderAdmin.ts
+++ b/src/services/authentication/isProviderAdmin.ts
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for "is the current user an admin for the active
+ * provider?" — replaces scattered `roles.includes(ADMIN)` checks.
+ *
+ * Resolution (any one grants admin for the currently active provider):
+ *   1. super-admin (global role) — admin everywhere
+ *   2. PROVISIONER managing the active provider (login `provisionerProviders`)
+ *   3. PROVIDER_ADMIN at the active provider (login `providerAssociations`)
+ *   4. legacy global `admin` role — deprecated, honored only until the role is
+ *      retired fleet-wide; scoped to "some provider is active" to match the
+ *      prior behavior so removing the role is the only change users notice.
+ *
+ * The active provider is the impersonated one (`context.provider`) when set,
+ * otherwise the JWT home provider (`state.provider`).
+ */
+import { getLoginState } from 'services/authentication/loginState';
+import { context } from 'services/context';
+
+// constants and types
+import { SUPER_ADMIN, PROVIDER_ADMIN, ADMIN } from 'constants/tmxConstants';
+
+export function isActiveProviderAdmin(): boolean {
+  const state = getLoginState();
+  if (!state) return false;
+  if (state.roles?.includes(SUPER_ADMIN)) return true;
+
+  const activeId = (context.provider ?? state.provider)?.organisationId;
+  if (activeId) {
+    if (state.provisionerProviders?.some((p) => p.providerId === activeId)) return true;
+    const association = state.providerAssociations?.find((a) => a.providerId === activeId);
+    if (association?.providerRole === PROVIDER_ADMIN) return true;
+  }
+
+  // Deprecated global `admin` role — remove once the legacy role is retired.
+  return !!(state.roles?.includes(ADMIN) && activeId);
+}

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -1,6 +1,7 @@
 import { renderSettingsTab } from 'pages/tournament/tabs/settingsTab/renderSettingsTab';
 import { renderOverview } from 'pages/tournament/tabs/overviewTab/renderOverview';
 import { initProviderSwitcher } from 'services/provider/initProviderSwitcher';
+import { isActiveProviderAdmin } from './isProviderAdmin';
 import { clearUserContext, fetchUserContext } from './getUserContext';
 import { clearActiveProvider } from 'services/provider/providerState';
 import { resetActivityTimer } from 'services/staleness/stalenessGuard';
@@ -22,7 +23,7 @@ import { t } from 'i18n';
 import type { LoginState } from 'types/tmx';
 
 // constants
-import { SUPER_ADMIN, ADMIN, TMX_TOURNAMENTS, NONE } from 'constants/tmxConstants';
+import { SUPER_ADMIN, TMX_TOURNAMENTS, NONE } from 'constants/tmxConstants';
 
 export function styleLogin(valid: LoginState | undefined | false): void {
   const el = document.getElementById('login');
@@ -144,7 +145,7 @@ export function initLoginToggle(id: string): void {
         },
         {
           text: t('loginMenu.admin'),
-          hide: !(superAdmin || (loggedIn?.roles?.includes(ADMIN) && context?.provider)),
+          hide: !isActiveProviderAdmin(),
           onClick: () => context.router?.navigate('/admin'),
         },
         {

--- a/src/services/provider/initProviderSwitcher.ts
+++ b/src/services/provider/initProviderSwitcher.ts
@@ -20,6 +20,7 @@ import {
   readPersistedProvider,
   getActiveProvider,
   getProviderAssociations,
+  getProvisionerProviders,
   resolveInitialProvider,
 } from './providerState';
 import { openProviderSwitcher } from 'components/popovers/providerSwitcher';
@@ -38,11 +39,18 @@ function hasMultipleAssociations(): boolean {
   return getProviderAssociations().length > 1;
 }
 
+function hasProvisionerProviders(): boolean {
+  // Provisioners need the affordance even for a single managed provider —
+  // they have no user_providers association, so the switcher is how they
+  // enter a managed provider's context (and gain provider-admin UI).
+  return getProvisionerProviders().length > 0;
+}
+
 function shouldOpenSwitcher(): boolean {
-  // Super-admins always; everyone else only when they have more than one
-  // association to switch among. Single-provider users get a read-only
-  // badge.
-  return isSuperAdmin() || hasMultipleAssociations();
+  // Super-admins always; everyone else when they have more than one
+  // association to switch among, or any provisioner-managed provider to
+  // enter. Single-provider users get a read-only badge.
+  return isSuperAdmin() || hasMultipleAssociations() || hasProvisionerProviders();
 }
 
 function onTournamentsRoute(): boolean {

--- a/src/services/provider/providerState.ts
+++ b/src/services/provider/providerState.ts
@@ -102,6 +102,11 @@ export function getProviderAssociations() {
   return getLoginState()?.providerAssociations ?? [];
 }
 
+/** Providers managed by the user's provisioner(s); admin-equivalent in TMX. */
+export function getProvisionerProviders() {
+  return getLoginState()?.provisionerProviders ?? [];
+}
+
 /**
  * Resolve the initial active provider for a multi-provider user. Precedence:
  *   1. tmx_impersonated_provider in localStorage with full identity fields

--- a/src/types/tmx.ts
+++ b/src/types/tmx.ts
@@ -43,6 +43,17 @@ export interface LoginState {
   }>;
   /** Caller's last explicitly-selected provider; null until they pick one. */
   lastSelectedProviderId?: string | null;
+  /**
+   * Providers managed by the user's provisioner(s), populated server-side at
+   * login for PROVISIONER-role users. Drives the provider switcher and grants
+   * provider-admin UI when one of these is the active provider. Server authz
+   * already honors these via `provisionerProviderIds` (checkTournamentAccess).
+   */
+  provisionerProviders?: Array<{
+    providerId: string;
+    organisationName: string;
+    organisationAbbreviation: string;
+  }>;
   exp: number;
 }
 
@@ -61,6 +72,8 @@ export interface UserContext {
   providerRoles: Record<string, string>;
   /** Convenience: Object.keys(providerRoles). */
   providerIds: string[];
+  /** Provider IDs inherited via the user's provisioner(s); admin-equivalent. */
+  provisionerProviderIds?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
Provider users (e.g. clubx@ionsport.com, a BOBOCA PROVIDER_ADMIN) were surfaced admin UI / routed into the `/admin` app purely via the **deprecated global `admin` role**. The same root cause blocked provisioners from acting as provider admins in TMX. Both reduce to TMX deciding "am I an admin here?" from the global role instead of the provider-scoped role.

## What
- New `services/authentication/isProviderAdmin.ts` → `isActiveProviderAdmin()`: admin for the **active** provider = super-admin **OR** `PROVIDER_ADMIN` at the active provider (`providerAssociations`) **OR** a provisioner-managed provider (`provisionerProviders`) **OR** (legacy) global `admin`.
- Rewired the three gates: login account-menu, `dashboardPanels.ts`, `renderOverview.ts` (dropped now-dead `ADMIN`/`SUPER_ADMIN` imports).
- Provider switcher now offers provisioner-managed providers (set local-only — they have no `user_providers` row to persist against).
- `LoginState.provisionerProviders` + `UserContext.provisionerProviderIds` types; `PROVIDER_ADMIN` / `PROVISIONER` constants.

## Tests
New `isProviderAdmin.test.ts` (9 cases). Full suite **487 pass**; check-types, lint, build all green.

## ⚠️ Deploy ordering
Companion server PR: **competition-factory-server `fix/provisioner-admin-routing`** (adds `provisionerProviders` to the login JWT, scopes admin-client `/admin` routing to real admins, and ships the role-retirement data-fix). **Deploy this gate before** running the data-fix that strips the legacy global `admin` role — otherwise every PROVIDER_ADMIN loses TMX admin UI. Server authz is unaffected.