### PR TITLE
feat(api): handle /factory/save 400 + validationErrors with details modal

### DIFF
--- a/src/components/modals/tournamentActions.ts
+++ b/src/components/modals/tournamentActions.ts
@@ -51,7 +51,11 @@ export function tournamentActions(): void {
       if (!tournamentRecord.parentOrganisation) {
         tournamentRecord.parentOrganisation = state.provider;
         tournamentEngine.setState(tournamentRecord);
-        const successClaim = () => {
+        const successClaim = (result: any) => {
+          // baseApi resolves to `undefined` on non-2xx (the danger toast is
+          // already shown by the interceptor) — skip the local cleanup when
+          // the server did NOT actually accept the claim.
+          if (!result?.success) return;
           tmx2db.deleteTournament(tournamentRecord.tournamentId);
           context.router?.navigate(`/tournament/${tournamentRecord.tournamentId}/detail`);
           tmxToast({
@@ -84,7 +88,12 @@ export function tournamentActions(): void {
     if (inputs.action.value === 'goOnline' && state?.provider) {
       const postMutation = (result: any) => {
         if (result?.success) {
-          const successOnline = () => {
+          const successOnline = (result: any) => {
+            // Guard against deleting the local copy when the server
+            // rejected the upload (baseApi resolves to `undefined` on
+            // non-2xx). Without this, a server-side validation 400 would
+            // destroy the only remaining copy of an offline tournament.
+            if (!result?.success) return;
             tmx2db.deleteTournament(tournamentRecord.tournamentId);
             const dnav = document.getElementById('dnav');
             if (dnav) dnav.style.backgroundColor = '';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -855,7 +855,9 @@
     "error": "Error",
     "success": "Success",
     "required": "Required",
-    "send": "Send"
+    "send": "Send",
+    "details": "Details",
+    "validationDetails": "Validation details"
   },
 
   "modals": {

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -547,7 +547,10 @@ export function createActionsPanel(): HTMLElement {
           record.parentOrganisation = activeProvider;
           tournamentEngine.setState(record);
           sendTournament({ tournamentRecord: record }).then(
-            () => {
+            (result: any) => {
+              // baseApi resolves to `undefined` on non-2xx; skip the local
+              // delete when the server didn't accept the claim.
+              if (!result?.success) return;
               tmx2db.deleteTournament(record.tournamentId);
               tmxToast({ message: t('modals.tournamentActions.tournamentClaimed'), intent: 'is-info' });
               renderOverview();
@@ -591,7 +594,14 @@ export function createActionsPanel(): HTMLElement {
             if (result?.success) {
               const updated = tournamentEngine.q.tournament();
               sendTournament({ tournamentRecord: updated }).then(
-                () => {
+                (result: any) => {
+                  // Skip local destruction when the server rejected the
+                  // upload — baseApi resolves to `undefined` on non-2xx and
+                  // would otherwise wipe the only remaining offline copy.
+                  if (!result?.success) {
+                    changeOnlineState({ state, offline: true });
+                    return;
+                  }
                   tmx2db.deleteTournament(updated.tournamentId);
                   const dnav = document.getElementById('dnav');
                   if (dnav) dnav.style.backgroundColor = '';

--- a/src/services/apis/baseApi.ts
+++ b/src/services/apis/baseApi.ts
@@ -1,5 +1,6 @@
 import { getJwtTokenStorageKey, getRefreshTokenStorageKey } from 'config/localStorage';
 import { tmxToast } from 'services/notifications/tmxToast';
+import { t } from 'i18n';
 import axios from 'axios';
 
 const JWT_TOKEN_STORAGE_NAME = getJwtTokenStorageKey();
@@ -103,8 +104,21 @@ axiosInstance.interceptors.response.use(
     if (error.response) {
       if (error.response?.status === 401) removeAuthorization();
       if (!silenceErrors) {
-        const message = error.response.data.message || error.response.data.error || error.response.data;
-        tmxToast({ message, intent: 'is-danger' });
+        const data = error.response.data ?? {};
+        const message = data.message || data.error || data;
+        const validationErrors: string[] | undefined = Array.isArray(data.validationErrors)
+          ? data.validationErrors
+          : undefined;
+        if (validationErrors?.length) {
+          tmxToast({
+            message,
+            intent: 'is-danger',
+            duration: 6000,
+            action: { text: t('common.details'), onClick: () => showValidationDetailsModal(validationErrors) },
+          });
+        } else {
+          tmxToast({ message, intent: 'is-danger' });
+        }
       }
     }
     // Preserve the pre-existing contract: rejected requests resolve to
@@ -112,6 +126,23 @@ axiosInstance.interceptors.response.use(
     return undefined;
   },
 );
+
+// Dynamic import: baseModal pulls in `courthive-components` which touches
+// the DOM at module load time; a static import would break vitest's
+// non-jsdom default. The Vite "INEFFECTIVE_DYNAMIC_IMPORT" warning here is
+// expected — chunk-splitting isn't the goal, test-environment isolation is.
+async function showValidationDetailsModal(errors: string[]): Promise<void> {
+  const { informModal } = await import('components/modals/baseModal/baseModal');
+  const list = document.createElement('ul');
+  list.style.margin = '0';
+  list.style.paddingLeft = '1.25rem';
+  for (const e of errors) {
+    const li = document.createElement('li');
+    li.textContent = e;
+    list.appendChild(li);
+  }
+  informModal({ title: t('common.validationDetails'), message: list, okAction: () => undefined });
+}
 
 const addAuthorization = () => {
   const token = localStorage.getItem(JWT_TOKEN_STORAGE_NAME);


### PR DESCRIPTION
## Summary

- baseApi error interceptor now attaches a **Details** action button to the danger toast when an error response carries `validationErrors[]`. The button opens an `informModal` listing the per-field errors.
- Gates `tmx2db.deleteTournament(...)` in four `sendTournament().then(success, …)` handlers (claim + goOnline, in both `tournamentActions.ts` and `dashboardPanels.ts`) on `result?.success === true`. baseApi resolves non-2xx to `undefined` — without the gate, a server-side rejection (now a real possibility under the CFS sync L2 validation gate shipped at `7e63321`) silently wiped the only remaining offline copy of the tournament. The same pattern would have fired previously on `Invalid user` / `User not allowed` body-level errors.
- Adds `common.details` + `common.validationDetails` to `en.json`. Other locales fall back to English until the translation pass.

## Context

Follow-on to the CFS L2 sync gate (`competition-factory-server` commit `7e63321`, 2026-05-27). `/factory/save` now returns HTTP 400 + `{ tournamentId, validationErrors[], validationWarnings[] }` for malformed records.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm check-types` clean
- [x] `pnpm test --run` 511/511 passing
- [x] `pnpm build` succeeds
- [ ] Manual: send a malformed tournament from /admin → expect danger toast with "Details" button → click → modal lists per-field validation errors → local copy is NOT destroyed
- [ ] Manual: send a valid claim → success path runs (local delete + navigate)
- [ ] Manual: goOnline with a server-rejected record → local copy survives, state stays offline