### PR TITLE
feat(auth): passwordless magic-link login (client)

### DIFF
--- a/src/components/modals/loginModal.ts
+++ b/src/components/modals/loginModal.ts
@@ -3,9 +3,10 @@
  * Authenticates user credentials and updates login state on success.
  */
 import { logIn, logOut } from 'services/authentication/loginState';
+import { systemLogin, requestMagicLink } from 'services/authentication/authApi';
 import { firstLoginPasswordModal } from './firstLoginPassword';
 import { renderForm, validators } from 'courthive-components';
-import { systemLogin } from 'services/authentication/authApi';
+import { tmxToast } from 'services/notifications/tmxToast';
 import { openModal } from './baseModal/baseModal';
 import { t } from 'i18n';
 
@@ -16,7 +17,10 @@ export function loginModal(callback?: () => void): void {
   const enableSubmit = ({ inputs }: any) => {
     const value = inputs['email'].value;
     const isValid = validators.emailValidator(value);
+    // Both actions need a valid email; only password-login needs the password
+    // field, which the submit handler reads directly.
     modalHandle?.setButtonState('loginButton', { disabled: !isValid });
+    modalHandle?.setButtonState('magicLinkButton', { disabled: !isValid });
   };
 
   const relationships = [
@@ -70,11 +74,28 @@ export function loginModal(callback?: () => void): void {
     systemLogin(email, password).then(response, (err: any) => console.log({ err }));
   };
 
+  // Passwordless option: request a one-time login link by email. The server is
+  // enumeration-defensive, so we always show the same neutral confirmation
+  // regardless of whether the address maps to an eligible account.
+  const submitMagicLink = () => {
+    const email = inputs.email.value;
+    requestMagicLink(email).catch(() => undefined);
+    tmxToast({ intent: 'is-info', message: t('toasts.magicLinkSent') });
+  };
+
   modalHandle = openModal({
     title: t('modals.login.title'),
     content,
     buttons: [
       { label: t('common.cancel'), intent: 'none', close: true },
+      {
+        onClick: submitMagicLink,
+        intent: 'is-link',
+        id: 'magicLinkButton',
+        disabled: true,
+        label: t('modals.login.magicLinkButton'),
+        close: true,
+      },
       {
         onClick: submitCredentials,
         intent: 'is-primary',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -886,7 +886,8 @@
       "emailPlaceholder": "valid@email.com",
       "passwordLabel": "Password",
       "passwordPlaceholder": "minimum 8 characters",
-      "loginButton": "Login"
+      "loginButton": "Login",
+      "magicLinkButton": "Email me a login link"
     },
     "firstLogin": {
       "title": "Set your password",
@@ -1484,6 +1485,8 @@
   "toasts": {
     "copiedToClipboard": "Copied to clipboard",
     "loggedIn": "Log in successful",
+    "magicLinkSent": "If an account exists for that email, a login link is on its way.",
+    "magicLinkInvalid": "That login link is invalid or has expired. Please request a new one.",
     "userRemoved": "User removed",
     "tournamentNotFound": "Tournament not found",
     "connectionError": "Connection error",

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,6 +1,8 @@
 import { renderTemplatesPage } from 'pages/templates/renderTemplatesPage';
 import { registrationModal } from 'components/modals/registrationModal';
-import { ssoLoginWithToken } from 'services/authentication/authApi';
+import { ssoLoginWithToken, consumeMagicLink } from 'services/authentication/authApi';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { t } from 'i18n';
 import { ensureConnected, queueKey } from 'services/messaging/socketIo';
 import { resetActivityTimer } from 'services/staleness/stalenessGuard';
 import { renderSettingsPage } from 'pages/settings/renderSettingsPage';
@@ -169,6 +171,28 @@ export function routeTMX() {
         logOut();
       }
     } else {
+      router.navigate(`/${TMX_TOURNAMENTS}`);
+    }
+  });
+
+  // Magic-link login: the email lands the user on `#/magic/:code`. The code is
+  // single-use and consumed server-side for an access + refresh session.
+  router.on('/magic/:code', async (match) => {
+    const code = match?.data?.code;
+    if (!code) {
+      router.navigate(`/${TMX_TOURNAMENTS}`);
+      return;
+    }
+    try {
+      const res = await consumeMagicLink(code);
+      if (res?.status === 200 && res.data?.token) {
+        logIn({ data: res.data });
+      } else {
+        tmxToast({ intent: 'is-danger', message: t('toasts.magicLinkInvalid') });
+        router.navigate(`/${TMX_TOURNAMENTS}`);
+      }
+    } catch {
+      tmxToast({ intent: 'is-danger', message: t('toasts.magicLinkInvalid') });
       router.navigate(`/${TMX_TOURNAMENTS}`);
     }
   });

--- a/src/services/apis/baseApi.ts
+++ b/src/services/apis/baseApi.ts
@@ -28,6 +28,7 @@ const AUTH_ENDPOINTS = [
   '/auth/logout',
   '/auth/complete-first-login',
   '/auth/sso/login-with-token',
+  '/auth/magic/',
 ];
 const isAuthEndpoint = (url?: string): boolean => !!url && AUTH_ENDPOINTS.some((p) => url.includes(p));
 

--- a/src/services/authentication/authApi.test.ts
+++ b/src/services/authentication/authApi.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post } = vi.hoisted(() => ({ post: vi.fn() }));
+vi.mock('services/apis/baseApi', () => ({ baseApi: { post } }));
+
+import { requestMagicLink, consumeMagicLink } from './authApi';
+
+beforeEach(() => {
+  post.mockReset();
+});
+
+describe('authApi magic-link', () => {
+  it('requestMagicLink posts the email to /auth/magic/request', async () => {
+    post.mockResolvedValue({ status: 200, data: { ok: true } });
+    await requestMagicLink('a@test.com');
+    expect(post).toHaveBeenCalledWith('/auth/magic/request', { email: 'a@test.com' });
+  });
+
+  it('consumeMagicLink posts the code to /auth/magic/consume with errors silenced', async () => {
+    post.mockResolvedValue({ status: 200, data: { token: 't', refreshToken: 'r' } });
+    await consumeMagicLink('mlk_abc');
+    expect(post).toHaveBeenCalledWith('/auth/magic/consume', { code: 'mlk_abc' }, { silenceErrors: true });
+  });
+});

--- a/src/services/authentication/authApi.ts
+++ b/src/services/authentication/authApi.ts
@@ -61,3 +61,13 @@ export async function completeFirstLogin(limitedToken: string, newPassword: stri
 export async function revokeRefreshToken(refreshToken: string) {
   return baseApi.post('/auth/logout', { refreshToken }, { silenceErrors: true });
 }
+
+/** Request a passwordless magic login link. Enumeration-defensive server-side. */
+export async function requestMagicLink(email: string) {
+  return baseApi.post('/auth/magic/request', { email });
+}
+
+/** Exchange a single-use magic-link code for an access + refresh session. */
+export async function consumeMagicLink(code: string) {
+  return baseApi.post('/auth/magic/consume', { code }, { silenceErrors: true });
+}


### PR DESCRIPTION
## Why

Client half of magic-link login. Pairs with **CourtHive/competition-factory-server#706**.

## What

- Login modal gains an **"Email me a login link"** action (enabled once the email is valid); shows a neutral, enumeration-safe confirmation.
- New `#/magic/:code` route consumes the single-use code via `POST /auth/magic/consume` and starts a session (`logIn` stores access + refresh tokens).
- `authApi.requestMagicLink` / `consumeMagicLink` clients.
- Magic endpoints excluded from the 401 silent-refresh interceptor (no refresh token exists pre-login).
- i18n keys added (`modals.login.magicLinkButton`, `toasts.magicLinkSent`, `toasts.magicLinkInvalid`).

## Tests

`tsc` + `eslint --max-warnings 0` clean · **vitest 503/503** (`TZ=UTC`; 2 new authApi tests).

Depends on: CourtHive/competition-factory-server#706