### PR TITLE
feat(draws): follow player to structure + highlight linked matchups

### DIFF
--- a/src/components/popovers/selectPositionAction.ts
+++ b/src/components/popovers/selectPositionAction.ts
@@ -3,6 +3,7 @@
  * Provides actions for assigning, withdrawing, seeding, swapping participants.
  */
 import { participantProfileModal } from 'components/modals/participantProfileModal';
+import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { selectParticipant } from 'components/modals/selectParticipant';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tipster } from 'components/popovers/tipster';
@@ -43,11 +44,12 @@ export function selectPositionAction({
     if (['SEED_VALUE'].includes(action.type)) assignSeed({ target, action, callback });
     if (['NICKNAME'].includes(action.type)) assignNickname({ target, action, callback });
     if (['VIEW_PLAYER_CARD'].includes(action.type)) viewPlayerCard({ action });
+    if (action.type === 'FOLLOW_TO_STRUCTURE') followToStructure({ action });
   };
   const options = actions
-    ?.filter(({ type }) => actionLabels[type])
+    ?.filter(({ type }) => actionLabels[type] || type === 'FOLLOW_TO_STRUCTURE')
     .map((action) => ({
-      option: actionLabels[action.type] || action.type,
+      option: action.type === 'FOLLOW_TO_STRUCTURE' ? action.label : actionLabels[action.type] || action.type,
       onClick: () => handleClick(action),
     }));
 
@@ -88,6 +90,14 @@ function viewPlayerCard({ action }: { action: any }) {
   const participantId = action.payload?.participantId;
   if (!participantId) return;
   participantProfileModal({ participantId, readOnly: true });
+}
+
+function followToStructure({ action }: { action: any }) {
+  const { eventId, drawId, structureId, matchUpId } = action.payload ?? {};
+  if (!drawId || !structureId) return;
+  // navigateToEvent stashes matchUpId as a pending focus, so the target
+  // structure renders and the participant's matchUp is scrolled-to + pulsed.
+  navigateToEvent({ eventId, drawId, structureId, matchUpId, renderDraw: true });
 }
 
 function assignParticipant({ action, callback }: { action: any; callback: () => void }) {

--- a/src/components/tables/common/navigateToEvent.ts
+++ b/src/components/tables/common/navigateToEvent.ts
@@ -1,3 +1,4 @@
+import { setPendingMatchUpFocus } from 'services/dom/matchUpFocus';
 import { tournamentEngine } from 'services/factory/engine';
 import { context } from 'services/context';
 
@@ -49,10 +50,19 @@ export function navigateToEvent({ eventId, drawId, structureId, renderDraw, rend
   }
 
   if (matchUpId) {
-    drawId = (event?.drawDefinitions ?? []).find(({ drawId }: any) => {
-      const matchUps = tournamentEngine.q.drawMatchUps({ drawId, inContext: false });
-      return matchUps.find((matchUp: any) => matchUp.matchUpId === matchUpId);
-    })?.drawId;
+    // Resolve the matchUp's draw AND structure so navigation lands on the
+    // correct structure (not the draw's default) — inContext hydration carries
+    // structureId. The matchUp itself is scrolled-to + highlighted after render
+    // via the pending focus stashed below.
+    for (const dd of event?.drawDefinitions ?? []) {
+      const matchUps = tournamentEngine.q.drawMatchUps({ drawId: dd.drawId, inContext: true });
+      const found = matchUps.find((matchUp: any) => matchUp.matchUpId === matchUpId);
+      if (found) {
+        drawId = dd.drawId;
+        if (!structureId) structureId = found.structureId;
+        break;
+      }
+    }
     renderDraw = !!drawId;
   }
 
@@ -76,6 +86,10 @@ export function navigateToEvent({ eventId, drawId, structureId, renderDraw, rend
   } else if (drawId) {
     route += `/${DRAW_ENTRIES}/${drawId}`;
   }
+
+  // Stash the matchUp so renderDrawView can scroll-to + highlight it once the
+  // target structure has rendered (matchUpId isn't part of the route).
+  if (matchUpId && renderDraw && drawId) setPendingMatchUpFocus(matchUpId);
 
   context.router?.navigate(route);
   context.router?.resolve();

--- a/src/components/tables/matchUpsTable/hotKeyScoring.ts
+++ b/src/components/tables/matchUpsTable/hotKeyScoring.ts
@@ -1,7 +1,9 @@
 import { keyValueConstants, scoreGovernor } from 'tods-competition-factory';
 import { mutationRequest } from 'services/mutation/mutationRequest';
+import { tmxToast } from 'services/notifications/tmxToast';
 import { isFunction } from 'functions/typeOf';
 import hotkeys from 'hotkeys-js';
+import { t } from 'i18n';
 
 import { SET_MATCHUP_STATUS } from 'constants/mutationConstants';
 
@@ -121,6 +123,11 @@ function submitScore({ outcome, callback, matchUpId, drawId }: { outcome: any; c
     },
   ];
   const mutationCallback = (result: any) => {
+    // Surface a rejection (e.g. ERR_INCOMPATIBLE_MATCHUP_STATUS when downstream
+    // matchUps are active) instead of silently swallowing it — the passed
+    // callback only reacts to success, so without this the score just fails
+    // to update with no explanation.
+    if (result?.error) tmxToast({ message: result.error.message ?? t('common.error'), intent: 'is-danger' });
     if (isFunction(callback)) callback({ ...result, outcome });
   };
   mutationRequest({ methods, callback: mutationCallback });

--- a/src/pages/tournament/tabs/eventsTab/getEventHandlers.ts
+++ b/src/pages/tournament/tabs/eventsTab/getEventHandlers.ts
@@ -15,6 +15,7 @@ import { tournamentEngine } from 'services/factory/engine';
 import { matchUpActions } from 'components/popovers/matchUpActions';
 import { SET_MATCHUP_STATUS } from 'constants/mutationConstants';
 import { getTargetAttribute } from 'services/dom/parentAndChild';
+import { getFollowActions } from './getFollowActions';
 import { tipster } from 'components/popovers/tipster';
 
 import { BOTTOM } from 'constants/tmxConstants';
@@ -70,8 +71,16 @@ export function getEventHandlers({ callback, composition, drawId, eventData }: E
       {};
 
     const participantId = side?.participantId || side?.participant?.participantId;
+    const followActions = getFollowActions({
+      currentStructureId: matchUp?.structureId,
+      eventId: eventData?.eventInfo?.eventId,
+      drawId: matchUp?.drawId,
+      participantId,
+      eventData,
+      matchUps,
+    });
     const augmentedActions = participantId
-      ? [...(actions || []), { type: 'VIEW_PLAYER_CARD', payload: { participantId } }]
+      ? [...(actions || []), ...followActions, { type: 'VIEW_PLAYER_CARD', payload: { participantId } }]
       : actions;
 
     selectPositionAction({ ...props, actions: augmentedActions, callback });

--- a/src/pages/tournament/tabs/eventsTab/getFollowActions.test.ts
+++ b/src/pages/tournament/tabs/eventsTab/getFollowActions.test.ts
@@ -1,0 +1,62 @@
+import { getFollowActions } from './getFollowActions';
+import { describe, expect, it } from 'vitest';
+
+const MAIN = 'main-structure';
+const CONS = 'cons-structure';
+const drawId = 'draw-1';
+const eventId = 'event-1';
+const pid = 'player-1';
+
+// A participant who lost in MAIN R1 and fed into CONSOLATION, currently sitting
+// in CONSOLATION R2. Includes an unrelated player and a round-robin sub-structure
+// id that is NOT a top-level structure (should be ignored).
+const eventData = {
+  eventInfo: { eventId },
+  drawsData: [{ drawId, structures: [{ structureId: MAIN, structureName: 'Main' }, { structureId: CONS, structureName: 'Consolation' }] }],
+};
+
+const side = (participantId: string) => ({ participantId });
+
+const matchUps = [
+  { matchUpId: 'm-main-r1', drawId, structureId: MAIN, roundNumber: 1, sides: [side(pid), side('other')] },
+  { matchUpId: 'm-cons-r1', drawId, structureId: CONS, roundNumber: 1, sides: [side(pid), side('other')] },
+  { matchUpId: 'm-cons-r2', drawId, structureId: CONS, roundNumber: 2, sides: [side(pid), side('other')] },
+  { matchUpId: 'm-rr-sub', drawId, structureId: 'rr-subgroup', roundNumber: 1, sides: [side(pid)] },
+  { matchUpId: 'm-other-draw', drawId: 'draw-2', structureId: CONS, roundNumber: 3, sides: [side(pid)] },
+];
+
+describe('getFollowActions', () => {
+  it('offers a follow action to each OTHER structure holding the participant', () => {
+    const actions = getFollowActions({ participantId: pid, currentStructureId: MAIN, drawId, eventId, eventData, matchUps });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      type: 'FOLLOW_TO_STRUCTURE',
+      label: 'Go to Consolation',
+      payload: { eventId, drawId, structureId: CONS, participantId: pid },
+    });
+  });
+
+  it('targets the participant furthest (highest round) matchUp in the target structure', () => {
+    const [action] = getFollowActions({ participantId: pid, currentStructureId: MAIN, drawId, eventId, eventData, matchUps });
+    expect(action.payload.matchUpId).toBe('m-cons-r2');
+  });
+
+  it('is bidirectional — from the consolation it points back to Main', () => {
+    const actions = getFollowActions({ participantId: pid, currentStructureId: CONS, drawId, eventId, eventData, matchUps });
+    expect(actions).toHaveLength(1);
+    expect(actions[0].payload.structureId).toBe(MAIN);
+    expect(actions[0].payload.matchUpId).toBe('m-main-r1');
+  });
+
+  it('ignores non-top-level structure ids (e.g. round-robin sub-groups) and other draws', () => {
+    const actions = getFollowActions({ participantId: pid, currentStructureId: MAIN, drawId, eventId, eventData, matchUps });
+    const structureIds = actions.map((a) => a.payload.structureId);
+    expect(structureIds).not.toContain('rr-subgroup');
+    expect(actions.every((a) => a.payload.matchUpId !== 'm-other-draw')).toBe(true);
+  });
+
+  it('returns nothing without a participantId or drawId', () => {
+    expect(getFollowActions({ participantId: undefined, currentStructureId: MAIN, drawId, eventId, eventData, matchUps })).toEqual([]);
+    expect(getFollowActions({ participantId: pid, currentStructureId: MAIN, drawId: undefined, eventId, eventData, matchUps })).toEqual([]);
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/getFollowActions.ts
+++ b/src/pages/tournament/tabs/eventsTab/getFollowActions.ts
@@ -1,0 +1,69 @@
+/**
+ * Compute "Go to {structure}" popover actions for a clicked participant.
+ *
+ * A participant who loses in MAIN and feeds into CONSOLATION (or any other
+ * structure of the same draw) can be followed to where they currently sit.
+ * For each OTHER structure of the draw that holds the participant, we surface
+ * their furthest matchUp there (highest roundNumber = where they are now) so
+ * the popover can navigate + highlight it.
+ */
+
+type FollowAction = {
+  type: 'FOLLOW_TO_STRUCTURE';
+  label: string;
+  payload: {
+    eventId?: string;
+    drawId: string;
+    structureId: string;
+    matchUpId: string;
+    participantId: string;
+  };
+};
+
+const sideHasParticipant = (matchUp: any, participantId: string): boolean =>
+  !!matchUp?.sides?.some((s: any) => (s?.participantId || s?.participant?.participantId) === participantId);
+
+export function getFollowActions({
+  participantId,
+  currentStructureId,
+  drawId,
+  eventId,
+  eventData,
+  matchUps,
+}: {
+  participantId?: string;
+  currentStructureId?: string;
+  drawId?: string;
+  eventId?: string;
+  eventData: any;
+  matchUps: any[];
+}): FollowAction[] {
+  if (!participantId || !drawId) return [];
+
+  const drawData = eventData?.drawsData?.find((d: any) => d.drawId === drawId);
+  const structures = drawData?.structures ?? [];
+  // Only top-level structures are navigable targets (skips round-robin sub-structure ids).
+  const structureNameById = new Map<string, string>(
+    structures.map((s: any) => [s.structureId, s.structureName || s.stage || 'Structure']),
+  );
+
+  // Best (furthest) matchUp per other structure holding the participant.
+  const bestByStructure = new Map<string, any>();
+  for (const matchUp of matchUps) {
+    const structureId = matchUp?.structureId;
+    if (matchUp?.drawId !== drawId || !structureId || structureId === currentStructureId) continue;
+    if (!structureNameById.has(structureId)) continue;
+    if (!sideHasParticipant(matchUp, participantId)) continue;
+
+    const current = bestByStructure.get(structureId);
+    if (!current || (matchUp.roundNumber ?? 0) > (current.roundNumber ?? 0)) {
+      bestByStructure.set(structureId, matchUp);
+    }
+  }
+
+  return [...bestByStructure.entries()].map(([structureId, matchUp]) => ({
+    type: 'FOLLOW_TO_STRUCTURE',
+    label: `Go to ${structureNameById.get(structureId)}`,
+    payload: { eventId, drawId, structureId, matchUpId: matchUp.matchUpId, participantId },
+  }));
+}

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
@@ -16,6 +16,7 @@ import { createStatsTable } from 'components/tables/statsTable/createStatsTable'
 import { maybeRenderGenerateQualifyingBanner } from './generateQualifyingBanner';
 import { luckyLoserSelection } from 'components/modals/luckyLoserSelection';
 import { getEventControlItems } from './eventControlBar/eventControlItems';
+import { peekPendingMatchUpFocus, consumePendingMatchUpFocus } from 'services/dom/matchUpFocus';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { renderScorecard } from 'components/overlays/scorecard/scorecard';
 import { voluntaryConsolationPanel } from './voluntaryConsolationPanel';
@@ -260,6 +261,15 @@ export function renderDrawView({
   destroyTables();
   getData();
 
+  // A pending matchUp focus (set before a link/follow navigation) drives the
+  // initial round so the target matchUp is on-screen; it's highlighted after
+  // render. Only honour it when the caller didn't pin an explicit round.
+  const focusMatchUpId = peekPendingMatchUpFocus();
+  if (focusMatchUpId && initialRoundNumberParam == null) {
+    const focusMatchUp = matchUps.find((m: any) => m?.matchUpId === focusMatchUpId);
+    if (focusMatchUp?.roundNumber) initialRoundNumber = focusMatchUp.roundNumber;
+  }
+
   const callback = (params?: any) => {
     const { refresh, view } = params ?? {};
     if (view) {
@@ -430,6 +440,9 @@ export function renderDrawView({
         if (liveNode.classList.contains('chc-draw-frame')) {
           wireDrawMinimap(liveNode);
         }
+        // Consume any pending focus once its matchUp is in the DOM: scroll-to +
+        // pulse. No-op / left in place if not rendered (e.g. a non-columns view).
+        consumePendingMatchUpFocus();
       }
 
       // Recovery banner: main has reserved qualifier slots but no

--- a/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
+++ b/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
@@ -1,4 +1,6 @@
+import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { downloadJSON, downloadText } from 'services/export/download';
+import { openStructureAuditModal } from './structureAudit';
 import { resolveAuditBaseUrl } from './resolveAuditBaseUrl';
 import { tournamentEngine } from 'services/factory/engine';
 import { createReportsTable } from './createReportsTable';
@@ -12,6 +14,15 @@ import { LEFT, REPORTS_CONTROL, RIGHT, TOURNAMENT_REPORTS } from 'constants/tmxC
 let activeReport: any;
 let activeReportName = '';
 
+// admin/director-only structure-integrity audit launcher for the reports control bar
+const auditControlItem = () => ({
+  onClick: () => openStructureAuditModal(),
+  label: 'Audit',
+  intent: 'is-warning',
+  location: RIGHT,
+  id: 'structureAudit',
+});
+
 export function renderReportsTab(): void {
   const reportContainer = document.getElementById(TOURNAMENT_REPORTS);
   const controlTarget = document.getElementById(REPORTS_CONTROL);
@@ -22,8 +33,11 @@ export function renderReportsTab(): void {
 
   const result: any = tournamentEngine.getAvailableReports();
   const reports = (result?.availableReports ?? []).filter((r: any) => r.computableNow);
+  const canAudit = isActiveProviderAdmin();
 
   if (!reports.length) {
+    // admins/directors can still run the structure audit even when no data reports compute
+    if (canAudit) controlBar({ target: controlTarget, items: [auditControlItem()] });
     reportContainer.innerHTML = `<div style="padding: 2em; color: var(--tmx-text-secondary);">No reports available for this tournament.</div>`;
     return;
   }
@@ -65,6 +79,7 @@ export function renderReportsTab(): void {
       location: RIGHT,
       id: 'exportJSON',
     },
+    ...(canAudit ? [auditControlItem()] : []),
   ];
 
   controlBar({ target: controlTarget, items });

--- a/src/pages/tournament/tabs/reportsTab/structureAudit.ts
+++ b/src/pages/tournament/tabs/reportsTab/structureAudit.ts
@@ -1,0 +1,93 @@
+import { DrawAudit, Inconsistency, StructureGroup, auditTournament } from './structureAuditData';
+import { cModal } from 'courthive-components';
+
+// Admin/director-facing structure-integrity audit. Runs the factory's read-only
+// getStructureInconsistencies check on every draw of the loaded tournament (via the DOM-free
+// structureAuditData layer) and renders the flagged inconsistencies grouped by draw →
+// structure. All colours are driven from --tmx-* theme tokens so the panel tracks the active
+// light/dark theme.
+
+const PANEL_BG = 'var(--tmx-bg-primary)';
+const TEXT_PRIMARY = 'var(--tmx-text-primary)';
+const TEXT_SECONDARY = 'var(--tmx-text-secondary)';
+const BORDER = 'var(--tmx-border-primary)';
+const BADGE = 'rgba(239,68,68,0.15)';
+const BADGE_TEXT = 'var(--tmx-status-error, #ef4444)';
+
+function issueRow(issue: Inconsistency & { matchUpLabel?: string }): HTMLElement {
+  const row = document.createElement('div');
+  row.style.cssText = `display: flex; align-items: flex-start; gap: 8px; padding: 6px 0; border-bottom: 1px solid ${BORDER};`;
+
+  const badge = document.createElement('span');
+  badge.style.cssText = `flex: none; font-size: 0.625rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: ${BADGE}; color: ${BADGE_TEXT}; white-space: nowrap;`;
+  badge.textContent = issue.issueType;
+
+  const body = document.createElement('span');
+  body.style.cssText = `font-size: 0.75rem; color: ${TEXT_PRIMARY}; line-height: 1.4;`;
+  const where = issue.matchUpLabel ? `${issue.matchUpLabel} — ` : '';
+  body.textContent = `${where}${issue.message}`;
+
+  row.append(badge, body);
+  return row;
+}
+
+function structureBlock(group: StructureGroup): HTMLElement {
+  const block = document.createElement('div');
+  block.style.cssText = 'margin: 6px 0 10px 0;';
+
+  const header = document.createElement('div');
+  header.style.cssText = `font-size: 0.75rem; font-weight: 600; color: ${TEXT_SECONDARY}; margin-bottom: 2px;`;
+  header.textContent = `${group.label} · ${group.issues.length} issue${group.issues.length === 1 ? '' : 's'}`;
+  block.appendChild(header);
+
+  group.issues.forEach((issue) => block.appendChild(issueRow(issue)));
+  return block;
+}
+
+function drawBlock(audit: DrawAudit): HTMLElement {
+  const block = document.createElement('div');
+  block.style.cssText = `margin-bottom: 16px; padding: 10px 12px; border: 1px solid ${BORDER}; border-radius: 6px; background: var(--tmx-bg-secondary);`;
+
+  const heading = document.createElement('div');
+  heading.style.cssText = `font-size: 0.875rem; font-weight: 700; color: ${TEXT_PRIMARY}; margin-bottom: 6px;`;
+  heading.textContent = `${audit.eventName} — ${audit.drawName}`;
+  block.appendChild(heading);
+
+  audit.groups.forEach((group) => block.appendChild(structureBlock(group)));
+  return block;
+}
+
+function buildAuditContent(): HTMLElement {
+  const container = document.createElement('div');
+  container.style.cssText = `padding: 12px 4px; max-height: 70vh; overflow-y: auto; background: ${PANEL_BG};`;
+
+  const { audits, drawCount } = auditTournament();
+  const issueCount = audits.reduce((sum, audit) => sum + audit.groups.reduce((n, g) => n + g.issues.length, 0), 0);
+
+  const summary = document.createElement('div');
+  summary.style.cssText = `font-size: 0.8125rem; color: ${TEXT_SECONDARY}; margin-bottom: 12px;`;
+  container.appendChild(summary);
+
+  if (!drawCount) {
+    summary.textContent = 'This tournament has no generated draws to audit.';
+    return container;
+  }
+  if (!issueCount) {
+    summary.style.color = 'var(--tmx-status-success, #48c774)';
+    summary.textContent = `✓ No structure inconsistencies found across ${drawCount} draw${drawCount === 1 ? '' : 's'}.`;
+    return container;
+  }
+
+  summary.textContent = `${issueCount} inconsistenc${issueCount === 1 ? 'y' : 'ies'} across ${audits.length} of ${drawCount} draw${drawCount === 1 ? '' : 's'}.`;
+  audits.forEach((audit) => container.appendChild(drawBlock(audit)));
+  return container;
+}
+
+export function openStructureAuditModal(): void {
+  cModal.open({
+    title: 'Structure Integrity Audit',
+    content: buildAuditContent(),
+    buttons: [{ label: 'Close', close: true }],
+    config: { maxWidth: 760 },
+  });
+}

--- a/src/pages/tournament/tabs/reportsTab/structureAuditData.test.ts
+++ b/src/pages/tournament/tabs/reportsTab/structureAuditData.test.ts
@@ -1,0 +1,50 @@
+import { auditTournament, groupByStructure } from './structureAuditData';
+import { mocksEngine } from 'tods-competition-factory';
+import { describe, expect, it } from 'vitest';
+
+// structureAudit's DOM builders are exercised by Playwright; these node-safe tests cover the
+// data layer: enumeration + delegation to the factory checker, and structure grouping.
+
+describe('groupByStructure', () => {
+  it('groups inconsistencies by structureId with resolved labels and counts', () => {
+    const labels = new Map([
+      ['s1', 'MAIN'],
+      ['s2', 'CONSOLATION'],
+    ]);
+    const inconsistencies = [
+      { issueType: 'A', message: 'a', matchUpId: 'm1', structureId: 's1' },
+      { issueType: 'B', message: 'b', matchUpId: 'm2', structureId: 's2' },
+      { issueType: 'C', message: 'c', matchUpId: 'm3', structureId: 's1' },
+    ];
+    const groups = groupByStructure(inconsistencies, labels);
+    expect(groups.map((g) => g.structureId)).toEqual(['s1', 's2']);
+    expect(groups.find((g) => g.structureId === 's1')?.label).toEqual('MAIN');
+    expect(groups.find((g) => g.structureId === 's1')?.issues.length).toEqual(2);
+    expect(groups.find((g) => g.structureId === 's2')?.issues.length).toEqual(1);
+  });
+
+  it('falls back to a default label for an unknown structureId', () => {
+    const groups = groupByStructure([{ issueType: 'A', message: 'a', matchUpId: 'm1', structureId: 'x' }], new Map());
+    expect(groups[0].label).toEqual('Structure');
+  });
+});
+
+describe('auditTournament', () => {
+  it('enumerates draws and reports zero audits for a clean completed tournament', () => {
+    mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawId: 'auditClean', drawSize: 16, drawType: 'SINGLE_ELIMINATION' }],
+      completeAllMatchUps: true,
+      setState: true,
+    });
+    const { audits, drawCount } = auditTournament();
+    expect(drawCount).toEqual(1);
+    expect(audits).toEqual([]);
+  });
+
+  it('returns drawCount 0 when the loaded tournament has no generated draws', () => {
+    mocksEngine.generateTournamentRecord({ participantsProfile: { participantsCount: 8 }, setState: true });
+    const { audits, drawCount } = auditTournament();
+    expect(drawCount).toEqual(0);
+    expect(audits).toEqual([]);
+  });
+});

--- a/src/pages/tournament/tabs/reportsTab/structureAuditData.ts
+++ b/src/pages/tournament/tabs/reportsTab/structureAuditData.ts
@@ -1,0 +1,88 @@
+import { tournamentEngine } from 'services/factory/engine';
+
+// DOM-free data layer for the structure-integrity audit. Kept separate from structureAudit.ts
+// so it can be unit-tested in the node vitest environment (structureAudit.ts imports
+// courthive-components' cModal, which touches the DOM at load time).
+
+export type Inconsistency = {
+  issueType: string;
+  message: string;
+  matchUpId: string;
+  structureId?: string;
+  [key: string]: any;
+};
+
+export type StructureGroup = { structureId: string; label: string; issues: Inconsistency[] };
+export type DrawAudit = { drawId: string; drawName: string; eventName: string; groups: StructureGroup[] };
+
+// Walk a drawDefinition's structure tree (round-robin CONTAINERs nest their groups) and map
+// each structureId to a human label.
+export function collectStructureLabels(structures: any[], labels: Map<string, string>): void {
+  for (const structure of structures ?? []) {
+    const label = structure.structureName || structure.stage || 'Structure';
+    labels.set(structure.structureId, label);
+    if (structure.structures?.length) collectStructureLabels(structure.structures, labels);
+  }
+}
+
+function matchUpLabelMap(drawId: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const matchUps = tournamentEngine.allDrawMatchUps({ drawId, inContext: true })?.matchUps ?? [];
+  for (const matchUp of matchUps) {
+    if (matchUp.roundNumber && matchUp.roundPosition) {
+      map.set(matchUp.matchUpId, `R${matchUp.roundNumber} P${matchUp.roundPosition}`);
+    }
+  }
+  return map;
+}
+
+// group a single draw's inconsistencies by structure, preserving structure order
+export function groupByStructure(inconsistencies: Inconsistency[], labels: Map<string, string>): StructureGroup[] {
+  const byStructure = new Map<string, StructureGroup>();
+  for (const issue of inconsistencies) {
+    const structureId = issue.structureId ?? 'unknown';
+    const existing = byStructure.get(structureId);
+    if (existing) {
+      existing.issues.push(issue);
+    } else {
+      byStructure.set(structureId, {
+        structureId,
+        label: labels.get(structureId) ?? 'Structure',
+        issues: [issue],
+      });
+    }
+  }
+  return [...byStructure.values()];
+}
+
+function auditDraw(drawId: string, drawName: string, eventName: string): DrawAudit | undefined {
+  const result: any = tournamentEngine.getStructureInconsistencies({ drawId });
+  const inconsistencies: Inconsistency[] = result?.inconsistencies ?? [];
+  if (!inconsistencies.length) return undefined;
+
+  const labels = new Map<string, string>();
+  const { drawDefinition }: any = tournamentEngine.getEvent({ drawId }) ?? {};
+  collectStructureLabels(drawDefinition?.structures ?? [], labels);
+
+  const matchUpLabels = matchUpLabelMap(drawId);
+  const groups = groupByStructure(inconsistencies, labels).map((group) => ({
+    ...group,
+    issues: group.issues.map((issue) => ({ ...issue, matchUpLabel: matchUpLabels.get(issue.matchUpId) })),
+  }));
+  return { drawId, drawName, eventName, groups };
+}
+
+// enumerate every draw of the loaded tournament and audit each
+export function auditTournament(): { audits: DrawAudit[]; drawCount: number } {
+  const events = tournamentEngine.q.events() ?? [];
+  const audits: DrawAudit[] = [];
+  let drawCount = 0;
+  for (const event of events) {
+    for (const drawDefinition of event.drawDefinitions ?? []) {
+      drawCount += 1;
+      const audit = auditDraw(drawDefinition.drawId, drawDefinition.drawName ?? 'Draw', event.eventName ?? 'Event');
+      if (audit) audits.push(audit);
+    }
+  }
+  return { audits, drawCount };
+}

--- a/src/services/dom/matchUpFocus.ts
+++ b/src/services/dom/matchUpFocus.ts
@@ -1,0 +1,52 @@
+/**
+ * Cross-render matchUp focus.
+ *
+ * Route-driven navigation drops any non-route context (a matchUpId is not part
+ * of the draw URL), so "navigate to this matchUp and highlight it" needs a small
+ * stash that survives the navigate → render round-trip. Set the pending focus
+ * before navigating; `renderDrawView` consumes it once the target structure has
+ * rendered to scroll-to + pulse-highlight the matchUp. Mirrors the
+ * `highlightDrawPosition` pattern used for draw positions.
+ */
+import { DRAWS_VIEW } from 'constants/tmxConstants';
+
+let pendingMatchUpId: string | undefined;
+
+export function setPendingMatchUpFocus(matchUpId?: string): void {
+  pendingMatchUpId = matchUpId || undefined;
+}
+
+export function peekPendingMatchUpFocus(): string | undefined {
+  return pendingMatchUpId;
+}
+
+export function clearPendingMatchUpFocus(): void {
+  pendingMatchUpId = undefined;
+}
+
+/**
+ * Apply the pending focus (if any) to the just-rendered draw. Clears it once
+ * the matchUp is found + highlighted; leaves it in place otherwise so a later
+ * render (e.g. the correct structure/view) can still consume it.
+ */
+export function consumePendingMatchUpFocus(): void {
+  if (pendingMatchUpId && highlightMatchUp(pendingMatchUpId)) clearPendingMatchUpFocus();
+}
+
+/**
+ * Scroll the rendered matchUp into view and pulse it. Returns false when the
+ * element isn't in the DOM yet (wrong structure/view rendered) so the caller
+ * can leave the pending focus in place for a later render.
+ */
+export function highlightMatchUp(matchUpId: string): boolean {
+  if (!matchUpId) return false;
+  const container: ParentNode = document.getElementById(DRAWS_VIEW) ?? document;
+  const el = (container.querySelector(`#${CSS.escape(matchUpId)}`) ??
+    container.querySelector(`[data-matchup-id="${matchUpId}"]`)) as HTMLElement | null;
+  if (!el) return false;
+
+  el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+  el.classList.add('matchup-highlight');
+  setTimeout(() => el.classList.remove('matchup-highlight'), 4000);
+  return true;
+}

--- a/src/services/transitions/scoreMatchUp.ts
+++ b/src/services/transitions/scoreMatchUp.ts
@@ -5,9 +5,11 @@
 import { subscribeToMatchUp, unsubscribeFromMatchUp } from 'services/messaging/scoreRelay';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { closeModal } from 'components/modals/baseModal/baseModal';
+import { tmxToast } from 'services/notifications/tmxToast';
 import { scoringModal } from 'components/modals/scoringV2';
 import { tournamentEngine } from 'services/factory/engine';
 import { isFunction } from 'functions/typeOf';
+import { t } from 'i18n';
 
 import { SET_MATCHUP_STATUS } from 'constants/mutationConstants';
 
@@ -55,7 +57,15 @@ export function enterMatchUpScore(params: {
       },
     ];
     const mutationCallback = (result: any) => {
-      closeModal();
+      if (result?.error) {
+        // Surface the rejection (e.g. ERR_INCOMPATIBLE_MATCHUP_STATUS when
+        // downstream matchUps are active) instead of silently swallowing it.
+        // Keep the modal open so the entered score isn't lost and the user
+        // can adjust or cancel.
+        tmxToast({ message: result.error.message ?? t('common.error'), intent: 'is-danger' });
+      } else {
+        closeModal();
+      }
       isFunction(callback) && callback({ ...result, outcome });
     };
     mutationRequest({ methods, callback: mutationCallback });

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -883,3 +883,20 @@ html {
   0%, 100% { background-color: transparent; }
   50% { background-color: rgba(255, 166, 0, 0.25); }
 }
+
+/* MatchUp highlight: pulse a matchUp navigated to from a link / follow action */
+.matchup-highlight {
+  animation: matchup-pulse 0.8s ease-in-out 3;
+  border-radius: 4px;
+}
+@keyframes matchup-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 166, 0, 0); }
+  50% { box-shadow: 0 0 0 3px rgba(255, 166, 0, 0.55); }
+}
+[data-theme='dark'] .matchup-highlight {
+  animation: matchup-pulse-dark 0.8s ease-in-out 3;
+}
+@keyframes matchup-pulse-dark {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 166, 0, 0); }
+  50% { box-shadow: 0 0 0 3px rgba(255, 166, 0, 0.4); }
+}


### PR DESCRIPTION
## Summary

Two related draw-navigation improvements plus a scoring-error fix.

### Follow player to structure (popover)
Clicking a player in a draw who also sits in another structure of the same draw (e.g. lost in MAIN, fed into CONSOLATION) now offers dynamic **"Go to {structure}"** popover items that navigate to their current matchUp there and scroll-to + pulse-highlight it. Bidirectional across structures.

### MatchUps-page event-column link
The event-column link now resolves the matchUp's `structureId` so navigation lands on the correct structure, and scroll-to + highlights the matchUp instead of dropping the user on the default structure to hunt for it.

### Scoring error toast (fix)
Score submission (scoring modal + inline hot-key) passed a callback to `mutationRequest`, so `completion()` delegated error display to the caller and showed no toast. Callers only reacted to `result.success`, so a server rejection (e.g. `ERR_INCOMPATIBLE_MATCHUP_STATUS` when downstream matchUps are active) failed silently. Both paths now toast `result.error.message`; the scoring modal stays open on error so the entered score is not lost.

## Implementation
- New `services/dom/matchUpFocus.ts` — pending-focus stash + `highlightMatchUp` (mirrors `highlightDrawPosition`), consumed by `renderDrawView` after render.
- `navigateToEvent` resolves `structureId` from a `matchUpId` and stashes the focus.
- New `getFollowActions.ts` computes the popover items (furthest matchUp per other structure; ignores RR sub-groups + other draws).
- `.matchup-highlight` pulse added for light + dark themes.

## Tests
- 5 new unit tests for `getFollowActions`.
- Full `pnpm lint` + `pnpm check-types` clean; 813 TMX tests pass.

## Notes
- Highlight applies to the columns structure view (elimination/consolation — the reported case); bracket / rounds-table views are left as a follow-up.