### PR TITLE
feat(viz): burst progression vs competitive coloring

### DIFF
--- a/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
@@ -118,7 +118,7 @@ function buildHistogramForDraw(
   return wrap;
 }
 
-function buildSunburstForDraw(enrichedStructure: any, expanded: boolean): HTMLElement | null {
+function buildSunburstForDraw(enrichedStructure: any, expanded: boolean, competitive: boolean): HTMLElement | null {
   // `enrichedStructure` is the `getEventData().drawsData[i].structures[j]`
   // shape that has `roundMatchUps` — NOT the raw `drawDefinition.structures[0]`.
   if (!enrichedStructure?.roundMatchUps) return null;
@@ -126,7 +126,14 @@ function buildSunburstForDraw(enrichedStructure: any, expanded: boolean): HTMLEl
   const container = document.createElement('div');
   container.style.cssText = `width:${size}px; height:${size}px; max-width:100%;`;
   const data = fromFactoryDrawData(enrichedStructure);
-  burstChart({ width: size, height: size, eventHandlers: {} }).render(container, data, '');
+  // competitive → color winner rings by matchUp competitiveness (computed by the
+  // adapter from score.sets); progression → default seed/entry coloring.
+  burstChart({
+    width: size,
+    height: size,
+    colorMode: competitive ? 'competitiveness' : 'default',
+    eventHandlers: {},
+  }).render(container, data, '');
   return container;
 }
 
@@ -168,6 +175,7 @@ export function buildDrawCardVisualization({
   if (!drawDefinition?.structures?.length) return null;
   if (mode === 'competitiveness') return buildCompetitivenessForMatchUps(competitiveMatchUps ?? []);
   if (mode === 'histogram') return buildHistogramForDraw(participantsById, drawParticipantIds, ratingScaleName);
-  if (mode === 'sunburst') return buildSunburstForDraw(enrichedStructure, expanded);
+  if (mode === 'sunburst') return buildSunburstForDraw(enrichedStructure, expanded, false);
+  if (mode === 'sunburst-competitive') return buildSunburstForDraw(enrichedStructure, expanded, true);
   return null;
 }

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardDisplayMode.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardDisplayMode.ts
@@ -4,15 +4,23 @@
  * tournament-director-preference design.
  */
 
-export type DrawCardDisplayMode = 'none' | 'histogram' | 'competitiveness' | 'sunburst';
+export type DrawCardDisplayMode = 'none' | 'histogram' | 'competitiveness' | 'sunburst' | 'sunburst-competitive';
 
 const KEY = 'tmx_draws_card_display';
+
+const VALID_MODES: ReadonlySet<string> = new Set([
+  'none',
+  'histogram',
+  'competitiveness',
+  'sunburst',
+  'sunburst-competitive',
+]);
 
 export function readDrawCardDisplayMode(): DrawCardDisplayMode {
   try {
     const stored = globalThis.localStorage?.getItem(KEY);
-    if (stored === 'histogram' || stored === 'competitiveness' || stored === 'sunburst' || stored === 'none') {
-      return stored;
+    if (stored && VALID_MODES.has(stored)) {
+      return stored as DrawCardDisplayMode;
     }
     return 'none';
   } catch {

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.test.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveDisplayMode, buildDisplayModeOptions, isSunburstMode, SUNBURST_CAP } from './drawCardVizGating';
+
+const COMPETITIVE = 'sunburst-competitive' as const;
+
+const avail = (hasRatings: boolean, hasCompetitiveness: boolean) => ({ hasRatings, hasCompetitiveness });
+
+describe('isSunburstMode', () => {
+  it('matches both burst variants and nothing else', () => {
+    expect(isSunburstMode('sunburst')).toBe(true);
+    expect(isSunburstMode(COMPETITIVE)).toBe(true);
+    expect(isSunburstMode('histogram')).toBe(false);
+    expect(isSunburstMode('none')).toBe(false);
+  });
+});
+
+describe('resolveDisplayMode — burst variants', () => {
+  it('allows burst (progression) under the cap', () => {
+    const r = resolveDisplayMode({ requested: 'sunburst', drawCount: 1, availability: avail(false, false) });
+    expect(r).toMatchObject({ mode: 'sunburst', gated: false });
+  });
+
+  it('allows burst (competitive) when completed matches exist', () => {
+    const r = resolveDisplayMode({ requested: COMPETITIVE, drawCount: 1, availability: avail(false, true) });
+    expect(r).toMatchObject({ mode: COMPETITIVE, gated: false });
+  });
+
+  it('gates burst (competitive) when there are no completed matches', () => {
+    const r = resolveDisplayMode({ requested: COMPETITIVE, drawCount: 1, availability: avail(false, false) });
+    expect(r).toMatchObject({ mode: 'none', gated: true, reason: 'no-competitiveness' });
+  });
+
+  it('gates both burst variants at/over the SUNBURST_CAP', () => {
+    const a = avail(false, true);
+    expect(resolveDisplayMode({ requested: 'sunburst', drawCount: SUNBURST_CAP, availability: a }).reason).toBe(
+      'sunburst-too-many',
+    );
+    expect(
+      resolveDisplayMode({ requested: COMPETITIVE, drawCount: SUNBURST_CAP, availability: a }).reason,
+    ).toBe('sunburst-too-many');
+  });
+});
+
+describe('buildDisplayModeOptions — burst variants', () => {
+  it('offers both burst options under the cap', () => {
+    const opts = buildDisplayModeOptions({ drawCount: 1, availability: avail(true, true) });
+    expect(opts.filter((o) => isSunburstMode(o.value)).map((o) => o.value)).toEqual([
+      'sunburst',
+      COMPETITIVE,
+    ]);
+  });
+
+  it('disables burst (competitive) when there are no completed matches', () => {
+    const opts = buildDisplayModeOptions({ drawCount: 1, availability: avail(true, false) });
+    expect(opts.find((o) => o.value === COMPETITIVE)?.disabled).toBe(true);
+  });
+
+  it('omits burst options at/over the cap', () => {
+    const opts = buildDisplayModeOptions({ drawCount: SUNBURST_CAP, availability: avail(true, true) });
+    expect(opts.some((o) => isSunburstMode(o.value))).toBe(false);
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.ts
@@ -15,6 +15,13 @@ import type { DrawCardDisplayMode } from './drawCardDisplayMode';
 export const HARD_CAP = 15;
 export const SUNBURST_CAP = 6;
 
+const SUNBURST_COMPETITIVE: DrawCardDisplayMode = 'sunburst-competitive';
+
+/** Both burst variants (progression + competitive) share gating + rendering. */
+export function isSunburstMode(mode: DrawCardDisplayMode): boolean {
+  return mode === 'sunburst' || mode === SUNBURST_COMPETITIVE;
+}
+
 export interface VizDataAvailability {
   hasRatings: boolean;
   hasCompetitiveness: boolean;
@@ -46,13 +53,13 @@ export function resolveDisplayMode({
   if (drawCount > HARD_CAP) {
     return { mode: 'none', requested, gated: true, reason: 'over-cap' };
   }
-  if (requested === 'sunburst' && drawCount >= SUNBURST_CAP) {
+  if (isSunburstMode(requested) && drawCount >= SUNBURST_CAP) {
     return { mode: 'none', requested, gated: true, reason: 'sunburst-too-many' };
   }
   if (requested === 'histogram' && !availability.hasRatings) {
     return { mode: 'none', requested, gated: true, reason: 'no-ratings' };
   }
-  if (requested === 'competitiveness' && !availability.hasCompetitiveness) {
+  if ((requested === 'competitiveness' || requested === SUNBURST_COMPETITIVE) && !availability.hasCompetitiveness) {
     return { mode: 'none', requested, gated: true, reason: 'no-competitiveness' };
   }
   return { mode: requested, requested, gated: false };
@@ -87,16 +94,24 @@ export function buildDisplayModeOptions({
       reason: !availability.hasCompetitiveness ? 'no completed matches' : undefined,
     },
   ];
-  // Sunburst only available when the draw count is below the SUNBURST_CAP.
+  // Burst variants only available when the draw count is below the SUNBURST_CAP.
   if (drawCount < SUNBURST_CAP) {
-    options.push({ value: 'sunburst', label: 'Sunburst' });
+    options.push(
+      { value: 'sunburst', label: 'Burst (progression)' },
+      {
+        value: SUNBURST_COMPETITIVE,
+        label: 'Burst (competitive)',
+        disabled: !availability.hasCompetitiveness,
+        reason: !availability.hasCompetitiveness ? 'no completed matches' : undefined,
+      },
+    );
   }
   return options;
 }
 
 export function gateReasonLabel(reason: GateReason): string {
   if (reason === 'over-cap') return `Visualizations hidden — too many draws (cap: ${HARD_CAP}).`;
-  if (reason === 'sunburst-too-many') return `Sunburst hidden — only available when fewer than ${SUNBURST_CAP} draws.`;
+  if (reason === 'sunburst-too-many') return `Burst hidden — only available when fewer than ${SUNBURST_CAP} draws.`;
   if (reason === 'no-ratings') return 'No ratings data — histogram hidden.';
   if (reason === 'no-competitiveness') return 'No completed matches — competitiveness hidden.';
   return '';

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
@@ -28,6 +28,7 @@ import {
   VizDataAvailability,
   gateReasonLabel,
   resolveDisplayMode,
+  isSunburstMode,
 } from './drawCardVizGating';
 
 import './drawsGrid.css';
@@ -228,7 +229,7 @@ export function renderDrawsGrid({
 
   const grid = document.createElement('div');
   grid.className = GRID_CLASS;
-  if (resolved.mode === 'sunburst') grid.classList.add(GRID_EXPANDED_CLASS);
+  if (isSunburstMode(resolved.mode)) grid.classList.add(GRID_EXPANDED_CLASS);
   wrap.appendChild(grid);
 
   const resolvedEvent = resolveEventData(eventId);
@@ -238,7 +239,7 @@ export function renderDrawsGrid({
   // Sunburst needs the enriched structures (with `roundMatchUps`) from
   // getEventData — drawDefinition.structures alone doesn't carry that field.
   const enrichedDrawsData =
-    resolved.mode === 'sunburst'
+    isSunburstMode(resolved.mode)
       ? (tournamentEngine as any).getEventData({ eventId })?.eventData?.drawsData ?? []
       : [];
 
@@ -271,7 +272,7 @@ export function renderDrawsGrid({
       const dd = resolvedEvent?.drawDefinitions.find((d: any) => d.drawId === row.drawId);
       if (dd) {
         const enrichedStructure =
-          resolved.mode === 'sunburst'
+          isSunburstMode(resolved.mode)
             ? enrichedDrawsData.find((d: any) => d.drawId === row.drawId)?.structures?.[0]
             : undefined;
         const competitiveMatchUps =
@@ -284,7 +285,7 @@ export function renderDrawsGrid({
         visualization = buildDrawCardVisualization({
           mode: resolved.mode,
           drawDefinition: dd,
-          expanded: resolved.mode === 'sunburst',
+          expanded: isSunburstMode(resolved.mode),
           ratingScaleName,
           participantsById,
           drawParticipantIds,

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -231,6 +231,31 @@ function writeSunburstView(view: SunburstView): void {
   }
 }
 
+// Burst coloring: 'progression' = seed/entry coloring; 'competitive' = winner
+// rings colored by matchUp competitiveness. Per-user preference, only relevant
+// while the burst (not donut) view is shown.
+type BurstColor = 'progression' | 'competitive';
+
+const BURST_COLOR_KEY = 'tmx:overview:burstColor';
+const BURST_COLOR_DEFAULT: BurstColor = 'progression';
+
+function readBurstColor(): BurstColor {
+  try {
+    const stored = localStorage.getItem(BURST_COLOR_KEY);
+    return stored === 'progression' || stored === 'competitive' ? stored : BURST_COLOR_DEFAULT;
+  } catch {
+    return BURST_COLOR_DEFAULT;
+  }
+}
+
+function writeBurstColor(color: BurstColor): void {
+  try {
+    localStorage.setItem(BURST_COLOR_KEY, color);
+  } catch {
+    // storage unavailable
+  }
+}
+
 const ALL_STRUCTURES = 'all';
 
 export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
@@ -238,6 +263,10 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
   panel.className = 'dash-panel dash-panel-green';
 
   let view: SunburstView = readSunburstView();
+  let burstColor: BurstColor = readBurstColor();
+  let burstInstance: { setColorMode: (m: 'default' | 'competitiveness') => void } | undefined;
+  const burstColorOption = (): 'default' | 'competitiveness' =>
+    burstColor === 'competitive' ? 'competitiveness' : 'default';
 
   // Header row: structure dropdown + view toggle
   const header = document.createElement('div');
@@ -274,6 +303,23 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
     toggleBtn.style.display = visible ? '' : 'none';
   };
 
+  // Burst color toggle (progression ↔ competitive) — only shown in burst view.
+  const colorToggleBtn = document.createElement('button');
+  colorToggleBtn.style.cssText = ICON_BTN_STYLE;
+  const setColorToggleAppearance = () => {
+    const competitive = burstColor === 'competitive';
+    colorToggleBtn.innerHTML = `<i class="fa ${competitive ? 'fa-fire' : 'fa-seedling'}"></i>`;
+    colorToggleBtn.title = competitive
+      ? t('dashboard.burstColorCompetitive', { defaultValue: 'Coloring: competitiveness — click for progression' })
+      : t('dashboard.burstColorProgression', { defaultValue: 'Coloring: progression — click for competitiveness' });
+  };
+  setColorToggleAppearance();
+  header.appendChild(colorToggleBtn);
+
+  const setColorToggleVisibility = (visible: boolean) => {
+    colorToggleBtn.style.display = visible ? '' : 'none';
+  };
+
   panel.appendChild(header);
 
   const chartDiv = document.createElement('div');
@@ -305,7 +351,11 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
         });
       },
     };
-    burstChart({ width: 500, height: 500, eventHandlers }).render(chartDiv, fromFactoryDrawData(drawData), title);
+    burstInstance = burstChart({ width: 500, height: 500, colorMode: burstColorOption(), eventHandlers }).render(
+      chartDiv,
+      fromFactoryDrawData(drawData),
+      title,
+    );
   };
 
   const renderDonut = (info: StructureInfo | null) => {
@@ -324,6 +374,7 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
   const renderStructure = (value: string) => {
     if (value === ALL_STRUCTURES) {
       setToggleVisibility(false);
+      setColorToggleVisibility(false);
       renderDonut(null);
       return;
     }
@@ -331,8 +382,10 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
     if (!info) return;
     setToggleVisibility(true);
     if (view === 'donut') {
+      setColorToggleVisibility(false);
       renderDonut(info);
     } else {
+      setColorToggleVisibility(true);
       renderBurst(info);
     }
   };
@@ -342,6 +395,14 @@ export function createSunburstPanel(structures: StructureInfo[]): HTMLElement {
     writeSunburstView(view);
     setToggleAppearance();
     renderStructure(select.value);
+  });
+
+  colorToggleBtn.addEventListener('click', () => {
+    burstColor = burstColor === 'competitive' ? 'progression' : 'competitive';
+    writeBurstColor(burstColor);
+    setColorToggleAppearance();
+    // Instant recolor without rebuilding the chart.
+    burstInstance?.setColorMode(burstColorOption());
   });
 
   select.addEventListener('change', () => renderStructure(select.value));


### PR DESCRIPTION
Builds on courthive-components burstChart `colorMode` (1.10.0).

## Draw cards
The single "Burst" display option becomes two:
- **Burst (progression)** — seed/entry coloring (unchanged behavior)
- **Burst (competitive)** — winner rings colored by matchUp competitiveness

New `sunburst-competitive` display mode + an `isSunburstMode` helper threads both variants through the gating/rendering pipeline. The competitive variant is gated on completed matches (like the competitiveness donut); both are gated on the draw-count cap.

## Overview dashboard
The burst panel gains a **color-toggle icon, visible only when the burst (not donut) view is active**, flipping progression ↔ competitive in place via `instance.setColorMode` (no rebuild). The choice persists in localStorage.

Competitiveness is computed by the burst adapter from `score.sets`, so no extra data fetch is required.

## Tests
`tsc` + ESLint clean (zero warnings); vitest 511 passing (+8 new drawCardVizGating tests); build OK.