### PR TITLE
feat(staleness): probe-based reconnect + poll, notify via refresh icon

### DIFF
--- a/src/services/apis/servicesApi.ts
+++ b/src/services/apis/servicesApi.ts
@@ -11,6 +11,13 @@ export async function requestTournament({ tournamentId, silent }: { tournamentId
   return await baseApi.post('/factory/fetch', { tournamentId }, silent ? { silenceErrors: true } : undefined);
 }
 
+/** Lightweight staleness probe — returns only `{ tournamentId, updatedAt }`,
+ * never the full tournament record. Used to cheaply detect whether the local
+ * copy has fallen behind the server. */
+export async function requestTournamentUpdatedAt({ tournamentId, silent }: { tournamentId: string; silent?: boolean }) {
+  return await baseApi.post('/factory/updated-at', { tournamentId }, silent ? { silenceErrors: true } : undefined);
+}
+
 export async function addProvider({ provider }: { provider: any }) {
   return await baseApi.post('/provider/add', provider);
 }

--- a/src/services/messaging/remoteMutations.ts
+++ b/src/services/messaging/remoteMutations.ts
@@ -8,9 +8,10 @@
  *   → refreshes active table data in-place (preserving sort/scroll)
  *   → shows sync indicator in navbar if no table could be refreshed
  */
+import { onTournamentMutation, joinTournamentRoom } from 'services/messaging/socketIo';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
 import { notifyMutationApplied } from 'services/mutation/mutationObservers';
-import { onTournamentMutation } from 'services/messaging/socketIo';
+import { requestTournament } from 'services/apis/servicesApi';
 import { tmxToast } from 'services/notifications/tmxToast';
 import * as factory from 'tods-competition-factory';
 import { debugConfig } from 'config/debugConfig';
@@ -21,6 +22,11 @@ import { SYNC_INDICATOR, TOURNAMENT_ENGINE } from 'constants/tmxConstants';
 import type { RemoteMutationPayload } from 'types/services';
 
 const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
+
+/** When set, the sync indicator is in "stale" mode: the local copy is behind the
+ * server (detected by the staleness probe) and a click must pull the full record
+ * from the server, not just re-render the active table from local state. */
+let staleRefreshTournamentId: string | undefined;
 
 /**
  * Initialize the remote mutation listener.
@@ -33,10 +39,39 @@ export function initRemoteMutationHandler(): void {
 
 /** Hide the sync indicator (called on navigation). */
 export function clearSyncIndicator(): void {
+  staleRefreshTournamentId = undefined;
   const el = document.getElementById(SYNC_INDICATOR);
   if (el) {
     el.style.display = 'none';
     el.classList.remove('sync-indicator--active');
+  }
+}
+
+/** Surface the sync indicator in "stale" mode — the staleness probe found the
+ * server ahead of the local copy. Clicking the icon pulls the fresh record. */
+export function markStaleNeedsRefresh(tournamentId: string): void {
+  staleRefreshTournamentId = tournamentId;
+  showSyncIndicator();
+}
+
+/** Pull the latest tournament record from the server and apply it locally. Only
+ * invoked on an explicit sync-icon click, so the full record is fetched on
+ * demand — never on a background poll. */
+async function refreshTournamentFromServer(tournamentId: string): Promise<void> {
+  try {
+    const result: any = await requestTournament({ tournamentId });
+    const serverRecord = result?.data?.tournamentRecords?.[tournamentId];
+    if (!serverRecord) return;
+
+    const factoryEngine: any = factory[TOURNAMENT_ENGINE];
+    factoryEngine.setState(serverRecord);
+    notifyMutationApplied();
+    await saveTournamentRecord();
+    joinTournamentRoom(tournamentId);
+
+    if (context.refreshActiveTable) context.refreshActiveTable();
+  } catch (err) {
+    console.warn('[syncIndicator] stale refresh failed:', err);
   }
 }
 
@@ -51,8 +86,12 @@ function showSyncIndicator(): void {
   if (!el.dataset.bound) {
     el.dataset.bound = '1';
     el.addEventListener('click', () => {
+      const staleId = staleRefreshTournamentId;
       clearSyncIndicator();
-      if (context.refreshActiveTable) {
+      if (staleId) {
+        slog('[syncIndicator] clicked — pulling fresh record (stale)');
+        void refreshTournamentFromServer(staleId);
+      } else if (context.refreshActiveTable) {
         slog('[syncIndicator] clicked — refreshing active table');
         context.refreshActiveTable();
       }

--- a/src/services/messaging/socketIo.ts
+++ b/src/services/messaging/socketIo.ts
@@ -61,6 +61,17 @@ const oi: any = {
 /** True after a disconnect event until cleared by `clearDisconnectFlag()`. */
 let disconnectedSinceLastNav = false;
 
+/** Listeners invoked after the socket reconnects (not on the first connect).
+ * Used by the staleness guard to check whether mutations were missed during the
+ * offline window. Registered via `onSocketReconnect`. */
+const reconnectListeners: Array<() => void> = [];
+
+/** Register a callback to run after the socket reconnects following a drop.
+ * Does not fire on the initial connection. */
+export function onSocketReconnect(listener: () => void): void {
+  reconnectListeners.push(listener);
+}
+
 const ackRequests: Record<string, (ack: ServerAck) => void> = {};
 const ackTimeouts: Record<string, ReturnType<typeof setTimeout>> = {};
 const socketQueue: any[] = [];
@@ -225,6 +236,9 @@ function socketEmit(msg: string, data: any): void {
 
 function connectionEvent(callback?: () => void): void {
   slog('[socket] connected — id:', oi.socket?.id);
+  // Capture before anything clears the flag: true only when this `connect` is a
+  // reconnect after a prior drop (the first connect leaves the flag false).
+  const reconnected = disconnectedSinceLastNav;
   emitTmx({ data: { type: 'timestamp' } });
   while (socketQueue.length) {
     const message = socketQueue.pop();
@@ -241,6 +255,18 @@ function connectionEvent(callback?: () => void): void {
   rejoinChatMonitorIfActive();
 
   void checkFactoryVersion();
+
+  // After a reconnect, notify listeners (staleness guard) so the client can
+  // detect mutations broadcast while it was offline (Socket.IO has no replay).
+  if (reconnected) {
+    for (const listener of reconnectListeners) {
+      try {
+        listener();
+      } catch (err) {
+        slog('[socket] reconnect listener error:', err);
+      }
+    }
+  }
 
   if (isFunction(callback)) callback();
 }

--- a/src/services/staleness/stalenessGuard.ts
+++ b/src/services/staleness/stalenessGuard.ts
@@ -11,9 +11,10 @@
  *    before any further mutations can be submitted.
  */
 import { hadDisconnect, clearDisconnectFlag, joinTournamentRoom, onSocketReconnect } from 'services/messaging/socketIo';
+import { requestTournament, requestTournamentUpdatedAt } from 'services/apis/servicesApi';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
+import { markStaleNeedsRefresh } from 'services/messaging/remoteMutations';
 import { getLoginState } from 'services/authentication/loginState';
-import { requestTournament } from 'services/apis/servicesApi';
 import { tournamentEngine } from 'services/factory/engine';
 import { debugConfig } from 'config/debugConfig';
 import { context } from 'services/context';
@@ -111,14 +112,45 @@ export function resetActivityTimer(): void {
   }, timeoutMs);
 }
 
-/** Check now whether local data is behind the server, showing the overlay if so.
- * Safe to call any time — no-ops when logged out, with no tournament loaded, or
- * when a check/overlay is already in flight. Used by the reconnect hook and the
- * periodic poll. */
+/** Check now whether local data is behind the server. Uses the lightweight
+ * `updatedAt` probe (never pulls the full record) and, if behind, surfaces the
+ * existing refresh icon — clicking it pulls the fresh record on demand. Safe to
+ * call any time; no-ops when logged out, with no tournament loaded, or when a
+ * check is already in flight. Used by the reconnect hook and the periodic poll. */
 export function triggerStalenessCheck(): void {
   if (!getLoginState()) return;
   const { tournamentRecord } = tournamentEngine.getTournament();
-  if (tournamentRecord?.tournamentId) checkAndShowOverlay(tournamentRecord.tournamentId);
+  if (tournamentRecord?.tournamentId) void probeStaleness(tournamentRecord.tournamentId);
+}
+
+/** Lightweight staleness probe — fetches only the server `updatedAt` and, when
+ * the server is ahead, flags the sync indicator stale (no full-record pull). */
+async function probeStaleness(tournamentId: string): Promise<void> {
+  if (checking || overlayVisible) return;
+  checking = true;
+
+  const debug = isDebugMode();
+  try {
+    const result: any = await requestTournamentUpdatedAt({ tournamentId, silent: true });
+    const serverUpdatedAt = result?.data?.updatedAt;
+    if (!serverUpdatedAt) return;
+
+    const localRecord = tournamentEngine.q.tournament();
+    const serverUpdated = new Date(serverUpdatedAt).getTime();
+    const localUpdated = localRecord?.updatedAt ? new Date(localRecord.updatedAt).getTime() : 0;
+
+    if (debug) console.log('[staleness] probe server=%s local=%s', serverUpdatedAt, localRecord?.updatedAt);
+
+    if (serverUpdated > localUpdated) {
+      markStaleNeedsRefresh(tournamentId);
+    } else if (hadDisconnect()) {
+      clearDisconnectFlag();
+    }
+  } catch (err) {
+    console.warn('[staleness] probe failed:', err);
+  } finally {
+    checking = false;
+  }
 }
 
 /** Periodic poll — only checks while the tab is visible (avoids background

--- a/src/services/staleness/stalenessGuard.ts
+++ b/src/services/staleness/stalenessGuard.ts
@@ -10,7 +10,7 @@
  * 3. If the server is ahead, a blocking overlay forces the TD to refresh
  *    before any further mutations can be submitted.
  */
-import { hadDisconnect, clearDisconnectFlag, joinTournamentRoom } from 'services/messaging/socketIo';
+import { hadDisconnect, clearDisconnectFlag, joinTournamentRoom, onSocketReconnect } from 'services/messaging/socketIo';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
 import { getLoginState } from 'services/authentication/loginState';
 import { requestTournament } from 'services/apis/servicesApi';
@@ -28,9 +28,21 @@ const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...a
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
+// Periodic "am I behind the server?" poll. Runs only while the tab is visible
+// and logged in — a safety net for mutations missed during a silent socket drop
+// where no `disconnect`/`visibilitychange` event fired. Override from console:
+// dev.stalenessPollInterval = 20 (seconds); 0 disables polling.
+const DEFAULT_POLL_MS = 45 * 1000;
+
 function getTimeoutMs(): number {
   const override = (globalThis as any).dev?.stalenessTimeout;
   return typeof override === 'number' && override > 0 ? override * 1000 : DEFAULT_TIMEOUT_MS;
+}
+
+function getPollMs(): number {
+  const override = (globalThis as any).dev?.stalenessPollInterval;
+  if (override === 0) return 0;
+  return typeof override === 'number' && override > 0 ? override * 1000 : DEFAULT_POLL_MS;
 }
 
 function isDebugMode(): boolean {
@@ -41,6 +53,7 @@ function isDebugMode(): boolean {
 
 let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
 let countdownInterval: ReturnType<typeof setInterval> | undefined;
+let pollInterval: ReturnType<typeof setInterval> | undefined;
 let timerExpired = false;
 let overlayVisible = false;
 let checking = false;
@@ -98,13 +111,39 @@ export function resetActivityTimer(): void {
   }, timeoutMs);
 }
 
+/** Check now whether local data is behind the server, showing the overlay if so.
+ * Safe to call any time — no-ops when logged out, with no tournament loaded, or
+ * when a check/overlay is already in flight. Used by the reconnect hook and the
+ * periodic poll. */
+export function triggerStalenessCheck(): void {
+  if (!getLoginState()) return;
+  const { tournamentRecord } = tournamentEngine.getTournament();
+  if (tournamentRecord?.tournamentId) checkAndShowOverlay(tournamentRecord.tournamentId);
+}
+
+/** Periodic poll — only checks while the tab is visible (avoids background
+ * round-trips). The reconnect hook covers detected drops; this catches silent
+ * ones where no disconnect event fired. */
+function startPolling(): void {
+  if (pollInterval) clearInterval(pollInterval);
+  const pollMs = getPollMs();
+  if (!pollMs) return;
+  pollInterval = setInterval(() => {
+    if (document.visibilityState !== 'visible') return;
+    triggerStalenessCheck();
+  }, pollMs);
+}
+
 /** Initialize the guard. Call once at startup. */
 export function initStalenessGuard(): void {
   if (initialized) return;
   initialized = true;
 
   document.addEventListener('visibilitychange', onVisibilityChange);
+  // On reconnect, immediately check for mutations missed while offline.
+  onSocketReconnect(triggerStalenessCheck);
   resetActivityTimer();
+  startPolling();
   slog('[staleness] guard initialized');
 }
 
@@ -112,6 +151,7 @@ export function initStalenessGuard(): void {
 export function destroyStalenessGuard(): void {
   if (inactivityTimer) clearTimeout(inactivityTimer);
   if (countdownInterval) clearInterval(countdownInterval);
+  if (pollInterval) clearInterval(pollInterval);
   document.removeEventListener('visibilitychange', onVisibilityChange);
   dismissOverlay();
   initialized = false;


### PR DESCRIPTION
## Problem

Clients silently fall behind the server after a socket drop (idle/network). Socket.IO has no replay buffer, so mutations broadcast while a client is offline are lost until manual refresh. The existing guard only fired on a 5-min inactivity timeout + tab-visibility change, so a silent reconnect inside that window slips through.

## Approach (revised per review)

Detection uses a **lightweight `updatedAt`-only probe** — it never pulls the full record on a background poll — and surfaces the **existing sync/refresh icon**; the full record is fetched only when the user clicks the icon.

**Requires CFS [PR #777](https://github.com/CourtHive/competition-factory-server/pull/777)** (the `POST /factory/updated-at` endpoint). Deploy CFS first.

- **`socketIo.ts`** — new `onSocketReconnect()` hook; fires listeners only on an actual reconnect (not first connect).
- **`servicesApi.ts`** — `requestTournamentUpdatedAt()` calling the cheap probe.
- **`stalenessGuard.ts`** — reconnect hook + periodic poll (visible-tab only, 45s default, `dev.stalenessPollInterval` override, `0` disables) call the probe; when the server is ahead, flag the sync icon stale. No full-record pull on the poll.
- **`remoteMutations.ts`** — the sync icon gains a "stale" mode (`markStaleNeedsRefresh`); clicking it pulls the fresh record on demand (`requestTournament` → `setState` → save → re-join room → refresh table). Normal (non-stale) clicks keep the existing table-refresh behavior.

## Scope notes

- The pre-existing **visibility/timer blocking overlay** (device-sleep safety, which still pulls the full record on its rare trigger) is **left unchanged**. Converting it to the probe + icon is a possible follow-up.
- **Testing:** TMX vitest is no-DOM (Playwright is the ecosystem DOM layer); this is DOM+timer+socket behavior, so the proper coverage is a Playwright E2E journey (disconnect → server mutation → reconnect → icon → click → fresh data). Verified here: check-types, lint, full unit suite (754) green.