### PR TITLE
feat: stamp matchUp.schedule.calledAt on active-strip drop

### DIFF
--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -64,6 +64,7 @@ export const RENAME_STRUCTURES = 'renameStructures';
 export const RESET_DRAW_DEFINITION = 'resetDrawDefinition';
 export const RESET_MATCHUP_LINEUPS = 'resetMatchUpLinesUps';
 export const RESET_SCORECARD = 'resetScorecard';
+export const SET_MATCHUP_CALLED_AT = 'setMatchUpCalledAt';
 export const SET_MATCHUP_FORMAT = 'setMatchUpFormat';
 export const SET_MATCHUP_STATUS = 'setMatchUpStatus';
 export const SET_DRAW_POSITION_PREFERENCES = 'setDrawPositionPreferences';

--- a/src/pages/tournament/tabs/schedule2Tab/gridView.ts
+++ b/src/pages/tournament/tabs/schedule2Tab/gridView.ts
@@ -58,7 +58,7 @@ import type {
 
 // constants
 import { COMPETITION_ENGINE, MINIMUM_SCHEDULE_COLUMNS } from 'constants/tmxConstants';
-import { ADD_MATCHUP_SCHEDULE_ITEMS } from 'constants/mutationConstants';
+import { ADD_MATCHUP_SCHEDULE_ITEMS, SET_MATCHUP_CALLED_AT } from 'constants/mutationConstants';
 import { addVenue } from 'pages/tournament/tabs/venuesTab/addVenue';
 import { hiddenCourtIds, syncVisibilityDate } from './visibilityState';
 import { renderSchedule2Tab } from './schedule2Tab';
@@ -303,6 +303,11 @@ export function renderGridView(
             schedule: { scheduledTime: '', scheduledDate: '', courtOrder: '', venueId: '', courtId: '' },
             removePriorValues: true,
           },
+        },
+        // Explicit unschedule — clear any prior active-strip "called" stamp.
+        {
+          method: SET_MATCHUP_CALLED_AT,
+          params: { matchUpId, drawId: item?.drawId ?? '', calledAt: null },
         },
       ];
 
@@ -599,6 +604,11 @@ function unscheduleFromCourt(matchUpId: string, drawId: string, refresh: () => v
       {
         method: ADD_MATCHUP_SCHEDULE_ITEMS,
         params: { matchUpId, drawId, schedule, removePriorValues: true },
+      },
+      // Explicit unschedule — clear any prior active-strip "called" stamp.
+      {
+        method: SET_MATCHUP_CALLED_AT,
+        params: { matchUpId, drawId, calledAt: null },
       },
     ],
     refresh,
@@ -1621,6 +1631,18 @@ function handleActiveStripDrop(
         venueId: court.venueId,
       },
       removePriorValues: true,
+    },
+  });
+
+  // Stamp the "called to court" timestamp — the active-strip drop is the
+  // deliberate signal that this matchUp is imminent. Distinct from regular
+  // grid drops (which leave calledAt untouched as historical record).
+  methods.push({
+    method: SET_MATCHUP_CALLED_AT,
+    params: {
+      matchUpId: payload.matchUp.matchUpId,
+      drawId: payload.matchUp.drawId ?? '',
+      calledAt: new Date().toISOString(),
     },
   });
 


### PR DESCRIPTION
## Summary

Wires the schedule2Tab "active strip" (the **Now** row) drop handler to capture the new factory `matchUp.schedule.calledAt` timestamp via `setMatchUpCalledAt`. Captures the moment a tournament director deliberately places a matchUp on the strip, signalling *"this matchUp is imminent on this court."*

Distinct from generic grid drops and from follow-by auto-population.

## Three trigger points

| Path | Behavior |
|---|---|
| `handleActiveStripDrop` (drag-drop ONTO a strip cell) | Sets `calledAt = new Date().toISOString()` in the same executionQueue payload that assigns courtId / venueId / courtOrder |
| `onMatchUpRemove` (drag a placed matchUp onto the catalog drop zone) | Clears `calledAt: null` — explicit removal |
| `unscheduleFromCourt` (Scheduled-tab unschedule path) | Clears `calledAt: null` — explicit removal |

Grid-to-grid moves **outside** the strip intentionally do NOT touch `calledAt` — the timestamp is a historical record of when the match was called and persists through subsequent schedule changes.

## Companion factory PR

[`feat/codes-matchup-calledAt`](https://github.com/CourtHive/competition-factory/pulls) — adds the `setMatchUpCalledAt` mutation and the `MatchUpSchedule.calledAt` type field. **Required**; this TMX PR will not lint-clean against factory `<= 5.0.0-alpha.0`.

## Verification

- `pnpm check-types` — green
- `pnpm lint` — green
- `pnpm test --run` — 48 files / 511 pass / 0 fail
- `pnpm build` — green

## Test plan

- [ ] CI green
- [ ] Manual smoke: drag a matchUp from the catalog onto a court's NOW strip; confirm `matchUp.schedule.calledAt` is populated in the saved record
- [ ] Manual smoke: drag the matchUp off the strip back to the catalog; confirm `matchUp.schedule.calledAt` is cleared
- [ ] Manual smoke: drag from NOW strip to a non-strip grid cell; confirm `matchUp.schedule.calledAt` is preserved (historical)
- [ ] Manual smoke: matchUp auto-appears on strip via follow-by; confirm `matchUp.schedule.calledAt` is NOT set