### PR TITLE
feat(auth): self-service recovery email modal in main menu

### DIFF
--- a/src/components/menus/mainMenu.ts
+++ b/src/components/menus/mainMenu.ts
@@ -3,6 +3,7 @@
  * Provides server connection controls and authentication options.
  */
 import { getLoginState, logOut } from 'services/authentication/loginState';
+import { contactEmailModal } from 'components/modals/contactEmail';
 import { renderMenu } from 'courthive-components';
 import { loginModal } from 'components/modals/loginModal';
 
@@ -20,6 +21,7 @@ export const mainMenu = (elem: HTMLElement, close: () => void): void => {
         { hide: socketConnected, text: 'Connect', onClick: connectSocket },
         { hide: !socketConnected, text: 'Disconnect', onClick: disconnectSocket },
         { hide: loggedIn, text: 'Log in', onClick: loginModal },
+        { hide: !loggedIn, text: 'Recovery email', onClick: () => contactEmailModal() },
         { hide: !loggedIn, text: 'Log out', onClick: logOut },
       ],
     },

--- a/src/components/modals/contactEmail.ts
+++ b/src/components/modals/contactEmail.ts
@@ -1,0 +1,151 @@
+/**
+ * Recovery-email management modal.
+ *
+ * Lets the logged-in user set or change `users.contact_email` and trigger
+ * a verification email. Distinct from `users.email` which is the LOGIN
+ * identifier (often a non-email string for legacy accounts).
+ *
+ * Live state comes from GET /auth/me on open so the user sees the
+ * verified-at timestamp even if their cached JWT is stale.
+ */
+import { setContactEmail, resendVerification } from 'services/authentication/authApi';
+import { fetchUserContext } from 'services/authentication/getUserContext';
+import { validators, renderForm } from 'courthive-components';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+const INTENT_SUCCESS = 'is-success';
+
+type ContactEmailState = {
+  contactEmail?: string | null;
+  emailVerifiedAt?: string | null;
+};
+
+export function contactEmailModal(onClose?: () => void): void {
+  let inputs: any;
+  let modalHandle: any;
+  let liveState: ContactEmailState = {};
+
+  const renderStatus = (statusEl: HTMLElement, state: ContactEmailState) => {
+    statusEl.innerHTML = '';
+    const text = document.createElement('div');
+    text.style.cssText = 'font-size: 0.9rem; margin-bottom: 12px;';
+    if (!state.contactEmail) {
+      text.textContent = t('modals.contactEmail.statusNotSet');
+      text.style.color = 'var(--tmx-status-warning)';
+    } else if (state.emailVerifiedAt) {
+      text.textContent = t('modals.contactEmail.statusVerified', { email: state.contactEmail });
+      text.style.color = 'var(--tmx-status-success)';
+    } else {
+      text.textContent = t('modals.contactEmail.statusPending', { email: state.contactEmail });
+      text.style.color = 'var(--tmx-status-warning)';
+    }
+    statusEl.appendChild(text);
+  };
+
+  const enableSubmit = ({ inputs }: any) => {
+    const value = inputs?.contactEmail?.value ?? '';
+    const isValid = validators.emailValidator(value);
+    modalHandle?.setButtonState('contactEmailSave', { disabled: !isValid });
+    // Resend button is enabled only when there's a pending (unverified)
+    // address on the LIVE state — typing a new address doesn't enable
+    // resend because that would resend the OLD pending address.
+    modalHandle?.setButtonState('contactEmailResend', {
+      disabled: !liveState.contactEmail || Boolean(liveState.emailVerifiedAt),
+    });
+  };
+
+  const relationships = [{ onInput: enableSubmit, control: 'contactEmail' }];
+
+  const statusContainer = document.createElement('div');
+  statusContainer.id = 'contactEmailStatus';
+
+  const content = (elem: HTMLElement) => {
+    elem.appendChild(statusContainer);
+    renderStatus(statusContainer, liveState);
+
+    inputs = renderForm(
+      elem,
+      [
+        {
+          iconLeft: 'fa-regular fa-envelope',
+          placeholder: 'you@example.com',
+          validator: validators.emailValidator,
+          autocomplete: 'email',
+          label: t('modals.contactEmail.label'),
+          field: 'contactEmail',
+          id: 'contactEmailInput',
+          value: liveState.contactEmail ?? '',
+        },
+      ],
+      relationships,
+    );
+
+    // Refresh live state in the background from GET /auth/me. Failures are
+    // non-fatal — the user can still try to save the form.
+    fetchUserContext().then(
+      (ctx) => {
+        liveState = { contactEmail: ctx?.contactEmail, emailVerifiedAt: ctx?.emailVerifiedAt };
+        renderStatus(statusContainer, liveState);
+        if (inputs?.contactEmail && !inputs.contactEmail.value) {
+          inputs.contactEmail.value = liveState.contactEmail ?? '';
+        }
+        enableSubmit({ inputs });
+      },
+      () => {
+        /* live refresh failed — keep showing JWT-derived state */
+      },
+    );
+  };
+
+  const onSave = () => {
+    const value = (inputs?.contactEmail?.value ?? '').trim();
+    if (!value) return;
+    setContactEmail(value).then(
+      (res: any) => {
+        if (res?.data?.error) {
+          tmxToast({ message: res.data.error, intent: 'is-danger' });
+          return;
+        }
+        tmxToast({
+          message: t('modals.contactEmail.savedPending', { email: value }),
+          intent: INTENT_SUCCESS,
+        });
+      },
+      (err: any) => {
+        const message = err?.response?.data?.message || err?.message || t('modals.contactEmail.failed');
+        tmxToast({ message, intent: 'is-danger' });
+      },
+    );
+  };
+
+  const onResend = () => {
+    resendVerification().then(
+      (res: any) => {
+        const status = res?.data?.status;
+        if (status === 'already_verified') {
+          tmxToast({ message: t('modals.contactEmail.alreadyVerified'), intent: INTENT_SUCCESS });
+        } else if (status === 'no_contact_email') {
+          tmxToast({ message: t('modals.contactEmail.statusNotSet'), intent: 'is-warning' });
+        } else {
+          tmxToast({ message: t('modals.contactEmail.resent'), intent: INTENT_SUCCESS });
+        }
+      },
+      () => {
+        tmxToast({ message: t('modals.contactEmail.failed'), intent: 'is-danger' });
+      },
+    );
+  };
+
+  modalHandle = openModal({
+    title: t('modals.contactEmail.title'),
+    content,
+    onClose,
+    buttons: [
+      { label: t('modals.contactEmail.resend'), id: 'contactEmailResend', disabled: true, onClick: onResend, intent: 'none' },
+      { label: t('common.cancel'), intent: 'none', close: true },
+      { label: t('modals.contactEmail.save'), id: 'contactEmailSave', disabled: true, onClick: onSave, close: true, intent: 'is-primary' },
+    ],
+  });
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -861,6 +861,19 @@
   },
 
   "modals": {
+    "contactEmail": {
+      "title": "Recovery email",
+      "label": "Recovery email",
+      "statusNotSet": "No recovery email set. Add one so you can recover access if you lose your password.",
+      "statusPending": "Pending verification — check {{email}} and click the link.",
+      "statusVerified": "Verified: {{email}}",
+      "save": "Save",
+      "resend": "Resend verification",
+      "savedPending": "Verification email sent to {{email}}.",
+      "resent": "Verification email sent.",
+      "alreadyVerified": "Recovery email is already verified.",
+      "failed": "Could not update recovery email. Please try again."
+    },
     "deleteEvents": {
       "titleOne": "Delete Event",
       "titleOther": "Delete Events",

--- a/src/services/authentication/authApi.ts
+++ b/src/services/authentication/authApi.ts
@@ -71,3 +71,21 @@ export async function requestMagicLink(email: string) {
 export async function consumeMagicLink(code: string) {
   return baseApi.post('/auth/magic/consume', { code }, { silenceErrors: true });
 }
+
+/**
+ * Set or change the caller's recovery mailbox (`users.contact_email`).
+ * Always clears `email_verified_at` server-side and fires a fresh
+ * verification email — see IdentityService.setContactEmail.
+ */
+export async function setContactEmail(contactEmail: string) {
+  return baseApi.post('/account/contact-email/set', { contactEmail });
+}
+
+/**
+ * Re-send the verification email for a pending (unverified) recovery
+ * mailbox. Idempotent — server returns status='already_verified' or
+ * 'no_contact_email' when there's nothing to send.
+ */
+export async function resendVerification() {
+  return baseApi.post('/account/contact-email/resend-verification', {});
+}

--- a/src/types/tmx.ts
+++ b/src/types/tmx.ts
@@ -74,6 +74,10 @@ export interface UserContext {
   providerIds: string[];
   /** Provider IDs inherited via the user's provisioner(s); admin-equivalent. */
   provisionerProviderIds?: string[];
+  /** Verified recovery mailbox — separate from the login `email` identifier. */
+  contactEmail?: string | null;
+  /** ISO timestamp at which `contactEmail` was verified, or null when pending. */
+  emailVerifiedAt?: string | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings TMX to parity with the admin-client `contact_email` flow so a logged-in user can set, change, and verify their recovery mailbox without an admin going through Edit User.

This is the user-side of the broader contact-email plan tracked at [`Mentat/planning/CONTACT_EMAIL_EDITABLE.md`](https://github.com/CourtHive/Mentat/blob/main/planning/CONTACT_EMAIL_EDITABLE.md) (Phase 4 / Task C). The other phases (admin Edit User modal, provider-admin scoping, audit events, backfill coverage tile) landed in CFS on `main` today.

## What changed

- `src/components/modals/contactEmail.ts` (new): ported from `competition-factory-server/admin-client/src/components/modals/contactEmail.ts`. Same three-state status block (not set / pending / verified), same Save + Resend behaviour (Resend gated on LIVE state, not draft input). Live state refreshed via `fetchUserContext()` on open.
- `src/services/authentication/authApi.ts`: new `setContactEmail` + `resendVerification` clients pointing at the existing `/account/contact-email/set` and `/account/contact-email/resend-verification` endpoints.
- `src/types/tmx.ts`: `UserContext` extended with `contactEmail` + `emailVerifiedAt` (the server's `buildUserContext` already returns them).
- `src/components/menus/mainMenu.ts`: new "Recovery email" entry between Log in and Log out for logged-in users.
- `src/i18n/locales/en.json`: 11 new keys under `modals.contactEmail`.

## Test plan

- [ ] Log in to TMX with an existing user
- [ ] Open the main menu → click "Recovery email"
- [ ] Verify the status block reflects current `contactEmail` / `emailVerifiedAt`
- [ ] Type a new address → Save → toast confirms verification email sent
- [ ] Open inbox → click verify link → re-open modal → status flips to "verified"
- [ ] Resend button only enables when there's an unverified `contactEmail` on the LIVE state

## Deferred / out of scope

- Post-login banner from admin-client (`contactEmailBanner.ts`) — modal + menu entry is the minimum useful slice.
- 5 pre-existing TS errors and 1 SonarJS warning on `main` are NOT touched by this PR.