### PR TITLE
refactor: route promoted-name reads through factory query methods (5.0.0 readiness)

### DIFF
--- a/src/components/drawers/addDraw/acceptedEntriesCount.ts
+++ b/src/components/drawers/addDraw/acceptedEntriesCount.ts
@@ -1,7 +1,7 @@
 import { acceptedEntryStatuses } from 'constants/acceptedEntryStatuses';
+import { tournamentEngine } from 'services/factory/engine';
 import { factoryConstants } from 'tods-competition-factory';
 
-const { FLIGHT_PROFILE } = factoryConstants.extensionConstants;
 const { MAIN } = factoryConstants.drawDefinitionConstants;
 
 export function acceptedEntriesCount({
@@ -13,7 +13,7 @@ export function acceptedEntriesCount({
   event: any;
   stage?: string;
 }): number {
-  const flightProfile = event?.extensions?.find((ext: any) => ext.name === FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const flight = flightProfile?.flights?.find((f: any) => f.drawId === drawId);
   const matchesStage = ({ entryStage = MAIN, entryStatus }: any) =>
     acceptedEntryStatuses(stage).includes(`${entryStage}.${entryStatus}`);

--- a/src/components/drawers/addDraw/drawFormModel.ts
+++ b/src/components/drawers/addDraw/drawFormModel.ts
@@ -585,7 +585,9 @@ function readNumericInput(value: number | string | undefined, fallback: number):
 }
 
 function readFlightMainEntries(draw: any, event: any): any[] {
-  const flightProfile = event?.extensions?.find((ext: any) => ext?.name === 'flightProfile')?.value;
+  // Pure-function model: read first-class with extension fallback inline (no
+  // engine dependency — see file header). Mode-agnostic across LEGACY/NATIVE.
+  const flightProfile = event?.flightProfile ?? event?.extensions?.find((ext: any) => ext?.name === 'flightProfile')?.value;
   const flight = flightProfile?.flights?.find((f: any) => f?.drawId === draw?.drawId);
   const flightMainEntries = (flight?.drawEntries ?? []).filter((entry: any) => {
     const entryStage = entry?.entryStage;

--- a/src/components/drawers/addDraw/getDrawFormItems.ts
+++ b/src/components/drawers/addDraw/getDrawFormItems.ts
@@ -46,7 +46,6 @@ import {
 const { ROUND_ROBIN, ROUND_ROBIN_WITH_PLAYOFF, SINGLE_ELIMINATION } = drawDefinitionConstants;
 const { DOMINANT_DUO, COLLEGE_DEFAULT, LAVER_CUP } = factoryConstants.tieFormatConstants;
 const { POLICY_TYPE_SCORING, POLICY_TYPE_SEEDING } = policyConstants;
-const { FLIGHT_PROFILE } = factoryConstants.extensionConstants;
 const { SINGLES } = factoryConstants.eventConstants;
 const { TEAM } = eventConstants;
 
@@ -78,7 +77,7 @@ export function getDrawFormItems({ event, mode }: { event: any; mode: DrawFormMo
   const existingTournamentPolicy = tournamentRecord?.policyDefinitions?.[POLICY_TYPE_SEEDING];
   const hasExistingPolicy = existingEventPolicy || existingTournamentPolicy;
 
-  const flightProfile = event?.extensions?.find((ext: any) => ext.name === FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const flight = flightProfile?.flights?.find((f: any) => f.drawId === drawId);
 
   const allowedFormats = providerConfig.getAllowedList('allowedMatchUpFormats');

--- a/src/components/drawers/addDraw/submitDrawParams.ts
+++ b/src/components/drawers/addDraw/submitDrawParams.ts
@@ -585,9 +585,7 @@ export function submitDrawParams({
   const matchUpFormat = providedMatchUpFormat || inputs[MATCHUP_FORMAT]?.value;
   const selectedSeedingPolicy = inputs[SEEDING_POLICY]?.value;
 
-  const flightProfile = event?.extensions?.find(
-    (ext: any) => ext.name === factoryConstants.extensionConstants.FLIGHT_PROFILE,
-  )?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const flight = flightProfile?.flights?.find((f: any) => f.drawId === drawId);
 
   const structureName = inputs[STRUCTURE_NAME]?.value;

--- a/src/components/modals/addAdHocRound.ts
+++ b/src/components/modals/addAdHocRound.ts
@@ -58,7 +58,7 @@ function resolvePositionLinkParticipants(positionLink: any, structure: any, draw
   const positionAssignments = sourceStructure?.positionAssignments || [];
   for (const pa of positionAssignments) {
     if (!pa.participantId) continue;
-    const tally = pa.extensions?.find((e: any) => e.name === 'tally')?.value;
+    const tally = tournamentEngine.getTally({ positionAssignment: pa })?.tally;
     const groupOrder = tally?.groupOrder || tally?.rankOrder;
     if (!targetFinishingPositions.length || (groupOrder && targetFinishingPositions.includes(groupOrder))) {
       ids.push(pa.participantId);

--- a/src/components/modals/drawEntriesModal.ts
+++ b/src/components/modals/drawEntriesModal.ts
@@ -7,7 +7,6 @@ import { cancelManualSeeding } from 'components/tables/eventsTable/seeding/cance
 import { headerSortElement } from 'components/tables/common/sorters/headerSortElement';
 import { getDrawEntriesColumns } from './drawEntriesColumns/getDrawEntriesColumns';
 import { tournamentEngine } from 'services/factory/engine';
-import { extensionConstants } from 'tods-competition-factory';
 import { saveSeeding } from 'components/tables/eventsTable/seeding/saveSeeding';
 import { mapEntry } from 'pages/tournament/tabs/eventsTab/mapEntry';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -30,7 +29,7 @@ export function drawEntriesModal({ eventId, drawId, drawName, eventName }: DrawE
     console.error('Event not found', { eventId });
     return;
   }
-  const flightProfile = event?.extensions?.find((ext: any) => ext.name === extensionConstants.FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const drawInfo = drawDef || flightProfile?.flights?.find((flight: any) => flight.drawId === drawId);
 
   if (!drawInfo) {

--- a/src/components/tables/statsTable/groupOrderAction.ts
+++ b/src/components/tables/statsTable/groupOrderAction.ts
@@ -15,7 +15,7 @@ function findBracket(structure: any, drawPosition: number) {
 
 function filterTiedAssignments(positionAssignments: any[], order: any) {
   return positionAssignments
-    ?.filter((pa) => pa.extensions?.find((ex) => ex.name === 'tally')?.value?.groupOrder === order)
+    ?.filter((pa) => tournamentEngine.getTally({ positionAssignment: pa })?.tally?.groupOrder === order)
     .map((pa) => ({ drawPosition: pa.drawPosition, participantId: pa.participantId }));
 }
 

--- a/src/pages/tournament/tabs/eventsTab/eventsTab.ts
+++ b/src/pages/tournament/tabs/eventsTab/eventsTab.ts
@@ -34,7 +34,7 @@ import { eventsView } from './eventsView';
 
 // constants
 import { tournamentEngine } from 'services/factory/engine';
-import { drawDefinitionConstants, extensionConstants } from 'tods-competition-factory';
+import { drawDefinitionConstants } from 'tods-competition-factory';
 import { controlBar } from 'courthive-components';
 import {
   DRAWS_HEADER,
@@ -139,9 +139,7 @@ function renderDrawsListOrPlaceholder(eventId: string, renderDraw: boolean | und
   const event = tournamentEngine.getEvent({ eventId })?.event;
   const drawDefs = event?.drawDefinitions || [];
 
-  const flightProfile = event?.extensions?.find(
-    (ext: any) => ext.name === extensionConstants.FLIGHT_PROFILE,
-  )?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const ungeneratedCount =
     flightProfile?.flights?.filter((f: any) => !drawDefs.some((dd: any) => dd.drawId === f.drawId))?.length || 0;
   const totalDrawItems = drawDefs.length + ungeneratedCount;

--- a/src/pages/tournament/tabs/eventsTab/mapEvent.ts
+++ b/src/pages/tournament/tabs/eventsTab/mapEvent.ts
@@ -5,7 +5,7 @@
 import { acceptedEntryStatuses } from 'constants/acceptedEntryStatuses';
 import { mapDrawDefinition } from './mapDrawDefinition';
 import { tournamentEngine } from 'services/factory/engine';
-import { publishingGovernor, drawDefinitionConstants, extensionConstants } from 'tods-competition-factory';
+import { publishingGovernor, drawDefinitionConstants } from 'tods-competition-factory';
 
 const { MAIN } = drawDefinitionConstants;
 
@@ -18,10 +18,10 @@ export function mapEvent({
   scaleValues?: any;
   event: any;
 }): any {
-  const { drawDefinitions = [], eventName, entries, eventId, extensions } = event;
+  const { drawDefinitions = [], eventName, entries, eventId } = event;
 
   const ungeneratedFlights: any = [];
-  const flightProfile = extensions?.find((ext: any) => ext.name === extensionConstants.FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   flightProfile?.flights?.forEach((flight: any) => {
     const drawDefinition = drawDefinitions.find((dd: any) => dd.drawId === flight.drawId);
     if (drawDefinition) {

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/eventControlBar/eventControlItems.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/eventControlBar/eventControlItems.ts
@@ -170,12 +170,12 @@ export function getEventControlItems({
     });
   }
 
-  // Draft status button when a draft is active
+  // Draft status button when a draft is active (mode-agnostic via getDraftState)
   const drawDefinition = drawId ? tournamentEngine.findDrawDefinition({ drawId })?.drawDefinition : undefined;
-  const draftExt = drawDefinition?.extensions?.find((ext: any) => ext.name === 'draftState');
+  const draftState = drawDefinition ? tournamentEngine.getDraftState({ drawDefinition })?.draftState : undefined;
 
-  if (draftExt) {
-    const draftComplete = draftExt.value?.status === 'COMPLETE';
+  if (draftState) {
+    const draftComplete = draftState.status === 'COMPLETE';
     items.push({
       onClick: () =>
         openConfigureDraft({ drawId, eventId, callback: () => renderDrawView({ eventId, drawId, structureId }) }),
@@ -188,7 +188,7 @@ export function getEventControlItems({
   // "Assign participants" button when there are unassigned positions
   const isAssignableStage =
     (structure?.stage === MAIN && structure?.stageSequence === 1) || structure?.stage === QUALIFYING;
-  if (isAssignableStage && !isTeam && !draftExt) {
+  if (isAssignableStage && !isTeam && !draftState) {
     const unassignedCount =
       structure.positionAssignments?.filter((pa: any) => !pa.participantId && !pa.bye && !pa.qualifier).length ?? 0;
     if (unassignedCount > 0) {

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/getActionOptions.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/getActionOptions.ts
@@ -46,9 +46,9 @@ export function getActionOptions({
   const structure = drawData?.structures?.find((structure: any) => structure?.structureId === structureId);
   const eventId = eventData?.eventInfo?.eventId;
 
-  // Check for active draft
+  // Check for active draft (mode-agnostic across LEGACY/NATIVE schemaWriteMode)
   const drawDefinition = tournamentEngine.findDrawDefinition({ drawId })?.drawDefinition;
-  const hasDraft = drawDefinition?.extensions?.some((ext: any) => ext.name === 'draftState');
+  const hasDraft = !!tournamentEngine.getDraftState({ drawDefinition })?.draftState;
 
   // Get scoring policy to check if participant assignment should be blocked
   const scoringPolicy = tournamentEngine.findPolicy({ policyType: POLICY_TYPE_SCORING, eventId });

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/getDrawsOptions.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/getDrawsOptions.ts
@@ -5,7 +5,6 @@
 import { selectAndDeleteEventFlights } from 'components/modals/selectAndDeleteFlights';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { tournamentEngine } from 'services/factory/engine';
-import { extensionConstants } from 'tods-competition-factory';
 
 export function getDrawsOptions({ eventData }: { eventData: any }): any[] {
   const deleteFlights = () => selectAndDeleteEventFlights({ eventData });
@@ -15,7 +14,7 @@ export function getDrawsOptions({ eventData }: { eventData: any }): any[] {
   // Count total draw items including ungenerated flights
   const event = tournamentEngine.getEvent({ eventId })?.event;
   const drawDefs = event?.drawDefinitions || [];
-  const flightProfile = event?.extensions?.find((ext: any) => ext.name === extensionConstants.FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const ungeneratedCount = flightProfile?.flights?.filter(
     (f: any) => !drawDefs.find((dd: any) => dd.drawId === f.drawId),
   )?.length || 0;

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
@@ -18,7 +18,7 @@ import { buildDrawCard, DrawCardData, mapDrawDefinitionToCardData } from 'courth
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { tournamentEngine } from 'services/factory/engine';
 import { addDraw } from 'components/drawers/addDraw/addDraw';
-import { extensionConstants, publishingGovernor, entryStatusConstants } from 'tods-competition-factory';
+import { publishingGovernor, entryStatusConstants } from 'tods-competition-factory';
 
 import { buildDrawCardVisualization } from './buildDrawCardVisualization';
 import { DrawCardDisplayMode } from './drawCardDisplayMode';
@@ -39,7 +39,6 @@ const GRID_EXPANDED_CLASS = 'tmx-draws-grid--expanded';
 const EMPTY_CLASS = 'tmx-draws-empty';
 const NOTICE_CLASS = 'tmx-draws-notice';
 
-const { FLIGHT_PROFILE } = extensionConstants;
 const { WITHDRAWN } = entryStatusConstants;
 
 function clearAnchor(anchor: HTMLElement): void {
@@ -71,8 +70,8 @@ interface ResolvedEvent {
 function resolveEventData(eventId: string): ResolvedEvent | null {
   const event = tournamentEngine.getEvent({ eventId })?.event;
   if (!event) return null;
-  const { drawDefinitions = [], extensions } = event;
-  const flightProfile = extensions?.find((ext: any) => ext.name === FLIGHT_PROFILE)?.value;
+  const { drawDefinitions = [] } = event;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   const flights: any[] = flightProfile?.flights ?? [];
   for (const flight of flights) {
     const dd = drawDefinitions.find((d: any) => d.drawId === flight.drawId);

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsTable.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsTable.ts
@@ -11,7 +11,6 @@ import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { addDraw } from 'components/drawers/addDraw/addDraw';
 import { tournamentEngine } from 'services/factory/engine';
-import { extensionConstants } from 'tods-competition-factory';
 import { t } from 'i18n';
 
 import { CENTER, DRAW_NAME, DRAW_TYPE, LEFT, UTR, WTN } from 'constants/tmxConstants';
@@ -20,11 +19,11 @@ export function renderDrawsTable({ eventId, target }: { eventId: string; target:
   const event = tournamentEngine.getEvent({ eventId })?.event;
   if (!event) return;
 
-  const { drawDefinitions = [], extensions } = event;
+  const { drawDefinitions = [] } = event;
 
   // Collect ungenerated flights from flight profile extension
   const ungeneratedFlights: any[] = [];
-  const flightProfile = extensions?.find((ext: any) => ext.name === extensionConstants.FLIGHT_PROFILE)?.value;
+  const flightProfile = tournamentEngine.getFlightProfile({ event })?.flightProfile;
   flightProfile?.flights?.forEach((flight: any) => {
     const hasDrawDef = drawDefinitions.find((dd: any) => dd.drawId === flight.drawId);
     if (hasDrawDef) {


### PR DESCRIPTION
## Summary

Factory 5.0.0 (currently \`5.0.0-alpha.0\` on master, [release-please PR open](https://github.com/CourtHive/competition-factory/pull/4383)) flips engine default \`schemaWriteMode\` from \`LEGACY\` to \`NATIVE\`. In NATIVE mode the factory writes a number of canonical names — \`tally\`, \`flightProfile\`, \`draftState\`, and several others — as first-class attributes ONLY, no longer to \`element.extensions[]\`. TMX had 14 read sites that did raw \`element.extensions?.find(ext => ext.name === X)?.value\` lookups against the affected names; in NATIVE mode those return \`undefined\` and the affected UI silently breaks.

This PR routes all 14 reads through the factory's mode-agnostic query methods (\`getFlightProfile\`, \`getDraftState\`, the new \`getTally\`), each of which uses \`firstClassOrExtension\` internally. Reads now work identically across LEGACY, DUAL, and NATIVE.

## Sites migrated

**FLIGHT_PROFILE (10 sites)** → \`tournamentEngine.getFlightProfile({ event })\`
- \`components/modals/drawEntriesModal.ts:33\`
- \`components/drawers/addDraw/acceptedEntriesCount.ts:16\`
- \`components/drawers/addDraw/submitDrawParams.ts:588\`
- \`components/drawers/addDraw/getDrawFormItems.ts:81\`
- \`pages/tournament/tabs/eventsTab/eventsTab.ts:142\`
- \`pages/tournament/tabs/eventsTab/mapEvent.ts:24\`
- \`pages/tournament/tabs/eventsTab/renderDraws/getDrawsOptions.ts:18\`
- \`pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts:75\`
- \`pages/tournament/tabs/eventsTab/renderDraws/renderDrawsTable.ts:27\`
- (\`components/drawers/addDraw/drawFormModel.ts:588\` uses an inline \`?? extensions.find()\` fallback because the file is the pure-function model and intentionally avoids engine dependencies — see its header)

**draftState (2 sites)** → \`tournamentEngine.getDraftState({ drawDefinition })\`
- \`pages/tournament/tabs/eventsTab/renderDraws/getActionOptions.ts:51\` — the \`.some()\` existence check becomes \`!!result.draftState\`
- \`pages/tournament/tabs/eventsTab/renderDraws/eventControlBar/eventControlItems.ts:175\` — \`.find()-then-.value\` becomes \`result.draftState.status\`

**tally (2 sites)** → \`tournamentEngine.getTally({ positionAssignment })\`
- \`components/tables/statsTable/groupOrderAction.ts:18\`
- \`components/modals/addAdHocRound.ts:61\`

Plus unused \`FLIGHT_PROFILE\` / \`extensionConstants\` imports removed where they were the only callers.

## Dependencies

- Requires factory PR \`feat: getTally engine query for mode-agnostic positionAssignment.tally read\` to land first ([CourtHive/competition-factory](https://github.com/CourtHive/competition-factory/pulls)). The \`getFlightProfile\` and \`getDraftState\` methods are already on factory master.
- Once factory 5.0.0 publishes, TMX picks it up via its existing \`link:../factory\` symlink (no \`package.json\` bump needed for dev). Production publish will pick up the new version on next build.

## Verification

- \`pnpm check-types\` — green
- \`pnpm lint\` — green
- \`pnpm test --run\` — 48 files / 511 pass / 0 fail (no regressions; behavior parity)
- \`pnpm build\` — green

## Test plan

- [ ] CI green
- [ ] Manual smoke: open a draw, confirm the flight profile / flights still render in the events tab
- [ ] Manual smoke: start a draft, confirm "Draft status" button appears, complete it, confirm completion state shows
- [ ] Manual smoke: complete a round-robin pool with ties, confirm group-order tiebreak resolution still works