### PR TITLE
feat(auth): silent access-token refresh via rotating refresh token

### DIFF
--- a/src/config/localStorage.ts
+++ b/src/config/localStorage.ts
@@ -4,3 +4,7 @@ export function getJwtTokenStorageKey(): string {
 
   return TOKEN_NAME;
 }
+
+export function getRefreshTokenStorageKey(): string {
+  return 'tmxRefreshToken';
+}

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -161,7 +161,7 @@ export function routeTMX() {
       try {
         const res = await ssoLoginWithToken(token);
         if (res?.status === 200 && res.data?.accessToken) {
-          logIn({ data: { token: res.data.accessToken } });
+          logIn({ data: { token: res.data.accessToken, refreshToken: res.data.refreshToken } });
         } else {
           logOut();
         }

--- a/src/services/apis/baseApi.test.ts
+++ b/src/services/apis/baseApi.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory localStorage (vitest runs in Node).
+const memStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => memStore[k] ?? null,
+  setItem: (k: string, v: string) => {
+    memStore[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete memStore[k];
+  },
+});
+
+// A single fake axios instance shared by every axios.create() call so the test
+// can drive and assert against baseApi's internal instance. Declared via
+// vi.hoisted so it exists when the (hoisted) vi.mock factory runs.
+const { fakeInstance, post } = vi.hoisted(() => {
+  const post = vi.fn();
+  const fakeInstance: any = {
+    interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+    defaults: { headers: { common: {} }, baseURL: '' },
+    post,
+  };
+  return { fakeInstance, post };
+});
+vi.mock('axios', () => ({ default: { create: () => fakeInstance }, create: () => fakeInstance }));
+vi.mock('services/notifications/tmxToast', () => ({ tmxToast: vi.fn() }));
+
+import { refreshAccessToken } from './baseApi';
+
+beforeEach(() => {
+  for (const k of Object.keys(memStore)) delete memStore[k];
+  post.mockReset();
+});
+
+describe('baseApi.refreshAccessToken', () => {
+  it('coalesces concurrent refreshes into one request and stores rotated tokens', async () => {
+    localStorage.setItem('tmxRefreshToken', 'rtok_old');
+    post.mockResolvedValue({ data: { token: 'access_new', refreshToken: 'rtok_new' } });
+
+    const [a, b] = await Promise.all([refreshAccessToken(), refreshAccessToken()]);
+
+    expect(a).toBe('access_new');
+    expect(b).toBe('access_new');
+    // Single-flight: a second concurrent caller must NOT trigger a second
+    // rotation (which the server's reuse-detection would treat as theft).
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/auth/refresh', { refreshToken: 'rtok_old' }, expect.objectContaining({ silenceErrors: true }));
+    expect(localStorage.getItem('tmxToken')).toBe('access_new');
+    expect(localStorage.getItem('tmxRefreshToken')).toBe('rtok_new');
+  });
+
+  it('returns null and makes no request when there is no stored refresh token', async () => {
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the refresh request fails (does not throw)', async () => {
+    localStorage.setItem('tmxRefreshToken', 'rtok_old');
+    post.mockRejectedValue(new Error('401'));
+    const result = await refreshAccessToken();
+    expect(result).toBeNull();
+    // The stale access token is left untouched for the caller to handle (logout).
+    expect(localStorage.getItem('tmxToken')).toBeNull();
+  });
+
+  it('allows a fresh refresh after the previous one settled (flight resets)', async () => {
+    localStorage.setItem('tmxRefreshToken', 'rtok_old');
+    post.mockResolvedValueOnce({ data: { token: 'a1', refreshToken: 'r1' } });
+    await refreshAccessToken();
+    post.mockResolvedValueOnce({ data: { token: 'a2', refreshToken: 'r2' } });
+    const second = await refreshAccessToken();
+    expect(second).toBe('a2');
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/apis/baseApi.ts
+++ b/src/services/apis/baseApi.ts
@@ -1,8 +1,9 @@
-import { getJwtTokenStorageKey } from 'config/localStorage';
+import { getJwtTokenStorageKey, getRefreshTokenStorageKey } from 'config/localStorage';
 import { tmxToast } from 'services/notifications/tmxToast';
 import axios from 'axios';
 
 const JWT_TOKEN_STORAGE_NAME = getJwtTokenStorageKey();
+const REFRESH_TOKEN_STORAGE_NAME = getRefreshTokenStorageKey();
 const baseURL = process.env.SERVER || globalThis.location?.origin || '';
 console.log('[baseApi] server URL:', baseURL);
 const axiosInstance = axios.create({ baseURL });
@@ -19,6 +20,53 @@ axiosInstance.interceptors.request.use(
   },
 );
 
+// Endpoints that mint or revoke tokens must never trigger a refresh-on-401:
+// the refresh would recurse, and a wrong-password login legitimately 401s.
+const AUTH_ENDPOINTS = [
+  '/auth/refresh',
+  '/auth/login',
+  '/auth/logout',
+  '/auth/complete-first-login',
+  '/auth/sso/login-with-token',
+];
+const isAuthEndpoint = (url?: string): boolean => !!url && AUTH_ENDPOINTS.some((p) => url.includes(p));
+
+// Single-flight: concurrent 401s share one in-flight refresh so the refresh
+// token is rotated exactly once. Two racing refreshes would present the same
+// token twice, and the server's reuse-detection would burn the whole family.
+let refreshPromise: Promise<string | null> | null = null;
+
+async function performRefresh(): Promise<string | null> {
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_STORAGE_NAME);
+  if (!refreshToken) return null;
+  try {
+    const { data } = await axiosInstance.post('/auth/refresh', { refreshToken }, { silenceErrors: true } as any);
+    if (data?.token) {
+      localStorage.setItem(JWT_TOKEN_STORAGE_NAME, data.token);
+      // Rotation: the server returns a fresh refresh token on every refresh.
+      if (data.refreshToken) localStorage.setItem(REFRESH_TOKEN_STORAGE_NAME, data.refreshToken);
+      addAuthorization();
+      return data.token;
+    }
+  } catch {
+    /* fall through → null (caller handles logout) */
+  }
+  return null;
+}
+
+/**
+ * Silently exchange the stored refresh token for a fresh access token. Returns
+ * the new access token or null. Coalesces concurrent callers into one request.
+ */
+export function refreshAccessToken(): Promise<string | null> {
+  if (!refreshPromise) {
+    refreshPromise = performRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+  return refreshPromise;
+}
+
 axiosInstance.interceptors.response.use(
   (response) => {
     if (response.data?.error && !(response.config as any)?.silenceErrors) {
@@ -26,8 +74,28 @@ axiosInstance.interceptors.response.use(
     }
     return response;
   },
-  (error) => {
-    const silenceErrors = (error.config as any)?.silenceErrors;
+  async (error) => {
+    const original = error.config;
+    const silenceErrors = (original as any)?.silenceErrors;
+
+    // Access token expired (or otherwise rejected): attempt one silent refresh
+    // and replay the original request before surfacing any error to the user.
+    if (error.response?.status === 401 && original && !(original as any)._retried && !isAuthEndpoint(original.url)) {
+      (original as any)._retried = true;
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        original.headers = original.headers ?? {};
+        original.headers.Authorization = `Bearer ${newToken}`;
+        return axiosInstance(original);
+      }
+      // No refresh token, or it was expired / rotated away → full logout.
+      // Lazy import avoids a static cycle (loginState → authApi → baseApi).
+      removeAuthorization();
+      const { logOut } = await import('services/authentication/loginState');
+      logOut();
+      return;
+    }
+
     if (error.message === 'Network Error' && !silenceErrors) {
       tmxToast({ message: error.message, intent: 'is-danger' });
     }
@@ -38,6 +106,9 @@ axiosInstance.interceptors.response.use(
         tmxToast({ message, intent: 'is-danger' });
       }
     }
+    // Preserve the pre-existing contract: rejected requests resolve to
+    // `undefined` (errors are surfaced via toasts), not a rejected promise.
+    return undefined;
   },
 );
 
@@ -63,4 +134,5 @@ export const baseApi: any = {
   ...axiosInstance,
   addAuthorization,
   removeAuthorization,
+  refreshAccessToken,
 };

--- a/src/services/authentication/authApi.ts
+++ b/src/services/authentication/authApi.ts
@@ -52,3 +52,12 @@ export async function ssoLoginWithToken(token: string) {
 export async function completeFirstLogin(limitedToken: string, newPassword: string) {
   return baseApi.post('/auth/complete-first-login', { limitedToken, newPassword });
 }
+
+/**
+ * Server-side revocation of a refresh token on logout. Idempotent and best-effort
+ * — failures are silenced so logout always completes locally. The access-token
+ * refresh itself lives in baseApi (refreshAccessToken) to avoid an import cycle.
+ */
+export async function revokeRefreshToken(refreshToken: string) {
+  return baseApi.post('/auth/logout', { refreshToken }, { silenceErrors: true });
+}

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -6,8 +6,10 @@ import { clearUserContext, fetchUserContext } from './getUserContext';
 import { clearActiveProvider } from 'services/provider/providerState';
 import { resetActivityTimer } from 'services/staleness/stalenessGuard';
 import { validateToken } from 'services/authentication/validateToken';
-import { getToken, removeToken, setToken } from './tokenManagement';
+import { getToken, removeToken, setToken, getRefreshToken, setRefreshToken, removeRefreshToken } from './tokenManagement';
 import { disconnectSocket } from 'services/messaging/socketIo';
+import { refreshAccessToken } from 'services/apis/baseApi';
+import { revokeRefreshToken } from './authApi';
 import { tournamentEngine } from 'services/factory/engine';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { loginModal } from 'components/modals/loginModal';
@@ -50,7 +52,12 @@ export function getLoginState(): LoginState | undefined {
 }
 
 export function logOut(): void {
+  // Best-effort server-side revocation of the refresh token so a leaked copy
+  // can't be replayed after logout. Fire-and-forget; never blocks local logout.
+  const refreshToken = getRefreshToken();
+  if (refreshToken) revokeRefreshToken(refreshToken).catch(() => undefined);
   removeToken();
+  removeRefreshToken();
   clearUserContext();
   checkDevState();
   disconnectSocket();
@@ -66,11 +73,18 @@ export function logOut(): void {
   styleLogin(false);
 }
 
-export function logIn({ data, callback }: { data: { token: string }; callback?: () => void }): void {
+export function logIn({
+  data,
+  callback,
+}: {
+  data: { token: string; refreshToken?: string };
+  callback?: () => void;
+}): void {
   const valid = validateToken(data.token);
   const tournamentInState = tournamentEngine.getTournament().tournamentRecord?.tournamentId;
   if (valid) {
     setToken(data.token);
+    if (data.refreshToken) setRefreshToken(data.refreshToken);
     clearUserContext();
     // Fire-and-forget: fetch the multi-provider user context from the server.
     // The context will be available by the time the user interacts with the
@@ -92,6 +106,45 @@ export function logIn({ data, callback }: { data: { token: string }; callback?: 
       reRenderActiveTab();
     }
   }
+}
+
+// Coalesce concurrent boot-time refresh attempts (getLoginState can be called
+// many times during routing) so the refresh token rotates only once.
+let silentRefreshInFlight: Promise<boolean> | null = null;
+
+/**
+ * Exchange the stored refresh token for a fresh access token and re-apply the
+ * session WITHOUT navigating or tearing down the socket. Used on boot (and any
+ * point a still-valid refresh token outlives an expired access token) so a
+ * returning user stays logged in instead of being bounced to a login screen.
+ * On failure, logs out cleanly.
+ */
+export function attemptSilentRefresh(): Promise<boolean> {
+  if (!silentRefreshInFlight) {
+    silentRefreshInFlight = doSilentRefresh().finally(() => {
+      silentRefreshInFlight = null;
+    });
+  }
+  return silentRefreshInFlight;
+}
+
+async function doSilentRefresh(): Promise<boolean> {
+  const newToken = await refreshAccessToken();
+  if (!newToken) {
+    logOut();
+    return false;
+  }
+  const valid = validateToken(newToken);
+  if (!valid) {
+    logOut();
+    return false;
+  }
+  clearUserContext();
+  fetchUserContext();
+  if (valid.activeProviderConfig) providerConfig.set(valid.activeProviderConfig);
+  styleLogin(valid);
+  initProviderSwitcher();
+  return true;
 }
 
 function reRenderActiveTab(): void {

--- a/src/services/authentication/tokenManagement.test.ts
+++ b/src/services/authentication/tokenManagement.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Vitest runs in Node by default — localStorage isn't defined. Stub a simple
+// in-memory implementation so the token helpers have somewhere to read/write.
+const memStore: Record<string, string> = {};
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => memStore[k] ?? null,
+  setItem: (k: string, v: string) => {
+    memStore[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete memStore[k];
+  },
+});
+
+import {
+  getToken,
+  setToken,
+  removeToken,
+  getRefreshToken,
+  setRefreshToken,
+  removeRefreshToken,
+} from './tokenManagement';
+
+beforeEach(() => {
+  for (const k of Object.keys(memStore)) delete memStore[k];
+});
+
+describe('tokenManagement refresh-token helpers', () => {
+  it('stores the refresh token under a distinct key from the access token', () => {
+    setToken('access-1');
+    setRefreshToken('rtok-1');
+    expect(getToken()).toBe('access-1');
+    expect(getRefreshToken()).toBe('rtok-1');
+    expect(memStore.tmxToken).toBe('access-1');
+    expect(memStore.tmxRefreshToken).toBe('rtok-1');
+  });
+
+  it('returns null when no refresh token is stored', () => {
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('removing the refresh token leaves the access token intact', () => {
+    setToken('access-1');
+    setRefreshToken('rtok-1');
+    removeRefreshToken();
+    expect(getRefreshToken()).toBeNull();
+    expect(getToken()).toBe('access-1');
+  });
+
+  it('removing the access token leaves the refresh token intact', () => {
+    setToken('access-1');
+    setRefreshToken('rtok-1');
+    removeToken();
+    expect(getToken()).toBeNull();
+    expect(getRefreshToken()).toBe('rtok-1');
+  });
+});

--- a/src/services/authentication/tokenManagement.ts
+++ b/src/services/authentication/tokenManagement.ts
@@ -1,6 +1,7 @@
-import { getJwtTokenStorageKey } from 'config/localStorage';
+import { getJwtTokenStorageKey, getRefreshTokenStorageKey } from 'config/localStorage';
 
 const JWT_TOKEN_STORAGE_NAME = getJwtTokenStorageKey();
+const REFRESH_TOKEN_STORAGE_NAME = getRefreshTokenStorageKey();
 
 export function removeToken(): void {
   localStorage.removeItem(JWT_TOKEN_STORAGE_NAME);
@@ -12,4 +13,16 @@ export function getToken(): string | null {
 
 export function setToken(token: string): void {
   localStorage.setItem(JWT_TOKEN_STORAGE_NAME, token);
+}
+
+export function removeRefreshToken(): void {
+  localStorage.removeItem(REFRESH_TOKEN_STORAGE_NAME);
+}
+
+export function getRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_STORAGE_NAME);
+}
+
+export function setRefreshToken(token: string): void {
+  localStorage.setItem(REFRESH_TOKEN_STORAGE_NAME, token);
 }

--- a/src/services/authentication/validateToken.ts
+++ b/src/services/authentication/validateToken.ts
@@ -1,8 +1,8 @@
 import { checkDevState } from './checkDevState';
-import { removeToken } from './tokenManagement';
+import { getRefreshToken, removeToken } from './tokenManagement';
 import { setDev } from 'services/setDev';
 import { jwtDecode } from 'jwt-decode';
-import { logOut } from './loginState';
+import { attemptSilentRefresh, logOut } from './loginState';
 
 import type { LoginState } from 'types/tmx';
 
@@ -25,6 +25,14 @@ export function validateToken(token: string | null | undefined): LoginState | un
   const dateNow = new Date();
   const tokenExpired = decodedToken.exp < dateNow.getTime() / 1000;
   if (tokenExpired) {
+    // An expired access token no longer means "log out" — if a refresh token
+    // is present, silently exchange it for a new access token and re-apply the
+    // session (fire-and-forget; re-renders on success, logs out on failure).
+    // Returning undefined here just means "not valid yet this tick".
+    if (getRefreshToken()) {
+      void attemptSilentRefresh();
+      return undefined;
+    }
     logOut();
     return undefined;
   }


### PR DESCRIPTION
## Why

Pairs with **CourtHive/competition-factory-server#704**, which adds rotating refresh tokens. This is the client half: keep a session alive across a multi-day event without forcing re-login.

## What

- Store the refresh token in `localStorage['tmxRefreshToken']` (alongside the existing `tmxToken`).
- `baseApi`: **single-flight** silent refresh — on a `401`, exchange the refresh token for a fresh access token and replay the original request once; concurrent 401s share one in-flight refresh (so the token rotates exactly once, avoiding the server's reuse-detection burning the family). On refresh failure, lazy-import `logOut` (avoids an import cycle).
- `validateToken`: when the access token is expired but a refresh token exists, **refresh silently** instead of logging out (covers app boot / returning users).
- `logIn` stores the refresh token; `logOut` revokes it server-side (`POST /auth/logout`, best-effort) and clears it; the SSO route threads it through.

## Tests

`tsc --noEmit` clean · `eslint --max-warnings 0` clean · **vitest 495/495** (`TZ=UTC`), incl. new coverage for the token helpers and `baseApi.refreshAccessToken` single-flight/rotation.

## ⚠ Rollout

Deploy together with CourtHive/competition-factory-server#704. Access TTL is 4h server-side; a stale cached PWA without this change would see 4h logouts, so the whole-ecosystem deploy is what makes 4h safe.

Depends on: CourtHive/competition-factory-server#704