### PR TITLE
feat(dev): keep dev tools active in the anonymous-user state on prod

### DIFF
--- a/src/services/authentication/checkDevState.ts
+++ b/src/services/authentication/checkDevState.ts
@@ -1,8 +1,0 @@
-export function checkDevState(): void {
-  const notLocal = !window.location.host.startsWith('localhost');
-  const isGithub = window.location.host.endsWith('github.io');
-  if (!isGithub && notLocal && window['dev']) {
-    delete window['dev'];
-    console.log('%c dev cancelled', 'color: cyan');
-  }
-}

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -17,7 +17,6 @@ import { providerConfig } from 'config/providerConfig';
 import { ensurePdfFontReady } from 'services/pdf/pdfFont';
 import { getLoginColor } from 'functions/getLoginColor';
 import { tipster } from 'components/popovers/tipster';
-import { checkDevState } from './checkDevState';
 import { isFunction } from 'functions/typeOf';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -60,7 +59,6 @@ export function logOut(): void {
   removeToken();
   removeRefreshToken();
   clearUserContext();
-  checkDevState();
   disconnectSocket();
   tournamentEngine.reset();
   clearActiveProvider();

--- a/src/services/authentication/validateToken.ts
+++ b/src/services/authentication/validateToken.ts
@@ -1,4 +1,3 @@
-import { checkDevState } from './checkDevState';
 import { getRefreshToken, removeToken } from './tokenManagement';
 import { setDev } from 'services/setDev';
 import { jwtDecode } from 'jwt-decode';
@@ -8,7 +7,6 @@ import type { LoginState } from 'types/tmx';
 
 export function validateToken(token: string | null | undefined): LoginState | undefined {
   if (!token || token === 'undefined') {
-    checkDevState();
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
Anonymous loads on `courthive.net/tmx` and `dev.courthive.net/tmx` used to drop `window.dev` immediately because `validateToken`'s no-token branch and `logOut()` both called `checkDevState()`, which deleted the dev object on any host other than `localhost` or `*.github.io`. That's exactly the wrong state to gate: anonymous demos benefit from having the factory debug helpers exposed, and the dev surface that can actually touch production data (mutationRequest etc.) is server-token-gated anyway.

Drop both call sites and remove the now-unused `checkDevState.ts`.

## Behaviour matrix

| host                         | logged-in user      | before  | after   |
|------------------------------|---------------------|---------|---------|
| `localhost`                  | any                 | dev on  | dev on  |
| `*.github.io` (GH Pages)     | any                 | dev on  | dev on  |
| `courthive.net` / `dev.courthive.net` | anonymous  | **dev off** | **dev on** |
| `courthive.net` / `dev.courthive.net` | logged in, no `devMode` | dev on (boot-set, never cancelled mid-session) | dev on |
| `courthive.net` / `dev.courthive.net` | logged in, with `devMode` | dev on | dev on |
| `courthive.net` / `dev.courthive.net` | after explicit logout | **dev off** | **dev on** |

The two cells in bold are the change. Everything else was already on.

## Test plan
- [ ] Load https://courthive.net/tmx in an incognito tab; in the devtools console, `typeof window.dev` should be `'object'`.
- [ ] Repeat on https://dev.courthive.net/tmx.
- [ ] Sign in, then sign out; confirm `window.dev` is still defined.
- [ ] GH Pages (https://courthive.github.io/TMX/) unchanged: `window.dev` defined.
- [ ] localhost dev server unchanged: `window.dev` defined.