### PR TITLE
feat(homenav): provider rankings icon linking to public viewer

### DIFF
--- a/src/components/framework/rootBlock.ts
+++ b/src/components/framework/rootBlock.ts
@@ -245,6 +245,7 @@ function newBlock(): HTMLDivElement {
 
       <i id='h-templates' class="home-nav-icon fa-solid fa-sitemap"></i>
       <i id='h-policies' class="home-nav-icon fa-solid fa-file-shield"></i>
+      <i id='h-rankings' class="home-nav-icon fa-solid fa-ranking-star" style="display: none;"></i>
       <span id='assistantIndicatorHome' style="display:none; position:relative; cursor:pointer; align-items:center;" title="Ask TMX">
         <i class="home-nav-icon fa-solid fa-robot"></i>
       </span>

--- a/src/constants/tmxConstants.ts
+++ b/src/constants/tmxConstants.ts
@@ -59,6 +59,7 @@ export const TMX_ADMIN = 'tmxAdmin';
 export const TEMPLATES = 'templates';
 export const POLICIES = 'policies';
 export const SETTINGS = 'settings';
+export const RANKINGS = 'rankings';
 export const DRAW_ENTRIES = 'drawEntries';
 export const TOURNAMENT = 'tournament';
 export const STRUCTURE = 'structure';

--- a/src/homeNavigation.ts
+++ b/src/homeNavigation.ts
@@ -3,7 +3,10 @@
  * Manages tab navigation and highlighting for non-tournament pages.
  * On mobile, renders a dropdown with translated page names instead of icons.
  */
+import { getProviderRankingsUrl, providerHasRankings } from 'services/rankings/providerRankings';
+import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { enhancedContentFunction } from 'services/dom/toolTip/plugins';
+import { getLoginState } from 'services/authentication/loginState';
 import { deviceConfig } from 'config/deviceConfig';
 import { context } from 'services/context';
 import tippy from 'tippy.js';
@@ -37,6 +40,82 @@ const homeI18nKeys: Record<string, string> = {
   'h-policies': 'pol',
   'h-settings': 'set',
 };
+
+// The rankings icon is NOT a homeRouteMap entry: it links out to the public
+// rankings viewer in a new tab rather than routing inside TMX. It is shown only
+// to provider admins (or super-admins impersonating) when the active provider
+// actually has published rankings.
+const RANKINGS_ICON = 'h-rankings';
+const RANKINGS_MOBILE_ITEM = 'mobile-nav-rankings';
+
+function activeProviderAbbr(): string | undefined {
+  const provider = context.provider ?? getLoginState()?.provider;
+  return provider?.organisationAbbreviation;
+}
+
+function sidebarTip(text: string): string {
+  const sideBar = document.querySelector('.side-bar');
+  return sideBar?.classList.contains('collapse') ? text : '';
+}
+
+function openRankings(abbreviation: string): void {
+  globalThis.open(getProviderRankingsUrl(abbreviation), '_blank', 'noopener');
+}
+
+function removeRankingsMobileItem(): void {
+  document.getElementById(RANKINGS_MOBILE_ITEM)?.remove();
+}
+
+function addRankingsMobileItem(abbreviation: string): void {
+  const menu = document.getElementById('mobileHomeNavMenu');
+  if (!menu || document.getElementById(RANKINGS_MOBILE_ITEM)) return;
+
+  const item = document.createElement('button');
+  item.id = RANKINGS_MOBILE_ITEM;
+  item.className = 'mobile-nav-item';
+  item.textContent = t('rnk');
+  item.onclick = () => {
+    menu.classList.remove(MENU_OPEN_CLASS);
+    document.getElementById('mobileHomeNavToggle')?.setAttribute(ARIA_EXPANDED, 'false');
+    openRankings(abbreviation);
+  };
+  menu.appendChild(item);
+}
+
+// Reveal the rankings icon (desktop + mobile) only when the active provider has
+// published rankings. Starts hidden every render and reveals asynchronously once
+// the existence probe resolves, so a provider switch never leaves a stale icon.
+function setupRankingsNav(): void {
+  const icon = document.getElementById(RANKINGS_ICON);
+  if (!icon) return;
+
+  icon.style.display = 'none';
+  removeRankingsMobileItem();
+
+  if (!isActiveProviderAdmin()) return;
+  const abbreviation = activeProviderAbbr();
+  if (!abbreviation) return;
+
+  providerHasRankings(abbreviation).then((exists) => {
+    if (!exists) return;
+    // Guard against a provider switch while the probe was in flight.
+    if (activeProviderAbbr()?.toUpperCase() !== abbreviation.toUpperCase()) return;
+
+    icon.style.display = '';
+    icon.onclick = () => openRankings(abbreviation);
+
+    if ((icon as any)._tippy) (icon as any)._tippy.destroy();
+    (tippy as any)(icon, {
+      dynContent: () => !deviceConfig.get().isMobile && sidebarTip(t('rnk')),
+      onShow: (options: any) => !!options.props.content,
+      plugins: [enhancedContentFunction],
+      placement: BOTTOM,
+      arrow: false,
+    });
+
+    addRankingsMobileItem(abbreviation);
+  });
+}
 
 function navigateHomeRoute(id: string): void {
   document.querySelectorAll('.home-nav-icon').forEach((i) => ((i as HTMLElement).style.color = ''));
@@ -134,6 +213,7 @@ export function homeNavigation(currentRoute?: string): void {
   });
 
   setupMobileHomeNav(currentRoute);
+  setupRankingsNav();
 }
 
 export function highlightHomeTab(route: string): void {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,6 +40,7 @@
   "cal": "Calendar",
   "tpl": "Templates",
   "pol": "Policies",
+  "rnk": "Rankings",
   "addcourts": "Add Courts",
   "login": "Login",
   "logout": "Logout",

--- a/src/services/rankings/providerRankings.test.ts
+++ b/src/services/rankings/providerRankings.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('platform', () => ({
+  platform: { getDefaultServerUrl: () => 'https://courthive.net' },
+}));
+
+import { getProviderRankingsUrl, providerHasRankings } from './providerRankings';
+
+const bundle = (abbreviation: string, withRankings = true) => ({
+  provider: { name: abbreviation, abbreviation },
+  rankings: withRankings ? { men: [], women: [] } : undefined,
+});
+
+function mockFetch(response: { ok: boolean; json?: () => any }) {
+  const fn = vi.fn().mockResolvedValue({
+    ok: response.ok,
+    json: response.json ?? (() => ({})),
+  });
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getProviderRankingsUrl', () => {
+  it('builds the public viewer URL with an upper-cased abbreviation', () => {
+    expect(getProviderRankingsUrl('boboca')).toBe('https://courthive.net/pub/#/rankings/BOBOCA');
+  });
+});
+
+describe('providerHasRankings', () => {
+  it('returns true when the bundle abbreviation matches and rankings are present', async () => {
+    mockFetch({ ok: true, json: () => bundle('BOBOCA') });
+    expect(await providerHasRankings('BOBOCA')).toBe(true);
+  });
+
+  it('returns false when the bundle is for a different provider', async () => {
+    mockFetch({ ok: true, json: () => bundle('BOBOCA') });
+    expect(await providerHasRankings('TYPTI')).toBe(false);
+  });
+
+  it('returns false when the matching bundle has no rankings', async () => {
+    mockFetch({ ok: true, json: () => bundle('NORANK', false) });
+    expect(await providerHasRankings('NORANK')).toBe(false);
+  });
+
+  it('returns false without an abbreviation and never calls the proxy', async () => {
+    const fn = mockFetch({ ok: true, json: () => bundle('ANY') });
+    expect(await providerHasRankings(undefined)).toBe(false);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the proxy request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('unreachable')),
+    );
+    expect(await providerHasRankings('DOWNP')).toBe(false);
+  });
+
+  it('memoizes the result per provider so the proxy is hit once', async () => {
+    const fn = mockFetch({ ok: true, json: () => bundle('CACHED') });
+    await providerHasRankings('CACHED');
+    await providerHasRankings('cached');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/rankings/providerRankings.ts
+++ b/src/services/rankings/providerRankings.ts
@@ -1,0 +1,55 @@
+/**
+ * Provider rankings helpers.
+ *
+ * Rankings are published by the separate `courthive-rankings` service and
+ * viewed in the `courthive-public` app at `<origin>/pub/#/rankings/<ABBR>`.
+ *
+ * Existence is probed through the CFS rankings proxy (`/api/rankings/bundle`),
+ * which today returns a single, non-provider-keyed bundle. We therefore treat
+ * rankings as "existing" for a provider only when that bundle's abbreviation
+ * matches the active provider AND it carries rankings — mirroring the liveness
+ * check the public per-provider page performs. This naturally scopes the icon
+ * to the one provider that currently has rankings and grows correctly once the
+ * backend adds provider-scoped filtering.
+ */
+import { platform } from 'platform';
+
+interface RankingsBundle {
+  provider?: { name?: string; abbreviation?: string };
+  rankings?: { men?: unknown; women?: unknown };
+}
+
+// Session-scoped memo keyed by provider abbreviation (upper-cased) so repeated
+// home-nav renders don't re-hit the proxy. Cleared on reload.
+const existenceCache = new Map<string, boolean>();
+
+function origin(): string {
+  return platform.getDefaultServerUrl().replace(/\/$/, '');
+}
+
+export function getProviderRankingsUrl(abbreviation: string): string {
+  return `${origin()}/pub/#/rankings/${encodeURIComponent(abbreviation.toUpperCase())}`;
+}
+
+export async function providerHasRankings(abbreviation?: string): Promise<boolean> {
+  if (!abbreviation) return false;
+  const key = abbreviation.toUpperCase();
+  const cached = existenceCache.get(key);
+  if (cached !== undefined) return cached;
+
+  let exists = false;
+  try {
+    const res = await fetch(`${origin()}/api/rankings/bundle`, { headers: { accept: 'application/json' } });
+    if (res.ok) {
+      const bundle = (await res.json()) as RankingsBundle;
+      const bundleAbbr = bundle?.provider?.abbreviation?.toUpperCase();
+      const hasRankings = !!(bundle?.rankings?.men && bundle?.rankings?.women);
+      exists = bundleAbbr === key && hasRankings;
+    }
+  } catch {
+    exists = false;
+  }
+
+  existenceCache.set(key, exists);
+  return exists;
+}


### PR DESCRIPTION
## What

Adds a **rankings icon** (`fa-ranking-star`) to the home navigation bar, between Policies and Settings.

- **Who sees it:** only provider admins — and super-admins while impersonating a provider (`isActiveProviderAdmin()`).
- **When it appears:** only when the active provider actually has published rankings. Existence is probed via the CFS rankings proxy (`GET /api/rankings/bundle`); the icon reveals only if the returned bundle's abbreviation matches the active provider and it carries rankings. Today that scopes the icon to the one provider with live rankings (BOBOCA; TYPTI once it ingests) and grows correctly once the backend adds provider-scoped filtering.
- **What it does:** opens the public rankings viewer at `<origin>/pub/#/rankings/<ABBR>` in a new tab. No in-TMX rankings page is built — it reuses the existing `courthive-public` viewer.

## Notes

- **No backend changes.** Both the viewer and the existence-check endpoint live on the same origin as the TMX server (`platform.getDefaultServerUrl()`), so no new env var is needed.
- Existence result is memoized per provider so repeated home-nav renders don't re-hit the proxy. The check only fires for provider admins, so regular users incur zero extra requests.
- Wired outside `homeRouteMap` (external link, not an internal route), so the mobile menu and highlight logic are unaffected; a matching mobile-menu item is added when the icon is shown.

## Tests

- New `providerRankings.test.ts` — 7 tests covering URL construction, abbreviation match/mismatch, empty rankings, missing abbreviation (no network call), fetch failure, and per-provider memoization.
- `pnpm check-types` and `pnpm lint` clean.