### PR TITLE
fix(participants): sort event chips by gender then event type

### DIFF
--- a/src/components/tables/common/formatters/eventsFormatter.ts
+++ b/src/components/tables/common/formatters/eventsFormatter.ts
@@ -1,7 +1,20 @@
-import { eventConstants } from 'tods-competition-factory';
+import { eventConstants, genderConstants } from 'tods-competition-factory';
 import { isFunction } from 'functions/typeOf';
 
-const { SINGLES } = eventConstants;
+const { SINGLES, DOUBLES, TEAM } = eventConstants;
+const { MIXED, ANY, OTHER } = genderConstants;
+
+// Single-gender (participant's own) events first, then mixed, then any/other/unknown.
+const genderRank = (gender?: string): number => {
+  const g = gender?.toUpperCase();
+  if (g === MIXED) return 1;
+  if (!g || g === ANY || g === OTHER) return 2;
+  return 0;
+};
+
+// Singles before Doubles before Team.
+const eventTypeOrder: Record<string, number> = { [SINGLES]: 0, [DOUBLES]: 1, [TEAM]: 2 };
+const eventTypeRank = (eventType?: string): number => eventTypeOrder[eventType ?? ''] ?? 3;
 
 export const eventsFormatter = (eventClick?: (params: any) => void) => (cell: any): HTMLDivElement => {
   const def = cell.getColumn().getDefinition();
@@ -11,7 +24,10 @@ export const eventsFormatter = (eventClick?: (params: any) => void) => (cell: an
   const events = cell.getValue();
   const rowData = cell.getRow().getData();
   const { participantId } = rowData;
-  const eventSorter = (a: any, b: any) => a?.eventName?.localeCompare(b?.eventName);
+  const eventSorter = (a: any, b: any) =>
+    genderRank(a?.gender) - genderRank(b?.gender) ||
+    eventTypeRank(a?.eventType) - eventTypeRank(b?.eventType) ||
+    (a?.eventName ?? '').localeCompare(b?.eventName ?? '', undefined, { numeric: true });
   events.sort(eventSorter).forEach((event: any) => {
     const pill = createPill({ def, participantId, event, eventClick });
     content.appendChild(pill);


### PR DESCRIPTION
Sorts the event chips in the participants table's events column by:

1. **Participant gender** — single-gender (Men's / Women's) first, then Mixed, then Any/Other/unknown
2. **Event type** — Singles → Doubles → Team
3. **Event name** — numeric-aware tiebreaker

Previously chips were sorted by event name alone, which put "Men's Doubles" before "Men's Singles". Now a participant's chips read Men's Singles → Men's Doubles → Mixed Doubles for a more consistent column.

Scope: `eventsFormatter` (intra-cell chip order) only; the column row-sorter is unchanged.