### PR TITLE
chore(deps): update courthive ecosystem packages to latest published

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "yargs": "18.0.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "^0.8.0",
-    "@courthive/scoring-visualizations": "^0.2.2",
+    "@courthive/provider-config": "^0.9.0",
+    "@courthive/scoring-visualizations": "^0.2.7",
     "@eslint/js": "^10.0.1",
     "@tiptap/core": "^3.22.2",
     "@tiptap/extension-color": "^3.22.2",
@@ -119,7 +119,7 @@
     "axios": "1.18.1",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.4.9",
+    "courthive-components": "3.5.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.4",
@@ -135,7 +135,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.8",
+    "pdf-factory": "0.8.9",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "qs": "6.15.3",


### PR DESCRIPTION
Bump TMX's CourtHive ecosystem pins to latest published: provider-config ^0.9.0, scoring-visualizations ^0.2.7, courthive-components 3.5.1, pdf-factory 0.8.9. Fixes the provider-config 0.x caret-pin trap (^0.8.0 excluded 0.9.0 on CI). Type-checks green.