### PR TITLE
chore(deps): bump tods-competition-factory to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "tabulator-tables": "6.4.0",
     "timepicker-ui": "4.3.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "4.2.0",
+    "tods-competition-factory": "5.0.0",
     "@courthive/provider-config": "^0.3.0",
     "vanillajs-datepicker": "1.3.4"
   }


### PR DESCRIPTION
## Summary

- Bumps `tods-competition-factory` from `4.2.0` → `5.0.0` (published 2026-05-31)
- TMX uses `syncEngine` (in-browser, IndexedDB-persisted); the AvailabilityEngine rename and matchUp.schedule.* first-class promotion most directly affect TMX's schedule2 view + scheduling-profile flow
- See factory's [4.x → 5.0.0 migration guide](https://github.com/CourtHive/competition-factory/blob/master/documentation/docs/migration/4.x-to-5.0.0.md)

## Local verification

- `pnpm lint` — clean
- `pnpm check-types` — clean
- `pnpm test --run` — 553 tests pass across 51 files

## Test plan

- [ ] CI strip-link path resolves `5.0.0` from npm
- [ ] Smoke test schedule2 (drag/drop matchUps onto courts, conflict detection)
- [ ] Round-robin tally renders (Phase 1 first-class promotion)
- [ ] Generate draw, verify draw bracket + matchUp scoring round-trip
- [ ] Schedule profile builder still produces a runnable profile