### PR TITLE
feat(rankings): gate rankings icon on the providers directory

### DIFF
--- a/src/services/rankings/providerRankings.test.ts
+++ b/src/services/rankings/providerRankings.test.ts
@@ -4,66 +4,71 @@ vi.mock('platform', () => ({
   platform: { getDefaultServerUrl: () => 'https://courthive.net' },
 }));
 
-import { getProviderRankingsUrl, providerHasRankings } from './providerRankings';
-
-const bundle = (abbreviation: string, withRankings = true) => ({
-  provider: { name: abbreviation, abbreviation },
-  rankings: withRankings ? { men: [], women: [] } : undefined,
-});
+// The module memoizes the provider list in a module-level promise, so each
+// test re-imports it fresh to isolate the cache.
+async function freshModule() {
+  vi.resetModules();
+  return import('./providerRankings');
+}
 
 function mockFetch(response: { ok: boolean; json?: () => any }) {
   const fn = vi.fn().mockResolvedValue({
     ok: response.ok,
-    json: response.json ?? (() => ({})),
+    json: response.json ?? (() => []),
   });
   vi.stubGlobal('fetch', fn);
   return fn;
 }
+
+const providers = [
+  { abbreviation: 'BOBOCA', name: 'Battle of Boca' },
+  { abbreviation: 'TYPTI', name: 'Tennis Europe' },
+];
 
 beforeEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe('getProviderRankingsUrl', () => {
-  it('builds the public viewer URL with an upper-cased abbreviation', () => {
+  it('builds the public viewer URL with an upper-cased abbreviation', async () => {
+    const { getProviderRankingsUrl } = await freshModule();
     expect(getProviderRankingsUrl('boboca')).toBe('https://courthive.net/pub/#/rankings/BOBOCA');
   });
 });
 
 describe('providerHasRankings', () => {
-  it('returns true when the bundle abbreviation matches and rankings are present', async () => {
-    mockFetch({ ok: true, json: () => bundle('BOBOCA') });
-    expect(await providerHasRankings('BOBOCA')).toBe(true);
+  it('returns true when the provider is in the directory (case-insensitive)', async () => {
+    mockFetch({ ok: true, json: () => providers });
+    const { providerHasRankings } = await freshModule();
+    expect(await providerHasRankings('boboca')).toBe(true);
+    expect(await providerHasRankings('TYPTI')).toBe(true);
   });
 
-  it('returns false when the bundle is for a different provider', async () => {
-    mockFetch({ ok: true, json: () => bundle('BOBOCA') });
-    expect(await providerHasRankings('TYPTI')).toBe(false);
-  });
-
-  it('returns false when the matching bundle has no rankings', async () => {
-    mockFetch({ ok: true, json: () => bundle('NORANK', false) });
-    expect(await providerHasRankings('NORANK')).toBe(false);
+  it('returns false when the provider is not in the directory', async () => {
+    mockFetch({ ok: true, json: () => providers });
+    const { providerHasRankings } = await freshModule();
+    expect(await providerHasRankings('NOPE')).toBe(false);
   });
 
   it('returns false without an abbreviation and never calls the proxy', async () => {
-    const fn = mockFetch({ ok: true, json: () => bundle('ANY') });
+    const fn = mockFetch({ ok: true, json: () => providers });
+    const { providerHasRankings } = await freshModule();
     expect(await providerHasRankings(undefined)).toBe(false);
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('returns false when the proxy request fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockRejectedValue(new Error('unreachable')),
-    );
-    expect(await providerHasRankings('DOWNP')).toBe(false);
+  it('returns false when the directory request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('unreachable')));
+    const { providerHasRankings } = await freshModule();
+    expect(await providerHasRankings('BOBOCA')).toBe(false);
   });
 
-  it('memoizes the result per provider so the proxy is hit once', async () => {
-    const fn = mockFetch({ ok: true, json: () => bundle('CACHED') });
-    await providerHasRankings('CACHED');
-    await providerHasRankings('cached');
+  it('fetches the directory once and reuses it across probes', async () => {
+    const fn = mockFetch({ ok: true, json: () => providers });
+    const { providerHasRankings } = await freshModule();
+    await providerHasRankings('BOBOCA');
+    await providerHasRankings('TYPTI');
+    await providerHasRankings('NOPE');
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/rankings/providerRankings.ts
+++ b/src/services/rankings/providerRankings.ts
@@ -4,24 +4,23 @@
  * Rankings are published by the separate `courthive-rankings` service and
  * viewed in the `courthive-public` app at `<origin>/pub/#/rankings/<ABBR>`.
  *
- * Existence is probed through the CFS rankings proxy (`/api/rankings/bundle`),
- * which today returns a single, non-provider-keyed bundle. We therefore treat
- * rankings as "existing" for a provider only when that bundle's abbreviation
- * matches the active provider AND it carries rankings — mirroring the liveness
- * check the public per-provider page performs. This naturally scopes the icon
- * to the one provider that currently has rankings and grows correctly once the
- * backend adds provider-scoped filtering.
+ * Existence is probed through the CFS rankings proxy's provider directory
+ * (`GET /api/rankings/providers` → `[{ abbreviation, name }]`): a provider
+ * "has rankings" when its abbreviation appears in that list. The whole list
+ * is fetched once and memoized, so probing any number of providers costs a
+ * single request per session.
  */
 import { platform } from 'platform';
 
-interface RankingsBundle {
-  provider?: { name?: string; abbreviation?: string };
-  rankings?: { men?: unknown; women?: unknown };
+interface RankingsProvider {
+  abbreviation?: string;
+  name?: string;
 }
 
-// Session-scoped memo keyed by provider abbreviation (upper-cased) so repeated
-// home-nav renders don't re-hit the proxy. Cleared on reload.
-const existenceCache = new Map<string, boolean>();
+// Session-scoped memo of the upper-cased abbreviations that have rankings.
+// Fetched once (a single in-flight promise coalesces concurrent probes) and
+// reused across home-nav renders; cleared on reload.
+let providerSetPromise: Promise<Set<string>> | undefined;
 
 function origin(): string {
   return platform.getDefaultServerUrl().replace(/\/$/, '');
@@ -31,25 +30,25 @@ export function getProviderRankingsUrl(abbreviation: string): string {
   return `${origin()}/pub/#/rankings/${encodeURIComponent(abbreviation.toUpperCase())}`;
 }
 
+function fetchProviderSet(): Promise<Set<string>> {
+  if (!providerSetPromise) {
+    providerSetPromise = (async () => {
+      try {
+        const res = await fetch(`${origin()}/api/rankings/providers`, { headers: { accept: 'application/json' } });
+        if (!res.ok) return new Set<string>();
+        const providers = (await res.json()) as RankingsProvider[];
+        if (!Array.isArray(providers)) return new Set<string>();
+        return new Set(providers.map((p) => p?.abbreviation?.toUpperCase()).filter((a): a is string => !!a));
+      } catch {
+        return new Set<string>();
+      }
+    })();
+  }
+  return providerSetPromise;
+}
+
 export async function providerHasRankings(abbreviation?: string): Promise<boolean> {
   if (!abbreviation) return false;
-  const key = abbreviation.toUpperCase();
-  const cached = existenceCache.get(key);
-  if (cached !== undefined) return cached;
-
-  let exists = false;
-  try {
-    const res = await fetch(`${origin()}/api/rankings/bundle`, { headers: { accept: 'application/json' } });
-    if (res.ok) {
-      const bundle = (await res.json()) as RankingsBundle;
-      const bundleAbbr = bundle?.provider?.abbreviation?.toUpperCase();
-      const hasRankings = !!(bundle?.rankings?.men && bundle?.rankings?.women);
-      exists = bundleAbbr === key && hasRankings;
-    }
-  } catch {
-    exists = false;
-  }
-
-  existenceCache.set(key, exists);
-  return exists;
+  const providers = await fetchProviderSet();
+  return providers.has(abbreviation.toUpperCase());
 }


### PR DESCRIPTION
## What

Now that the rankings service is provider-scoped (courthive-rankings #34), switch TMX's rankings-icon existence check from the single-bundle abbreviation match to the new **provider directory**:

- `providerHasRankings(abbr)` fetches `GET /api/rankings/providers` → `[{ abbreviation, name }]` and returns true when the active provider's abbreviation is in the list.
- The directory is fetched **once** and memoized via a shared in-flight promise, so probing any number of providers costs a single request per session (previously each distinct abbreviation hit `/bundle`).
- Correct for N providers — the old logic only worked while the backend served a single bundle.

No change to the icon wiring in `homeNavigation.ts` or the viewer URL; only the probe changed.

## Depends on
- courthive-rankings #34 (`/providers` endpoint). Until it deploys, `/providers` 404s → `providerHasRankings` returns false → the icon simply stays hidden (safe).

## Tests
- Updated `providerRankings.test.ts` (6 tests): directory membership (case-insensitive), absent abbreviation (no network call), fetch failure, and single-fetch memoization.
- `check-types` + `lint` clean.