### PR TITLE
chore(deps): bump tods-competition-factory to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.0.0",
+    "tods-competition-factory": "6.0.2",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Bump tods-competition-factory to 6.0.2 (latest — bug fixes).