### PR TITLE
fix(ci): force-checkout docs branch in deploy-pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -67,8 +67,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # `Strip link: overrides for CI` left pnpm-lock.yaml deleted and
+          # pnpm-workspace.yaml modified — both are tracked on `main`, and a
+          # plain `git checkout docs` refuses to overwrite those working-tree
+          # changes. We already used the stripped state for install + build,
+          # so discard it with -f. The docs branch only tracks .gitignore and
+          # docs/, so nothing else of value is at risk.
           git fetch origin docs
-          git checkout docs
+          git checkout -f docs
 
           rm -rf docs
           mkdir docs


### PR DESCRIPTION
## Summary
First real run of `deploy-pages.yml` failed at the `git checkout docs` step. The earlier `Strip link: overrides for CI` step deletes `pnpm-lock.yaml` and modifies `pnpm-workspace.yaml` — both tracked on `main` — so plain `git checkout docs` aborts with `local changes would be overwritten`.

The stripped state is only needed for `pnpm install` + `pnpm build`, which already ran. `docs` branch only tracks `.gitignore` and `docs/`, so discarding the strip with `-f` doesn't risk anything else.

Run that exposed it: https://github.com/CourtHive/TMX/actions/runs/27062548336

## Test plan
- [ ] After merge, re-run `deploy-pages` via `workflow_dispatch` and confirm it publishes 7.2.1 to the docs branch
- [ ] Verify https://courthive.github.io/TMX/version.json reports 7.2.1