### PR TITLE
refactor(staleness): unify on probe + refresh icon, drop blocking overlay

### DIFF
--- a/e2e/journeys/51-staleness-refresh-icon.spec.ts
+++ b/e2e/journeys/51-staleness-refresh-icon.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Journey 51 — Staleness refresh icon
+ *
+ * When the local copy falls behind the server (detected by the lightweight
+ * updated-at probe on reconnect / poll), TMX surfaces the navbar sync icon
+ * instead of pulling the whole record in the background. The icon is the only
+ * affordance that triggers a full-record fetch — and only on click.
+ *
+ * This journey drives the stale state deterministically via `dev.forceStaleness()`
+ * (equivalent to the probe deciding the server is ahead) and mocks the
+ * `/factory/fetch` endpoint so the click-to-refresh path runs without a live
+ * server. It verifies:
+ *   - the icon is hidden until stale, then shown,
+ *   - while stale, `isStale()` is true (mutations are blocked — see mutationRequest),
+ *   - clicking the icon pulls the full record (one /factory/fetch) and hides the icon,
+ *   - the background poll never pulls the full record (no /factory/fetch without a click).
+ */
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { PROFILE_DRAW_GENERATED, seedTournament } from '../helpers/seed';
+import { S } from '../helpers/selectors';
+
+test.describe('Journey 51 — staleness refresh icon', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('stale → icon shown, mutations blocked, click pulls fresh record', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_DRAW_GENERATED);
+
+    const icon = page.locator(S.SYNC_INDICATOR);
+    await expect(icon).toBeHidden();
+    expect(await page.evaluate(() => dev.isStale())).toBe(false);
+
+    // Count full-record fetches and serve a fresh record when one is requested.
+    let fetchCalls = 0;
+    await page.route('**/factory/fetch', async (route) => {
+      fetchCalls += 1;
+      const record = await page.evaluate(() => dev.getTournament());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tournamentRecords: { [tournamentId]: record } }),
+      });
+    });
+
+    // Enter the stale state (what the probe does when the server is ahead).
+    await page.evaluate(() => dev.forceStaleness());
+
+    // Icon is shown and the guard reports stale → mutationRequest will block.
+    await expect(icon).toBeVisible();
+    expect(await page.evaluate(() => dev.isStale())).toBe(true);
+
+    // Merely entering the stale state must NOT pull the full record.
+    expect(fetchCalls).toBe(0);
+
+    // Click the icon → exactly one full-record fetch, icon hidden, no longer stale.
+    await icon.click();
+    await expect(icon).toBeHidden();
+    await expect.poll(() => fetchCalls).toBe(1);
+    expect(await page.evaluate(() => dev.isStale())).toBe(false);
+  });
+
+  test('forceStaleness is idempotent and clears after refresh', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_DRAW_GENERATED);
+    const icon = page.locator(S.SYNC_INDICATOR);
+
+    await page.route('**/factory/fetch', async (route) => {
+      const record = await page.evaluate(() => dev.getTournament());
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tournamentRecords: { [tournamentId]: record } }),
+      });
+    });
+
+    // Two stale signals before any click — still one icon, still stale.
+    await page.evaluate(() => {
+      dev.forceStaleness();
+      dev.forceStaleness();
+    });
+    await expect(icon).toBeVisible();
+    expect(await page.evaluate(() => dev.isStale())).toBe(true);
+
+    // Refresh clears the stale state; a fresh signal can re-arm it.
+    await icon.click();
+    await expect(icon).toBeHidden();
+    expect(await page.evaluate(() => dev.isStale())).toBe(false);
+
+    await page.evaluate(() => dev.forceStaleness());
+    await expect(icon).toBeVisible();
+    expect(await page.evaluate(() => dev.isStale())).toBe(true);
+  });
+});

--- a/src/services/messaging/remoteMutations.ts
+++ b/src/services/messaging/remoteMutations.ts
@@ -54,6 +54,13 @@ export function markStaleNeedsRefresh(tournamentId: string): void {
   showSyncIndicator();
 }
 
+/** True when the local copy is known to be behind the server (icon in stale
+ * mode). Mutations are blocked while this is true so a director can't act on
+ * stale data — they must click the refresh icon first. */
+export function isSyncStale(): boolean {
+  return !!staleRefreshTournamentId;
+}
+
 /** Pull the latest tournament record from the server and apply it locally. Only
  * invoked on an explicit sync-icon click, so the full record is fetched on
  * demand — never on a background poll. */

--- a/src/services/setDev.ts
+++ b/src/services/setDev.ts
@@ -7,7 +7,7 @@ import { exportTournamentRecord } from 'components/modals/exportTournamentRecord
 import { teamProfileModal } from 'components/modals/teamProfileModal';
 import { connectSocket, disconnectSocket, emitTmx } from './messaging/socketIo';
 import { addOrUpdateTournament } from 'services/storage/addOrUpdateTournament';
-import { forceStalenessOverlay } from 'services/staleness/stalenessGuard';
+import { forceStaleness, isStale, triggerStalenessCheck } from 'services/staleness/stalenessGuard';
 import { loadTournament, renderTournament } from 'pages/tournament/tournamentDisplay';
 import { buildFromSources } from '../dev/cfsToTournamentRecord.mjs';
 import { baseApi, setBaseURL, getBaseURL } from './apis/baseApi';
@@ -148,7 +148,7 @@ export function setDev(): void {
     openTeamProfile: (participantId: string) => teamProfileModal({ participantId }),
   });
 
-  addDev({ completeMatchUps, forceStalenessOverlay });
+  addDev({ completeMatchUps, forceStaleness, isStale, triggerStalenessCheck });
   addDev({ providerConfig });
   addDev({
     openFormatWizard: () => {

--- a/src/services/staleness/stalenessGuard.ts
+++ b/src/services/staleness/stalenessGuard.ts
@@ -1,26 +1,25 @@
 /**
- * Staleness guard — detects when local tournament data may be out of sync
- * with the server after the device sleeps or the tab goes to background.
+ * Staleness guard — detects when local tournament data may be behind the server
+ * (device sleep, tab background, socket drop, or a silent broadcast gap) and
+ * surfaces the sync/refresh icon so the director can pull the fresh record on
+ * demand.
  *
- * Mechanism:
- * 1. An inactivity timer (default 5 min) resets on any mutation or navigation.
- * 2. When the page becomes visible again (Page Visibility API), if the timer
- *    has expired OR a socket disconnect was detected, a lightweight server
- *    check compares `updatedAt` timestamps.
- * 3. If the server is ahead, a blocking overlay forces the TD to refresh
- *    before any further mutations can be submitted.
+ * Detection is always a lightweight `updatedAt` probe — it never pulls the full
+ * record. Triggers:
+ *   1. An inactivity timer (default 5 min) that resets on any mutation/navigation.
+ *   2. Page becomes visible again, if the timer expired or a disconnect occurred.
+ *   3. Socket reconnect.
+ *   4. A periodic poll while the tab is visible.
+ * When the server is ahead, the sync icon is flagged stale; clicking it pulls
+ * the full record. While stale, `isStale()` is true and mutations are blocked
+ * (see mutationRequest) so a director can't act on stale data.
  */
-import { hadDisconnect, clearDisconnectFlag, joinTournamentRoom, onSocketReconnect } from 'services/messaging/socketIo';
-import { requestTournament, requestTournamentUpdatedAt } from 'services/apis/servicesApi';
-import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
-import { markStaleNeedsRefresh } from 'services/messaging/remoteMutations';
+import { markStaleNeedsRefresh, isSyncStale } from 'services/messaging/remoteMutations';
+import { hadDisconnect, clearDisconnectFlag, onSocketReconnect } from 'services/messaging/socketIo';
+import { requestTournamentUpdatedAt } from 'services/apis/servicesApi';
 import { getLoginState } from 'services/authentication/loginState';
 import { tournamentEngine } from 'services/factory/engine';
 import { debugConfig } from 'config/debugConfig';
-import { context } from 'services/context';
-
-// constants
-import { SYNC_INDICATOR } from 'constants/tmxConstants';
 
 const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
 
@@ -56,15 +55,15 @@ let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
 let countdownInterval: ReturnType<typeof setInterval> | undefined;
 let pollInterval: ReturnType<typeof setInterval> | undefined;
 let timerExpired = false;
-let overlayVisible = false;
 let checking = false;
 let initialized = false;
 
 // ── Public API ──
 
-/** Returns true when the stale-data overlay is showing — mutations must be blocked. */
+/** Returns true when the local copy is known to be behind the server — the sync
+ * icon is in stale mode and mutations must be blocked until the user refreshes. */
 export function isStale(): boolean {
-  return overlayVisible;
+  return isSyncStale();
 }
 
 /** Reset the inactivity timer. No-op in local-only mode (not logged in),
@@ -105,18 +104,16 @@ export function resetActivityTimer(): void {
       if (debug) console.log('[staleness] no longer logged in — skipping check');
       return;
     }
-    const { tournamentRecord } = tournamentEngine.getTournament();
-    if (tournamentRecord?.tournamentId) {
-      checkAndShowOverlay(tournamentRecord.tournamentId);
-    }
+    triggerStalenessCheck();
   }, timeoutMs);
 }
 
 /** Check now whether local data is behind the server. Uses the lightweight
  * `updatedAt` probe (never pulls the full record) and, if behind, surfaces the
- * existing refresh icon — clicking it pulls the fresh record on demand. Safe to
- * call any time; no-ops when logged out, with no tournament loaded, or when a
- * check is already in flight. Used by the reconnect hook and the periodic poll. */
+ * refresh icon — clicking it pulls the fresh record on demand. Safe to call any
+ * time; no-ops when logged out, with no tournament loaded, or when a check is
+ * already in flight. Used by the inactivity timer, visibility handler, reconnect
+ * hook, and periodic poll. */
 export function triggerStalenessCheck(): void {
   if (!getLoginState()) return;
   const { tournamentRecord } = tournamentEngine.getTournament();
@@ -126,7 +123,7 @@ export function triggerStalenessCheck(): void {
 /** Lightweight staleness probe — fetches only the server `updatedAt` and, when
  * the server is ahead, flags the sync indicator stale (no full-record pull). */
 async function probeStaleness(tournamentId: string): Promise<void> {
-  if (checking || overlayVisible) return;
+  if (checking || isSyncStale()) return;
   checking = true;
 
   const debug = isDebugMode();
@@ -185,7 +182,6 @@ export function destroyStalenessGuard(): void {
   if (countdownInterval) clearInterval(countdownInterval);
   if (pollInterval) clearInterval(pollInterval);
   document.removeEventListener('visibilitychange', onVisibilityChange);
-  dismissOverlay();
   initialized = false;
 }
 
@@ -209,160 +205,18 @@ function onVisibilityChange(): void {
     return;
   }
 
-  // Must be logged in and have a tournament loaded
-  if (!getLoginState()) {
-    if (debug) console.log('[staleness] not logged in — skipping check');
-    return;
-  }
-  const { tournamentRecord } = tournamentEngine.getTournament();
-  if (!tournamentRecord?.tournamentId) {
-    if (debug) console.log('[staleness] no tournament loaded — skipping check');
-    return;
-  }
-
-  if (debug) console.log('[staleness] checking server for:', tournamentRecord.tournamentId);
-  checkAndShowOverlay(tournamentRecord.tournamentId);
-}
-
-// ── Core check logic ──
-
-async function checkAndShowOverlay(tournamentId: string): Promise<void> {
-  if (checking || overlayVisible) return;
-  checking = true;
-
-  const debug = isDebugMode();
-
-  try {
-    // Background staleness check — must be silent. A "Missing tournamentRecord"
-    // server response here is normal (e.g. local-only tournaments) and
-    // shouldn't surface as a user-visible toast.
-    const result = await requestTournament({ tournamentId, silent: true });
-    const serverRecord = result?.data?.tournamentRecords?.[tournamentId];
-
-    if (!serverRecord) {
-      if (debug) console.log('[staleness] server returned no record — skipping');
-      return;
-    }
-
-    const localRecord = tournamentEngine.q.tournament();
-    const serverUpdated = serverRecord.updatedAt ? new Date(serverRecord.updatedAt).getTime() : 0;
-    const localUpdated = localRecord?.updatedAt ? new Date(localRecord.updatedAt).getTime() : 0;
-
-    if (debug)
-      console.log(
-        '[staleness] server=%s local=%s stale=%s',
-        serverRecord.updatedAt,
-        localRecord?.updatedAt,
-        serverUpdated > localUpdated,
-      );
-
-    if (serverUpdated > localUpdated) {
-      showOverlay(tournamentId, serverRecord);
-    } else {
-      if (debug) console.log('[staleness] data is current — no overlay needed');
-      if (hadDisconnect()) clearDisconnectFlag();
-    }
-  } catch (err) {
-    console.warn('[staleness] check failed:', err);
-  } finally {
-    checking = false;
-  }
+  if (debug) console.log('[staleness] page visible with staleness signal — probing');
+  triggerStalenessCheck();
 }
 
 /**
- * Force the staleness overlay for testing.
- * Call from console: dev.forceStalenessOverlay()
+ * Force the stale indicator for testing. Call from console: dev.forceStaleness()
  */
-export function forceStalenessOverlay(): void {
+export function forceStaleness(): void {
   const { tournamentRecord } = tournamentEngine.getTournament();
   if (!tournamentRecord?.tournamentId) {
     console.warn('[staleness] no tournament loaded');
     return;
   }
-  showOverlay(tournamentRecord.tournamentId, tournamentRecord);
-}
-
-// ── Overlay ──
-
-function showOverlay(tournamentId: string, serverRecord: any): void {
-  overlayVisible = true;
-
-  const overlay = document.createElement('div');
-  overlay.id = 'staleness-overlay';
-  overlay.style.cssText = [
-    'position: fixed',
-    'inset: 0',
-    'z-index: 99999',
-    'display: flex',
-    'flex-direction: column',
-    'align-items: center',
-    'justify-content: center',
-    'background: rgba(0, 0, 0, 0.6)',
-    'backdrop-filter: blur(2px)',
-  ].join('; ');
-
-  const card = document.createElement('div');
-  card.style.cssText = [
-    'background: var(--chc-bg-primary, #fff)',
-    'color: var(--chc-text-primary, #333)',
-    'border-radius: 12px',
-    'padding: 2rem 2.5rem',
-    'max-width: 400px',
-    'text-align: center',
-    'box-shadow: 0 8px 32px rgba(0,0,0,0.3)',
-  ].join('; ');
-
-  const icon = document.createElement('div');
-  icon.innerHTML =
-    '<i class="fa-solid fa-rotate" style="font-size: 2rem; color: var(--tmx-accent-blue, #3273dc);"></i>';
-  icon.style.marginBottom = '1rem';
-
-  const title = document.createElement('h3');
-  title.textContent = 'Tournament data has changed';
-  title.style.cssText = 'margin: 0 0 0.5rem; font-size: 1.1rem;';
-
-  const message = document.createElement('p');
-  message.textContent = 'Changes were made while this session was inactive. Please refresh to continue.';
-  message.style.cssText = 'margin: 0 0 1.5rem; font-size: 0.9rem; color: var(--chc-text-secondary, #666);';
-
-  const button = document.createElement('button');
-  button.className = 'button is-primary';
-  button.textContent = 'Refresh';
-  button.style.cssText = 'min-width: 140px;';
-  button.onclick = () => applyRefresh(tournamentId, serverRecord);
-
-  card.appendChild(icon);
-  card.appendChild(title);
-  card.appendChild(message);
-  card.appendChild(button);
-  overlay.appendChild(card);
-  document.body.appendChild(overlay);
-}
-
-function applyRefresh(tournamentId: string, serverRecord: any): void {
-  tournamentEngine.setState(serverRecord);
-  saveTournamentRecord();
-
-  // Re-join the tournament room in case the socket reconnected
-  joinTournamentRoom(tournamentId);
-  if (hadDisconnect()) clearDisconnectFlag();
-
-  // Refresh the active table if one exists
-  if (context.refreshActiveTable) {
-    context.refreshActiveTable();
-  } else {
-    const el = document.getElementById(SYNC_INDICATOR);
-    if (el) {
-      el.style.display = '';
-      el.classList.add('sync-indicator--active');
-    }
-  }
-
-  dismissOverlay();
-}
-
-function dismissOverlay(): void {
-  overlayVisible = false;
-  const el = document.getElementById('staleness-overlay');
-  if (el) el.remove();
+  markStaleNeedsRefresh(tournamentRecord.tournamentId);
 }


### PR DESCRIPTION
Follow-up to #1162 (which is merged). Addresses the two requested items: **convert the legacy visibility/timer blocking overlay** to the probe + icon, and add the **Playwright E2E** required before deploy.

## What changed

- **No trigger pulls the full record for detection anymore.** The inactivity timer + page-visibility path now use the same lightweight `updated-at` probe as reconnect/poll. The full tournament record is fetched **only when the user clicks the refresh icon** (on demand).
- **Blocking overlay removed** (`showOverlay`/`applyRefresh`/`checkAndShowOverlay`/`dismissOverlay`).
- **Safety preserved (per your choice):** `isStale()` now reflects the sync icon's stale mode (`remoteMutations.isSyncStale()`), so `mutationRequest` still **blocks mutations on stale data** with the existing 'refresh first' toast — the director must click the icon to refresh before changing anything. The notification is just the non-blocking icon instead of a full-screen overlay.
- `forceStaleness()` dev helper replaces `forceStalenessOverlay()`; `isStale`/`triggerStalenessCheck` exposed on `dev` for tests.

## When/how the record is pulled
Confirmed: background poll/reconnect/timer/visibility = **probe only** (timestamp). The full `/factory/fetch` happens **once, on the icon click**.

## E2E (required before deploy)
New **Playwright journey 51** — deterministic, server-independent (drives the stale state via `dev.forceStaleness()`, mocks `/factory/fetch` via `page.route`):
- icon hidden until stale, then shown;
- while stale, `isStale()` true (mutations blocked);
- entering the stale state pulls **zero** full records;
- clicking the icon triggers **exactly one** `/factory/fetch`, hides the icon, clears stale;
- idempotent + re-arm after refresh.

Both tests pass (`pnpm test:e2e --grep 'Journey 51'`). check-types, lint, unit suite (754) all green.

## Deploy ordering reminder
This rides on the probe endpoint — deploy **CFS first** (#777, merged), then TMX.