### PR TITLE
feat(pdf): user/provider-selectable PDF font (Latin-2)

### DIFF
--- a/src/initialState.ts
+++ b/src/initialState.ts
@@ -9,6 +9,7 @@ import { loadColumnVisibility } from 'components/tables/common/columnIsVisible';
 import { initRemoteMutationHandler } from 'services/messaging/remoteMutations';
 import { initProviderSwitcher } from 'services/provider/initProviderSwitcher';
 import { hydrateConfigFromStorage } from 'services/settings/settingsStorage';
+import { initPdfFont } from 'services/pdf/pdfFont';
 import { initTheme, initThemeToggle } from 'services/theme/themeService';
 import { initStalenessGuard } from 'services/staleness/stalenessGuard';
 import { initTmxVersionCheck } from 'services/version/checkTmxVersion';
@@ -140,6 +141,11 @@ export function setupTMX(): void {
   initLoginToggle('burger');
   initThemeToggle('themeToggle');
   initProviderSwitcher();
+
+  // Warm the PDF font catalog + apply the resolved font (user → provider →
+  // helvetica) so all generated PDFs embed it. Re-applied after login in
+  // loginState once the provider config (defaultPdfFont) is known.
+  void initPdfFont();
   if (!(Array.prototype as any).toSorted) {
     (Array.prototype as any).toSorted = function (compareFn?: (a: any, b: any) => number) {
       return this.slice().sort(compareFn);

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -1,6 +1,7 @@
 import { isDesktopNotificationsEnabled, setDesktopNotificationsEnabled } from 'services/notifications/osNotification';
 import { connectSocket, connected, disconnectSocket } from 'services/messaging/socketIo';
-import { persistConfigToStorage, loadSettings } from 'services/settings/settingsStorage';
+import { persistConfigToStorage, loadSettings, saveSettings } from 'services/settings/settingsStorage';
+import { getCachedFontCatalog, ensurePdfFontReady, PROVIDER_DEFAULT_FONT } from 'services/pdf/pdfFont';
 import { tournamentEngine } from 'services/factory/engine';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
@@ -346,6 +347,35 @@ export async function renderSettingsGrid(container: HTMLElement, options?: { exc
     },
   ]);
   fontPanel.appendChild(fontSizeForm);
+
+  // PDF font — embedded in generated PDFs for Latin-2 / Central-European names
+  const currentPdfFont = loadSettings()?.pdfFont ?? PROVIDER_DEFAULT_FONT;
+  const pdfFontForm = document.createElement('div');
+  pdfFontForm.style.marginTop = '8px';
+  renderForm(pdfFontForm, [
+    {
+      options: [
+        {
+          value: PROVIDER_DEFAULT_FONT,
+          label: t('modals.settings.useProviderDefault', { defaultValue: 'Use provider default' }),
+          selected: currentPdfFont === PROVIDER_DEFAULT_FONT,
+        },
+        ...getCachedFontCatalog().map((font) => ({
+          value: font.id,
+          label: font.label,
+          selected: font.id === currentPdfFont,
+        })),
+      ],
+      onChange: (e: Event) => {
+        const select = e.target as HTMLSelectElement;
+        saveSettings({ pdfFont: select.value });
+        void ensurePdfFontReady();
+      },
+      field: 'pdfFont',
+      id: 'pdfFont',
+    },
+  ]);
+  fontPanel.appendChild(pdfFontForm);
 
   grid.appendChild(fontPanel);
 

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -12,6 +12,7 @@ import { tournamentEngine } from 'services/factory/engine';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { loginModal } from 'components/modals/loginModal';
 import { providerConfig } from 'config/providerConfig';
+import { ensurePdfFontReady } from 'services/pdf/pdfFont';
 import { getLoginColor } from 'functions/getLoginColor';
 import { tipster } from 'components/popovers/tipster';
 import { checkDevState } from './checkDevState';
@@ -77,6 +78,8 @@ export function logIn({ data, callback }: { data: { token: string }; callback?: 
     // tournaments table or any provider-scoped UI element.
     fetchUserContext();
     if (valid.activeProviderConfig) providerConfig.set(valid.activeProviderConfig);
+    // Re-resolve the PDF font now that the provider's defaultPdfFont is known.
+    void ensurePdfFontReady();
     tmxToast({ intent: 'is-success', message: t('toasts.loggedIn') });
     disconnectSocket();
     if (!tournamentInState) tournamentEngine.reset();

--- a/src/services/pdf/pdfFont.test.ts
+++ b/src/services/pdf/pdfFont.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Avoid loading the heavy pdf-factory/jsPDF bundle in this unit test; only the
+// resolution logic is under test here.
+vi.mock('pdf-factory', () => ({ setDefaultFont: () => undefined }));
+
+// Vitest runs in Node by default — localStorage isn't defined. Stub a simple
+// in-memory implementation (mirrors settingsStorage.test.ts).
+const memStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => memStore[k] ?? null,
+  setItem: (k: string, v: string) => {
+    memStore[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete memStore[k];
+  },
+  clear: () => {
+    for (const k of Object.keys(memStore)) delete memStore[k];
+  },
+});
+
+import { providerConfig } from 'config/providerConfig';
+import { getSelectedFontId, getCachedFontCatalog, PROVIDER_DEFAULT_FONT } from './pdfFont';
+
+const SETTINGS_KEY = 'tmx_settings';
+const DEJAVU = 'dejavu-sans';
+const LIBERATION = 'liberation-sans';
+
+describe('pdfFont resolution (user → provider → helvetica)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    providerConfig.reset();
+  });
+
+  it('defaults to helvetica when neither user nor provider set a font', () => {
+    expect(getSelectedFontId()).toBe('helvetica');
+  });
+
+  it('uses the provider default when the user follows it', () => {
+    providerConfig.set({ defaults: { defaultPdfFont: LIBERATION } as any });
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({ pdfFont: PROVIDER_DEFAULT_FONT }));
+    expect(getSelectedFontId()).toBe(LIBERATION);
+  });
+
+  it('falls back to the provider default when the user has no setting', () => {
+    providerConfig.set({ defaults: { defaultPdfFont: DEJAVU } as any });
+    expect(getSelectedFontId()).toBe(DEJAVU);
+  });
+
+  it('lets an explicit user choice override the provider default', () => {
+    providerConfig.set({ defaults: { defaultPdfFont: LIBERATION } as any });
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify({ pdfFont: DEJAVU }));
+    expect(getSelectedFontId()).toBe(DEJAVU);
+  });
+});
+
+describe('pdfFont catalog', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('exposes the built-in + Central-European fonts by default', () => {
+    const ids = getCachedFontCatalog().map((f) => f.id);
+    expect(ids).toContain('helvetica');
+    expect(ids).toContain(DEJAVU);
+    expect(ids).toContain(LIBERATION);
+  });
+
+  it('marks the CE fonts as non-builtin with file URLs', () => {
+    const dejavu = getCachedFontCatalog().find((f) => f.id === DEJAVU);
+    expect(dejavu?.builtin).toBe(false);
+    expect(dejavu?.files?.normal).toContain('/fonts/files/');
+  });
+});

--- a/src/services/pdf/pdfFont.ts
+++ b/src/services/pdf/pdfFont.ts
@@ -1,0 +1,195 @@
+/**
+ * PDF font resolution + pre-cache.
+ *
+ * Resolves which font generated PDFs should embed — user setting → provider
+ * default → built-in helvetica — and makes it available to pdf-factory via its
+ * module-level `setDefaultFont`, so EVERY print type picks it up without any
+ * per-call wiring.
+ *
+ * Fonts (TrueType) are hosted by competition-factory-server at `/fonts`. We fetch
+ * the chosen font once, base64-encode it, and cache it in IndexedDB (Dexie
+ * `pdfFonts` table) so subsequent prints are instant and work offline.
+ *
+ * See Mentat/planning/PDF_CE_FONT_SUPPORT.md (WS-3).
+ */
+
+import { setDefaultFont } from 'pdf-factory';
+import type { FontDefinition } from 'pdf-factory';
+
+import { baseApi } from 'services/apis/baseApi';
+import { tmx2db } from 'services/storage/tmx2db';
+import { loadSettings } from 'services/settings/settingsStorage';
+import { providerConfig } from 'config/providerConfig';
+
+// constants and types
+export const PROVIDER_DEFAULT_FONT = '__provider_default__';
+const BUILTIN_FONT_ID = 'helvetica';
+const CATALOG_STORAGE_KEY = 'tmx_pdf_font_catalog';
+const FONTS_TABLE = 'pdfFonts';
+
+export interface FontStyleUrls {
+  normal: string;
+  bold?: string;
+  italic?: string;
+  bolditalic?: string;
+}
+
+export interface PdfFontCatalogEntry {
+  id: string;
+  label: string;
+  languages: string[];
+  builtin: boolean;
+  files?: FontStyleUrls;
+}
+
+const CENTRAL_EUROPEAN = ['en', 'cs', 'sk', 'pl', 'hu', 'hr', 'sl', 'ro', 'de', 'fr', 'es', 'it', 'tr'];
+
+// Stable fallback catalog matching what CFS seeds, so the feature works before
+// (or without) a successful `/fonts` fetch — the file URLs are stable.
+const DEFAULT_CATALOG: PdfFontCatalogEntry[] = [
+  { id: BUILTIN_FONT_ID, label: 'Helvetica (built-in)', languages: ['en'], builtin: true },
+  {
+    id: 'dejavu-sans',
+    label: 'DejaVu Sans',
+    languages: CENTRAL_EUROPEAN,
+    builtin: false,
+    files: { normal: '/fonts/files/DejaVuSans.ttf', bold: '/fonts/files/DejaVuSans-Bold.ttf' },
+  },
+  {
+    id: 'liberation-sans',
+    label: 'Liberation Sans',
+    languages: CENTRAL_EUROPEAN,
+    builtin: false,
+    files: { normal: '/fonts/files/LiberationSans-Regular.ttf', bold: '/fonts/files/LiberationSans-Bold.ttf' },
+  },
+];
+
+let catalogCache: PdfFontCatalogEntry[] | undefined;
+
+/** Catalog from memory → localStorage → built-in defaults (always non-empty). */
+export function getCachedFontCatalog(): PdfFontCatalogEntry[] {
+  if (catalogCache?.length) return catalogCache;
+  try {
+    const raw = localStorage.getItem(CATALOG_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as PdfFontCatalogEntry[]) : undefined;
+    if (parsed?.length) {
+      catalogCache = parsed;
+      return parsed;
+    }
+  } catch (err) {
+    console.warn('[pdfFont] failed to read cached catalog:', err);
+  }
+  return DEFAULT_CATALOG;
+}
+
+/** Refresh the catalog from CFS `/fonts`; falls back to the cached/default list. */
+export async function fetchFontCatalog(): Promise<PdfFontCatalogEntry[]> {
+  try {
+    const { data } = await baseApi.get('/fonts', { silenceErrors: true } as any);
+    const fonts = data?.fonts as PdfFontCatalogEntry[] | undefined;
+    if (fonts?.length) {
+      catalogCache = fonts;
+      localStorage.setItem(CATALOG_STORAGE_KEY, JSON.stringify(fonts));
+      return fonts;
+    }
+  } catch (err) {
+    console.warn('[pdfFont] catalog fetch failed; using cached/default:', err);
+  }
+  return getCachedFontCatalog();
+}
+
+/** The font id to use: explicit user choice → provider default → built-in. */
+export function getSelectedFontId(): string {
+  const userChoice = loadSettings()?.pdfFont;
+  if (userChoice && userChoice !== PROVIDER_DEFAULT_FONT) return userChoice;
+  const providerDefault = (providerConfig.get().defaults as any)?.defaultPdfFont as string | undefined;
+  return providerDefault || BUILTIN_FONT_ID;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + chunkSize)));
+  }
+  return btoa(chunks.join(''));
+}
+
+async function fetchFontBase64(url: string): Promise<string> {
+  const { data } = await baseApi.get(url, { responseType: 'arraybuffer', silenceErrors: true } as any);
+  return arrayBufferToBase64(data as ArrayBuffer);
+}
+
+function familyFromId(id: string): string {
+  return id.replaceAll(/[^A-Za-z0-9]/g, '') || 'PdfFont';
+}
+
+async function readCachedFont(id: string): Promise<FontDefinition | undefined> {
+  try {
+    const cached = await tmx2db.findUnique(FONTS_TABLE, 'fontId', id);
+    if (cached?.normal) return { family: cached.family, normal: cached.normal, bold: cached.bold };
+  } catch (err) {
+    console.warn('[pdfFont] cache read failed:', err);
+  }
+  return undefined;
+}
+
+async function cacheFont(id: string, def: FontDefinition): Promise<void> {
+  try {
+    await tmx2db.addItem(FONTS_TABLE, { fontId: id, ...def, cachedAt: Date.now() });
+  } catch (err) {
+    console.warn('[pdfFont] cache write failed:', err);
+  }
+}
+
+/** Resolve a catalog entry to an embeddable FontDefinition (cached or fetched). */
+async function loadFontDefinition(entry: PdfFontCatalogEntry): Promise<FontDefinition | undefined> {
+  if (entry.builtin || !entry.files?.normal) return undefined;
+
+  const cached = await readCachedFont(entry.id);
+  if (cached) return cached;
+
+  const normal = await fetchFontBase64(entry.files.normal);
+  const bold = entry.files.bold ? await fetchFontBase64(entry.files.bold) : undefined;
+  const def: FontDefinition = { family: familyFromId(entry.id), normal, bold };
+  await cacheFont(entry.id, def);
+  return def;
+}
+
+function findCatalogEntry(id: string): PdfFontCatalogEntry | undefined {
+  return getCachedFontCatalog().find((f) => f.id === id);
+}
+
+/**
+ * Resolve the active PDF font and install it as pdf-factory's default so all
+ * generators embed it. Falls back to the built-in helvetica (clears the default)
+ * on the built-in id or any failure. Safe to call repeatedly; cached after first.
+ */
+export async function ensurePdfFontReady(): Promise<void> {
+  const id = getSelectedFontId();
+  if (!id || id === BUILTIN_FONT_ID) {
+    setDefaultFont(undefined);
+    return;
+  }
+  const entry = findCatalogEntry(id);
+  if (!entry || entry.builtin) {
+    setDefaultFont(undefined);
+    return;
+  }
+  try {
+    setDefaultFont(await loadFontDefinition(entry));
+  } catch (err) {
+    console.warn('[pdfFont] failed to load font; falling back to helvetica:', err);
+    setDefaultFont(undefined);
+  }
+}
+
+/**
+ * Boot/login entry point: warm the catalog (for the settings picker) and apply
+ * the resolved font. Fire-and-forget; never throws.
+ */
+export async function initPdfFont(): Promise<void> {
+  await fetchFontCatalog();
+  await ensurePdfFontReady();
+}

--- a/src/services/provider/providerState.ts
+++ b/src/services/provider/providerState.ts
@@ -11,6 +11,7 @@
  * Mentat/planning/MULTI_PROVIDER_SESSION_CONTEXT.md.
  */
 import { providerConfig } from 'config/providerConfig';
+import { ensurePdfFontReady } from 'services/pdf/pdfFont';
 import { getLoginState } from 'services/authentication/loginState';
 import { baseApi } from 'services/apis/baseApi';
 import { context } from 'services/context';
@@ -53,6 +54,8 @@ export function setActiveProvider(provider: ProviderValue, options: SetActivePro
     fetchEffectiveConfig(provider.organisationId).then(
       (effective) => {
         if (effective) providerConfig.set(effective);
+        // Re-resolve the PDF font for the newly impersonated provider's default.
+        void ensurePdfFontReady();
       },
       () => {
         /* fetch failure — keep prior providerConfig (better than wiping) */

--- a/src/services/settings/settingsStorage.ts
+++ b/src/services/settings/settingsStorage.ts
@@ -62,6 +62,13 @@ export type TMXSettings = {
   fontFamily?: string;
   fontSize?: string;
   /**
+   * Selected PDF font: a CFS font-catalog id (e.g. 'dejavu-sans',
+   * 'liberation-sans', 'helvetica'), or the sentinel '__provider_default__'
+   * (or unset) to follow the provider's defaultPdfFont. Resolved by
+   * services/pdf/pdfFont.ts; embedded in generated PDFs for Latin-2 coverage.
+   */
+  pdfFont?: string;
+  /**
    * @deprecated — promoted to standard features. Retained in the type only so
    * existing localStorage values deserialize cleanly; ignored on hydrate.
    */

--- a/src/services/storage/tmx2db.ts
+++ b/src/services/storage/tmx2db.ts
@@ -28,6 +28,10 @@ export class TMXDatabase {
         this.dex.version(5).stores({ tournaments, providers, idioms, policies, topologies, tieFormats });
         const compositions = namedSource;
         this.dex.version(6).stores({ tournaments, providers, idioms, policies, topologies, tieFormats, compositions });
+        const pdfFonts = '&fontId, cachedAt';
+        this.dex
+          .version(7)
+          .stores({ tournaments, providers, idioms, policies, topologies, tieFormats, compositions, pdfFonts });
         resolve();
       } catch (err) {
         reject(err);


### PR DESCRIPTION
## What

Let users pick a PDF font (Settings → Font) and pre-cache it so generated PDFs render Central-European diacritics. Resolution order: **user setting → provider default → built-in helvetica**.

- `services/pdf/pdfFont.ts` — fetches the CFS `/fonts` catalog, resolves the selected font, fetches + base64-encodes + caches the TTF in a new Dexie `pdfFonts` table, and installs it via pdf-factory `setDefaultFont` so **all** print types embed it (draws, schedule, player list, sign-in, court cards, match cards, fact sheet, reports)
- Settings Font panel: PDF font selector (catalog + "Use provider default")
- applied at boot (`initialState`), on login + impersonation switch (`loginState` / `providerState`), and on settings change
- `tmx_settings` gains `pdfFont`; Dexie schema v7 adds `pdfFonts`

## Tests
`tsc` + ESLint clean (zero warnings); vitest 493 passing (+6); build OK.

## Dependencies (merge/deploy order)
Part of the PDF Central-European font initiative (`Mentat/planning/PDF_CE_FONT_SUPPORT.md`, WS-3). Depends on:
- CourtHive/pdf-factory#73 (`setDefaultFont` / `page.font`)
- CourtHive/provider-config#10 (`defaults.defaultPdfFont`)
- CourtHive/competition-factory-server#702 (`/fonts` hosting + provider default)

Suggested order: pdf-factory + provider-config → competition-factory-server (deploy so `/fonts` is live) → TMX.