### PR TITLE
test(tmx): e2e provider switcher + admin gating (real login)

### DIFF
--- a/e2e/helpers/role-fixtures.ts
+++ b/e2e/helpers/role-fixtures.ts
@@ -1,0 +1,154 @@
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * Server-side fixtures for the role-gating journey (real login, not token
+ * injection — TMX's authenticated boot is server-coupled, so the JWT must come
+ * from a genuine /auth/login). Seeds providers / role-scoped users / a
+ * provisioner via the admin API, as a super-admin.
+ *
+ * Bootstrap super-admin defaults to the dedicated e2e account the admin-client
+ * suite provisions; override via env. If it can't authenticate, the caller
+ * should test.skip the journey (mirrors journey 28's reachability skip) rather
+ * than fail CI when the seed admin is absent.
+ */
+export const SERVER = process.env.E2E_API_BASE ?? 'http://localhost:8383';
+export const SUPERADMIN_EMAIL = process.env.E2E_SUPERADMIN_EMAIL ?? 'e2e-admin@courthive.test';
+export const SUPERADMIN_PASSWORD = process.env.E2E_SUPERADMIN_PASSWORD ?? 'e2e-test-password-do-not-reuse';
+export const ROLE_PASSWORD = process.env.E2E_ROLE_PASSWORD ?? 'e2e-role-password-do-not-reuse';
+
+const authHeaders = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+/** Returns a super-admin JWT, or null if the bootstrap admin can't authenticate. */
+export async function signInSuperAdmin(request: APIRequestContext): Promise<string | null> {
+  try {
+    const res = await request.post(`${SERVER}/auth/login`, {
+      data: { email: SUPERADMIN_EMAIL, password: SUPERADMIN_PASSWORD },
+      timeout: 5000,
+    });
+    if (!res.ok()) return null;
+    const body = await res.json();
+    return body?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureProvider(
+  request: APIRequestContext,
+  token: string,
+  organisationAbbreviation: string,
+  organisationName: string,
+): Promise<string> {
+  const addRes = await request.post(`${SERVER}/provider/add`, {
+    headers: authHeaders(token),
+    data: { organisationAbbreviation, organisationName },
+  });
+  const addBody = await addRes.json().catch(() => ({}));
+  if (addBody?.providerId) return addBody.providerId;
+
+  const listRes = await request.post(`${SERVER}/provider/allproviders`, { headers: authHeaders(token) });
+  const listBody = await listRes.json();
+  const match = (listBody?.providers ?? []).find(
+    (p: any) => p?.value?.organisationAbbreviation === organisationAbbreviation,
+  );
+  const providerId = match?.value?.organisationId;
+  if (!providerId) throw new Error(`ensureProvider(${organisationAbbreviation}): ${JSON.stringify(addBody)}`);
+  return providerId;
+}
+
+export interface CreateUserOpts {
+  email: string;
+  roles?: string[];
+  providerId?: string;
+  providerRole?: 'PROVIDER_ADMIN' | 'DIRECTOR';
+}
+
+/** Create a login-ready user (clears the forced first-login password change). */
+export async function createLoginableUser(
+  request: APIRequestContext,
+  token: string,
+  opts: CreateUserOpts,
+): Promise<void> {
+  const createRes = await request.post(`${SERVER}/auth/admin-create-user`, {
+    headers: authHeaders(token),
+    data: {
+      email: opts.email,
+      password: ROLE_PASSWORD,
+      roles: opts.roles ?? [],
+      providerId: opts.providerId,
+      providerRole: opts.providerRole,
+    },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`admin-create-user(${opts.email}) failed (${createRes.status()}): ${await createRes.text()}`);
+  }
+  const loginRes = await request.post(`${SERVER}/auth/login`, {
+    data: { email: opts.email, password: ROLE_PASSWORD },
+  });
+  const loginBody = await loginRes.json().catch(() => ({}));
+  if (loginBody?.limitedToken) {
+    const completeRes = await request.post(`${SERVER}/auth/complete-first-login`, {
+      data: { limitedToken: loginBody.limitedToken, newPassword: ROLE_PASSWORD },
+    });
+    if (!completeRes.ok()) {
+      throw new Error(`complete-first-login(${opts.email}) failed (${completeRes.status()})`);
+    }
+  }
+}
+
+export async function removeUser(request: APIRequestContext, token: string, email: string): Promise<void> {
+  if (!email) return;
+  await request.post(`${SERVER}/auth/remove`, { headers: authHeaders(token), data: { email } });
+}
+
+export async function createProvisioner(request: APIRequestContext, token: string, name: string): Promise<string> {
+  const res = await request.post(`${SERVER}/admin/provisioners`, { headers: authHeaders(token), data: { name } });
+  if (!res.ok()) throw new Error(`create provisioner(${name}) failed (${res.status()})`);
+  const body = await res.json();
+  const id = body?.provisionerId ?? body?.id ?? body?.provisioner?.provisionerId ?? body?.provisioner?.id;
+  if (!id) throw new Error(`create provisioner(${name}): no id in ${JSON.stringify(body)}`);
+  return id;
+}
+
+export async function associateProviderToProvisioner(
+  request: APIRequestContext,
+  token: string,
+  provisionerId: string,
+  providerId: string,
+): Promise<void> {
+  const res = await request.post(`${SERVER}/admin/provisioners/${provisionerId}/providers`, {
+    headers: authHeaders(token),
+    data: { providerId, relationship: 'owner' },
+  });
+  if (!res.ok()) throw new Error(`associate provider failed (${res.status()})`);
+}
+
+export async function assignProvisionerRep(
+  request: APIRequestContext,
+  token: string,
+  provisionerId: string,
+  email: string,
+): Promise<void> {
+  const res = await request.post(`${SERVER}/admin/provisioners/${provisionerId}/users`, {
+    headers: authHeaders(token),
+    data: { email },
+  });
+  if (!res.ok()) throw new Error(`assign rep(${email}) failed (${res.status()})`);
+}
+
+export async function cleanupProvisioner(
+  request: APIRequestContext,
+  token: string,
+  provisionerId: string,
+): Promise<void> {
+  if (!provisionerId) return;
+  await request.put(`${SERVER}/admin/provisioners/${provisionerId}`, {
+    headers: authHeaders(token),
+    data: { isActive: false },
+  });
+  await request.delete(`${SERVER}/admin/provisioners/${provisionerId}`, { headers: authHeaders(token) });
+}
+
+export function uniqueSuffix(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+}

--- a/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
+++ b/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, type Page } from '@playwright/test';
+import { waitForAppReady } from '../helpers/dev-bridge';
+import {
+  SERVER,
+  ROLE_PASSWORD,
+  uniqueSuffix,
+  removeUser,
+  ensureProvider,
+  createProvisioner,
+  signInSuperAdmin,
+  assignProvisionerRep,
+  cleanupProvisioner,
+  createLoginableUser,
+  associateProviderToProvisioner,
+} from '../helpers/role-fixtures';
+
+/**
+ * Journey 36 — provider switcher + admin gating (real server login).
+ *
+ * Validates the provisioner-admin-routing client work end-to-end: a real login
+ * issues a JWT whose providerAssociations / provisionerProviders drive
+ * `isActiveProviderAdmin()` (account-menu "Admin" item) and the provider
+ * switcher. Token injection is NOT used — TMX's authenticated boot is
+ * server-coupled, so the JWT must come from a genuine /auth/login (mirrors
+ * journey 28's pattern).
+ *
+ * Seeds via the admin API as a super-admin; if that bootstrap account is
+ * unavailable the whole journey skips (so it never red-fails CI on a missing
+ * seed). Requires CFS at SERVER.
+ */
+const suffix = uniqueSuffix();
+const PROVIDER_ADMIN_EMAIL = `e2e-tmx-padmin-${suffix}@courthive.test`;
+const DIRECTOR_EMAIL = `e2e-tmx-director-${suffix}@courthive.test`;
+const REP_EMAIL = `e2e-tmx-rep-${suffix}@courthive.test`;
+const PROVISIONER_NAME = `E2E-TMX-Provisioner-${suffix}`;
+const PROVIDER_NAME = 'E2E TMX Role Provider';
+
+let token: string | null = null;
+let seeded = false;
+let providerId = '';
+let provisionerId = '';
+
+async function loginViaModal(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await page.locator('#login').click();
+  await page.getByText('Log in').click();
+  await page.locator('input[placeholder*="email"]').fill(email);
+  await page.locator('input[placeholder*="8 characters"]').fill(password);
+  await page.getByRole('button', { name: 'Login' }).click();
+  // Sign-in + provider resolution are async; give the app a beat to settle
+  // (matches journey 28). Subsequent assertions poll, so this is a floor.
+  await page.waitForTimeout(1500);
+}
+
+test.describe('Journey 36 — provider switcher + admin gating (real login)', () => {
+  test.beforeAll(async ({ request }) => {
+    token = await signInSuperAdmin(request);
+    if (!token) return; // seed admin unavailable → tests skip below
+
+    providerId = await ensureProvider(request, token, 'TMXROLE', PROVIDER_NAME);
+    await createLoginableUser(request, token, {
+      email: PROVIDER_ADMIN_EMAIL,
+      roles: ['client'],
+      providerId,
+      providerRole: 'PROVIDER_ADMIN',
+    });
+    await createLoginableUser(request, token, {
+      email: DIRECTOR_EMAIL,
+      roles: ['client'],
+      providerId,
+      providerRole: 'DIRECTOR',
+    });
+    await createLoginableUser(request, token, { email: REP_EMAIL, roles: ['client'] });
+    provisionerId = await createProvisioner(request, token, PROVISIONER_NAME);
+    await associateProviderToProvisioner(request, token, provisionerId, providerId);
+    await assignProvisionerRep(request, token, provisionerId, REP_EMAIL);
+    seeded = true;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (!token) return;
+    await cleanupProvisioner(request, token, provisionerId);
+    await removeUser(request, token, PROVIDER_ADMIN_EMAIL);
+    await removeUser(request, token, DIRECTOR_EMAIL);
+    await removeUser(request, token, REP_EMAIL);
+  });
+
+  test('PROVIDER_ADMIN sees the Admin item in the account menu', async ({ page }) => {
+    test.skip(!seeded, `seed unavailable (CFS at ${SERVER} / bootstrap super-admin)`);
+    await loginViaModal(page, PROVIDER_ADMIN_EMAIL, ROLE_PASSWORD);
+    await page.locator('#login').click();
+    await expect(page.getByText('Admin', { exact: true })).toBeVisible();
+  });
+
+  test('a DIRECTOR does NOT see the Admin item', async ({ page }) => {
+    test.skip(!seeded, `seed unavailable (CFS at ${SERVER} / bootstrap super-admin)`);
+    await loginViaModal(page, DIRECTOR_EMAIL, ROLE_PASSWORD);
+    await page.locator('#login').click();
+    await expect(page.getByText('Log out', { exact: true })).toBeVisible(); // menu opened
+    await expect(page.getByText('Admin', { exact: true })).toHaveCount(0);
+  });
+
+  test('a provisioner sees their managed provider in the switcher', async ({ page }) => {
+    test.skip(!seeded, `seed unavailable (CFS at ${SERVER} / bootstrap super-admin)`);
+    await loginViaModal(page, REP_EMAIL, ROLE_PASSWORD);
+    // Login lands on /tournaments; the provider badge opens the switcher, which
+    // offers the provisioner-managed provider (validates the server emits
+    // provisionerProviders and TMX consumes them).
+    await page.locator('#provider').click();
+    await expect(page.getByText(PROVIDER_NAME)).toBeVisible();
+  });
+});


### PR DESCRIPTION
Companion to the admin-client role-routing e2e (competition-factory-server #694). Adds TMX end-to-end coverage for the provisioner-admin-routing client work.

## Journey 36 (real login)
- **PROVIDER_ADMIN** → "Admin" item visible in the account menu (`isActiveProviderAdmin`)
- **DIRECTOR** → "Admin" item not visible (menu still opens)
- **provisioner rep** → their managed provider is listed in the `#provider` switcher (validates the server emits `provisionerProviders` and TMX consumes them)

Uses a genuine `/auth/login` (not token injection) because TMX's authenticated boot is server-coupled — mirrors the existing journey 28. Seeds providers / role-scoped users / a provisioner via the admin API as a super-admin (`e2e/helpers/role-fixtures.ts`), and **skips cleanly** if that bootstrap account isn't reachable, so it never red-fails CI on a missing seed.

## Verification
Verified locally as far as the environment allows: `playwright --list` compiles the specs, typecheck is clean for the new files, and the fixture API path is proven (the same provisioner endpoints pass in CFS #694's journey 06). **The browser assertions are CI-validated** — TMX would not boot to `#dnav` in a local worktree harness (the existing journey 31 fails there too), so I could not run the navbar interactions locally. Please let CI exercise it.

The TMX gating logic also has unit coverage in `src/services/authentication/isProviderAdmin.test.ts` (9 cases).