### PR TITLE
fix(overview): show 'None allocated' for undefined practice capacity

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1518,6 +1518,7 @@
     "allStructures": "All structures",
     "practiceCapacity": "Practice capacity",
     "practiceUnlimited": "Unlimited",
+    "practiceNoneAllocated": "None allocated",
     "practiceClosed": "Closed"
   },
 

--- a/src/pages/tournament/tabs/overviewTab/renderOverview.ts
+++ b/src/pages/tournament/tabs/overviewTab/renderOverview.ts
@@ -213,11 +213,12 @@ export function renderOverview(): void {
   // Practice default-capacity card — small admin affordance for the
   // tournament-wide PRACTICE booking capacity default. Doesn't reorganise
   // the grid; lives between categories and events as another clickable
-  // stat card. Value reads as "Unlimited" when null/absent, "Closed" for 0.
+  // stat card. Value reads as "None allocated" when null/absent (no default
+  // has been set), "Closed" for 0.
   const currentCapacity = resolveCurrentPracticeDefaultCapacity();
   const capacityValue =
     currentCapacity === null
-      ? t('dashboard.practiceUnlimited')
+      ? t('dashboard.practiceNoneAllocated')
       : currentCapacity === 0
         ? t('dashboard.practiceClosed')
         : String(currentCapacity);


### PR DESCRIPTION
## What

The practice-capacity stat card on the tournament overview showed **"Unlimited"** when no default capacity was set. That misrepresents an unconfigured tournament as having limitless practice booking. It now shows **"None allocated"** for the null/absent case.

Behavior unchanged for the other states:
- `0` → "Closed"
- explicit cap → the number

## Note

The edit modal (opened by clicking the card) still labels the clear-capacity option **"Unlimited"**, since there it genuinely means "remove the cap." I left that wording alone to avoid changing the editing UX semantics — happy to align it to "None / no cap" in a follow-up if you'd prefer consistency between the card and the modal.

`check-types` + `lint` clean; existing practice-capacity logic tests pass.