### PR TITLE
feat(scheduling): resolve player conflicts from the schedule grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "yargs": "18.0.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "^0.9.0",
+    "@courthive/provider-config": "^0.10.0",
     "@courthive/scoring-visualizations": "^0.2.7",
     "@eslint/js": "^10.0.1",
     "@tiptap/core": "^3.22.2",

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -58,6 +58,7 @@ export const UPDATE_PRACTICE_REGISTRATION = 'updatePracticeRegistration';
 export const UPDATE_PARTICIPANT_RESULTS = 'updateParticipantResults';
 export const SET_PRACTICE_DEFAULT_CAPACITY = 'setPracticeDefaultCapacity';
 export const PRO_AUTO_SCHEDULE = 'proAutoSchedule';
+export const PRO_COLUMN_RESOLVE = 'proColumnResolve';
 export const PUBLISH_EVENT = 'publishEvent';
 export const REMOVE_INDIVIDUAL_PARTICIPANT_IDS = 'removeIndividualParticipantIds';
 export const REMOVE_ONLINE_RESOURCE = 'removeOnlineResource';

--- a/src/pages/tournament/tabs/scheduleViews/gridHeaderActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridHeaderActions.ts
@@ -42,6 +42,8 @@ export interface GridHeaderActionsParams {
   onSearch: (text: string) => void;
   /** Open the "shift courts down" picker (make room above already-placed matches). */
   onShiftCourts?: () => void;
+  /** Resolve player conflicts by spacing matches down (courts & times unchanged). */
+  onResolveConflicts?: () => void;
 }
 
 export interface GridHeaderActions {
@@ -69,6 +71,7 @@ export function buildGridHeaderActions(params: GridHeaderActionsParams): GridHea
     onMinRowsChange,
     onSearch,
     onShiftCourts,
+    onResolveConflicts,
   } = params;
 
   const catalogBtn = buildToggleIconButton({
@@ -127,10 +130,25 @@ export function buildGridHeaderActions(params: GridHeaderActionsParams): GridHea
   shiftBtn.disabled = !onShiftCourts;
   shiftBtn.addEventListener('click', () => onShiftCourts?.());
 
+  const resolveBtn = document.createElement('button');
+  resolveBtn.style.cssText =
+    TOGGLE_BTN_BASE_STYLE +
+    `; background: ${TOGGLE_BG_UNPRESSED}` +
+    (bulkMode ? '; opacity: 0.45; cursor: not-allowed' : '; color: var(--tmx-accent-blue, #3b82f6)');
+  resolveBtn.innerHTML = '<i class="fa-solid fa-arrows-down-to-line" style="font-size: 0.75rem;"></i>';
+  resolveBtn.title = bulkMode
+    ? 'Exit bulk mode to resolve conflicts'
+    : 'Resolve player conflicts (space matches down; courts & times unchanged)';
+  resolveBtn.disabled = bulkMode || !onResolveConflicts;
+  resolveBtn.addEventListener('click', () => {
+    if (bulkMode) return;
+    onResolveConflicts?.();
+  });
+
   return {
     leading: [catalogBtn],
     titleSlot: buildSearchSlot(onSearch),
-    trailing: [stripBtn, startOnDropBtn, rowsStepper, shiftBtn, printBtn],
+    trailing: [stripBtn, startOnDropBtn, rowsStepper, shiftBtn, resolveBtn, printBtn],
   };
 }
 

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -97,6 +97,7 @@ import {
   ADD_MATCHUP_SCHEDULE_ITEMS,
   BULK_SCHEDULE_MATCHUPS,
   SET_MATCHUP_CALLED_AT,
+  PRO_COLUMN_RESOLVE,
   SET_MATCHUP_STATUS,
 } from 'constants/mutationConstants';
 import { COMPETITION_ENGINE, MINIMUM_SCHEDULE_COLUMNS, REPORTS_TAB, TOURNAMENT } from 'constants/tmxConstants';
@@ -2369,6 +2370,57 @@ export function shiftCourtsDown(): void {
       });
     });
     if (methods.length && currentRefresh) executeMethods(methods, currentRefresh);
+  });
+}
+
+/**
+ * Resolve player conflicts on the selected day by invoking the factory
+ * `proColumnResolve` mutation: it re-lays the grid vertically (courtOrder +
+ * inserted blank rows) so conflicting matchUps land on different rows, WITHOUT
+ * changing any match's court or scheduledTime. Confirm-first; whole grid.
+ *
+ * We count the currently-flagged participant / potential-participant conflicts
+ * client-side (same `proConflicts` the header/row indicators use) to decide
+ * whether there is anything to do. After the mutation, the grid refresh re-runs
+ * those indicators, so any conflict the resolver could NOT fix (e.g. a feeder
+ * scheduled at a later time than the match it feeds) stays visibly highlighted.
+ */
+export function resolveColumnConflicts(): void {
+  if (!currentRefresh || !currentDate) return;
+
+  const { matchUps } = getCachedAllMatchUps() || {};
+  const scheduledMatchUps = (matchUps || []).filter(
+    (m: any) => m.schedule?.courtId && m.schedule?.scheduledDate === currentDate,
+  );
+  if (!scheduledMatchUps.length) {
+    scheduleToast({ message: 'No scheduled matches to resolve on this day', intent: INTENT_WARNING });
+    return;
+  }
+
+  const conflictResult = unwrapOr(competitionEngine.proConflicts({ matchUps: scheduledMatchUps }), null);
+  const { CONFLICT_PARTICIPANTS, CONFLICT_POTENTIAL_PARTICIPANTS, SCHEDULE_CONFLICT } = scheduleConstants;
+  const participantConflicts = Object.values(conflictResult?.rowIssues || {})
+    .flat()
+    .filter(
+      (issue: any) =>
+        issue?.issue === SCHEDULE_CONFLICT &&
+        (issue.issueType === CONFLICT_PARTICIPANTS || issue.issueType === CONFLICT_POTENTIAL_PARTICIPANTS),
+    );
+  if (!participantConflicts.length) {
+    scheduleToast({ message: 'No player conflicts to resolve on this day', intent: 'is-success' });
+    return;
+  }
+
+  confirmModal({
+    title: 'Resolve player conflicts?',
+    query:
+      `Space matches down to clear player conflicts on ${currentDate}. ` +
+      'Courts and start times stay the same — only the row order changes. Continue?',
+    okIntent: 'is-warning',
+    okAction: () => {
+      const methods = [{ method: PRO_COLUMN_RESOLVE, params: { scheduledDate: currentDate, matchUps: scheduledMatchUps } }];
+      if (currentRefresh) executeMethods(methods, currentRefresh);
+    },
   });
 }
 

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -40,6 +40,7 @@ import {
   refreshGridView,
   setGridActiveStripVisible,
   shiftCourtsDown,
+  resolveColumnConflicts,
   DEFAULT_MIN_COURT_GRID_ROWS,
 } from '../scheduleViews/gridView';
 import {
@@ -260,6 +261,7 @@ function renderGridMode(container: HTMLElement, scheduledDate: string, params: R
     },
     onSearch: (text: string) => searchGridCells(text),
     onShiftCourts: shiftCourtsDown,
+    onResolveConflicts: resolveColumnConflicts,
   });
 
   renderGridView(container, scheduledDate, {


### PR DESCRIPTION
## What

Adds a **resolve-player-conflicts** action to the scheduling grid. A new toolbar icon (`fa-arrows-down-to-line`, next to the shift-courts button) invokes the factory `proColumnResolve` mutation, which re-lays the grid **vertically** — reassigning `courtOrder` and inserting blank rows — so conflicting matchUps land on different rows **without changing any match's court or scheduledTime**.

Whole-grid, **confirm-first**:

- On click, if there are no participant / potential-participant conflicts on the selected day → info toast, no-op.
- Otherwise a confirm dialog, then the mutation fires. The grid refresh re-runs `proConflicts`, so anything physically unresolvable (a feeder scheduled after the match it feeds) stays visibly flagged.

## Commits

- `feat` — resolve action: `PRO_COLUMN_RESOLVE` in `mutationConstants`, the toolbar button in `gridHeaderActions`, the `resolveColumnConflicts` handler in `gridView` (co-located beside `shiftCourtsDown`), and a 2-line wire in `schedulingTab`.
- `chore(deps)` — bump `@courthive/provider-config` `^0.9.0 → ^0.10.0` (picks up the `proColumnResolve → canModifySchedule` gate on the client).

## Coordination

Built in an isolated git worktree/branch to avoid colliding with the concurrent `tmx-schedule2-followups` session (which has uncommitted WIP in the shared tree). The only overlap is **two lines in `schedulingTab.ts`** (an import + one callback next to `onShiftCourts`) — a trivial merge.

## Rollout dependency (does not block this PR / CI)

This PR compiles and tests independently — the mutation is dispatched by string name, so there is **no compile-time dependency** on the factory method's signature. The feature only **functions end-to-end** once the runtime chain lands:

1. Publish factory `6.3.0` (release-please PR #4476) — contains `proColumnResolve`.
2. Bump `tods-competition-factory` `6.2.0 → 6.3.0` (exact pins) in server + TMX.
3. Deploy competition-factory-server.

## Verification

`pnpm check-types`, `pnpm lint`, `pnpm build`, and the full `pnpm test --run` (846 tests) all green. Factory-side correctness of `proColumnResolve` is locked by its own tests; a Playwright e2e for this UI is a follow-up (to coordinate with the e2e workstream).

Plan: `Mentat/planning/TMX_PRO_COLUMN_RESOLVE_UI.md`.