### PR TITLE
chore(deps): bump tods-competition-factory to 5.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "tabulator-tables": "6.4.0",
     "timepicker-ui": "4.3.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "5.2.4",
+    "tods-competition-factory": "5.2.5",
     "@courthive/provider-config": "^0.5.0",
     "vanillajs-datepicker": "1.3.4"
   }


### PR DESCRIPTION
## Summary
Bumps `tods-competition-factory` `5.2.4` → `5.2.5`.

5.2.5 ships [factory PR #4423](https://github.com/CourtHive/competition-factory/pull/4423) — the `addMatchUpContext` fix that preserves the hydrated `matchUp.schedule` (`venueName` / `courtName` / `venueAbbreviation` / `isoDateString` / `milliseconds` / `time` + applied embargo/publish-state filtering) under NATIVE schema-write mode.

TMX runs its own factory locally for the offline / local-first paths, so this bump is mostly a consistency move (CFS #745 is the one that fixes IONSport's prod symptom — TMX wasn't reading the lost fields off the wire), but worth keeping the trio in lockstep.

## Test plan
- [ ] CI green (lint)
- [ ] Local TMX still loads + schedule tab renders venueName/courtName for an offline tournament