### PR TITLE
test(e2e): re-enable scheduling journeys + nonRandom everywhere

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -9,6 +9,13 @@ import type { Page } from '@playwright/test';
  * for the 11 pre-built profiles.
  */
 export interface MockProfile {
+  /**
+   * Deterministic-fixture seed. `seedTournament` defaults this to `1` so every
+   * journey gets identical mock data across runs (the ecosystem rule — see the
+   * e2e determinism note in Mentat coding-standards). Override only when a spec
+   * genuinely needs randomised layout.
+   */
+  nonRandom?: number;
   tournamentName?: string;
   tournamentAttributes?: { tournamentId?: string; [key: string]: unknown };
   participantsProfile?: { scaledParticipantsCount?: number; [key: string]: unknown };
@@ -44,6 +51,7 @@ export interface MockProfile {
 export async function seedTournament(page: Page, profile: MockProfile): Promise<string> {
   return page.evaluate(async (p: MockProfile) => {
     const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
       setState: true,
       ...p,
     });
@@ -203,6 +211,7 @@ export async function seedTeamTournamentWithStaff(
         await dev.tmx2db.initDB();
 
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E Team Profile',
           tournamentAttributes: { tournamentId: 'e2e-team-profile' },

--- a/e2e/journeys/29-schedule2-active-strip.spec.ts
+++ b/e2e/journeys/29-schedule2-active-strip.spec.ts
@@ -75,6 +75,7 @@ async function seedAndScheduleFirstMatchUp(
       await dev.tmx2db.initDB();
 
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
         setState: true,
         tournamentName: 'E2E Active Strip',
         tournamentAttributes: { tournamentId: 'e2e-active-strip', startDate: date, endDate: date },

--- a/e2e/journeys/38-schedule2-scheduled-panel.spec.ts
+++ b/e2e/journeys/38-schedule2-scheduled-panel.spec.ts
@@ -63,6 +63,7 @@ async function seedScheduledMatchUps(
         await dev.tmx2db.initDB();
 
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E Scheduled Panel',
           tournamentAttributes: {

--- a/e2e/journeys/39-schedule2-round-emphasis.spec.ts
+++ b/e2e/journeys/39-schedule2-round-emphasis.spec.ts
@@ -50,6 +50,7 @@ async function seedUnscheduledEvent(page: import('@playwright/test').Page): Prom
       await dev.tmx2db.initDB();
 
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
         setState: true,
         tournamentName: 'E2E Round Emphasis',
         tournamentAttributes: { tournamentId: 'e2e-round-emphasis', startDate: date, endDate: date },

--- a/e2e/journeys/47-schedule2-completed-orphans.spec.ts
+++ b/e2e/journeys/47-schedule2-completed-orphans.spec.ts
@@ -65,6 +65,7 @@ async function seedOrphansWithCompletedMix(
         await dev.tmx2db.initDB();
 
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E Completed Orphans',
           tournamentAttributes: {
@@ -138,6 +139,7 @@ async function seedNoOrphans(page: import('@playwright/test').Page): Promise<{ t
       try {
         await dev.tmx2db.initDB();
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E No Orphans',
           tournamentAttributes: {
@@ -175,6 +177,7 @@ async function seedByeOnDate(page: import('@playwright/test').Page): Promise<{ t
       try {
         await dev.tmx2db.initDB();
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E BYE Date Count',
           tournamentAttributes: {

--- a/e2e/journeys/48-schedule2-score-entry-refresh.spec.ts
+++ b/e2e/journeys/48-schedule2-score-entry-refresh.spec.ts
@@ -45,6 +45,7 @@ async function seedCourtScheduledMatchUp(page: import('@playwright/test').Page):
         await dev.tmx2db.initDB();
 
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E Score Entry Refresh',
           tournamentAttributes: {

--- a/e2e/journeys/49-schedule2-grid-swap.spec.ts
+++ b/e2e/journeys/49-schedule2-grid-swap.spec.ts
@@ -64,8 +64,8 @@ async function seedScheduled(
     async ({ date, assigns }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: 'E2E Grid Swap',
         tournamentAttributes: { tournamentId: 'e2e-grid-swap', startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },

--- a/e2e/journeys/50-schedule2-court-time-order.spec.ts
+++ b/e2e/journeys/50-schedule2-court-time-order.spec.ts
@@ -54,8 +54,8 @@ async function seedOneCourt(
     async ({ date, times }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: 'E2E Time Order',
         tournamentAttributes: { tournamentId: 'e2e-time-order', startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },

--- a/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
+++ b/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
@@ -64,6 +64,7 @@ async function seedOnePlacement(
     async ({ date, scheduledTime }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
         setState: true,
         tournamentName: 'E2E Strip Preserve',
         tournamentAttributes: { tournamentId: 'e2e-strip-preserve', startDate: date, endDate: date },

--- a/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
+++ b/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
@@ -26,6 +26,7 @@ async function seedScheduledMatchUp(page: Page): Promise<{ tournamentId: string;
   return page.evaluate(async (date) => {
     await dev.tmx2db.initDB();
     const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
       setState: true,
       tournamentName: 'E2E View Draw Focus',
       tournamentAttributes: { tournamentId: 'e2e-view-draw-focus', startDate: date, endDate: date },

--- a/e2e/journeys/57-matchups-calledat-column.spec.ts
+++ b/e2e/journeys/57-matchups-calledat-column.spec.ts
@@ -26,6 +26,7 @@ async function seedWithCalledAt(page: Page): Promise<{ tournamentId: string; mat
   return page.evaluate(async () => {
     await dev.tmx2db.initDB();
     const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
       setState: true,
       tournamentName: 'E2E CalledAt Column',
       tournamentAttributes: { tournamentId: 'e2e-calledat-column' },

--- a/e2e/journeys/59-schedule2-date-badge-recompute.spec.ts
+++ b/e2e/journeys/59-schedule2-date-badge-recompute.spec.ts
@@ -46,6 +46,7 @@ async function seedOneScheduledOneCatalog(page: import('@playwright/test').Page)
         await dev.tmx2db.initDB();
 
         const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
           setState: true,
           tournamentName: 'E2E Date Badge Recompute',
           tournamentAttributes: {

--- a/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
+++ b/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
@@ -55,8 +55,8 @@ async function seed(page: Page): Promise<Seed> {
     async ({ date }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: 'E2E Bulk Save Discard',
         tournamentAttributes: { tournamentId: 'e2e-bulk-save-discard', startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },
@@ -105,9 +105,7 @@ async function openGridInBulkMode(page: Page, tournamentId: string): Promise<voi
   await page.locator(BULK_TOGGLE).check();
 }
 
-// SKIPPED pending Problem B: seeded schedule renders as "Scheduled 0" (see
-// Mentat/planning/E2E_SCHEDULING_SEED_DISPLAY_BUG.md). nonRandom + logic are ready; re-enable once B is fixed.
-test.describe.skip('Journey 60 — scheduling grid bulk save / discard', () => {
+test.describe('Journey 60 — scheduling grid bulk save / discard', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
+++ b/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
@@ -23,8 +23,8 @@ async function seedOnePlaced(page: Page, scheduledTime?: string): Promise<{ tour
     async ({ date, scheduledTime }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: 'E2E Auto Call',
         tournamentAttributes: { tournamentId: 'e2e-auto-call', startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },
@@ -59,9 +59,7 @@ async function seedOnePlaced(page: Page, scheduledTime?: string): Promise<{ tour
   );
 }
 
-// SKIPPED pending Problem B: seeded schedule renders as "Scheduled 0" (see
-// Mentat/planning/E2E_SCHEDULING_SEED_DISPLAY_BUG.md). nonRandom + logic are ready; re-enable once B is fixed.
-test.describe.skip('Journey 61 — now-strip auto-call due-gating', () => {
+test.describe('Journey 61 — now-strip auto-call due-gating', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
+++ b/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
@@ -29,8 +29,8 @@ async function seed(page: Page): Promise<Seed> {
     async ({ date }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: 'E2E Clear Day',
         tournamentAttributes: { tournamentId: 'e2e-clear-day', startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },
@@ -84,9 +84,7 @@ async function scheduledDateOf(page: Page, matchUpId: string): Promise<string | 
   }, matchUpId);
 }
 
-// SKIPPED pending Problem B: seeded schedule renders as "Scheduled 0" (see
-// Mentat/planning/E2E_SCHEDULING_SEED_DISPLAY_BUG.md). nonRandom + logic are ready; re-enable once B is fixed.
-test.describe.skip('Journey 63 — clear this day (keep completed)', () => {
+test.describe('Journey 63 — clear this day (keep completed)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
+++ b/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
@@ -28,8 +28,8 @@ async function seedScheduled(page: Page, tournamentId: string, scheduledCount: n
     async ({ date, tournamentId, scheduledCount }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
-        setState: true,
         nonRandom: 1,
+        setState: true,
         tournamentName: `E2E Cache ${tournamentId}`,
         tournamentAttributes: { tournamentId, startDate: date, endDate: date },
         participantsProfile: { scaledParticipantsCount: 16 },
@@ -67,9 +67,7 @@ async function seedScheduled(page: Page, tournamentId: string, scheduledCount: n
   );
 }
 
-// SKIPPED pending Problem B: seeded schedule renders as "Scheduled 0" (see
-// Mentat/planning/E2E_SCHEDULING_SEED_DISPLAY_BUG.md). nonRandom + logic are ready; re-enable once B is fixed.
-test.describe.skip('Journey 64 — scheduling cross-tournament cache invalidation', () => {
+test.describe('Journey 64 — scheduling cross-tournament cache invalidation', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/journeys/72-registrations-nav-visibility.spec.ts
+++ b/e2e/journeys/72-registrations-nav-visibility.spec.ts
@@ -24,6 +24,7 @@ async function seedTournamentWithReg(page: Page, withRegistration: boolean): Pro
   return page.evaluate(async (withReg) => {
     await dev.tmx2db.initDB();
     const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
       setState: true,
       tournamentName: 'E2E Registrations',
       tournamentAttributes: { tournamentId: `e2e-reg-${withReg ? 'open' : 'none'}` },


### PR DESCRIPTION
## Problem B — "Scheduled 0" resolved (no code fix needed)

The seeded+scheduled tournament rendering `Scheduled 0` (Mentat/planning/E2E_SCHEDULING_SEED_DISPLAY_BUG.md) was **not** a TMX bug and **not** a NATIVE-writeMode persistence break. Direct node testing against factory 6.3.0 shows the full chain is healthy: `addMatchUpScheduleItems` writes schedule first-class on `matchUp.schedule`, it survives `JSON.stringify`+`setState`, and `allTournamentMatchUps` reads it back matching the date-badge key. The original symptom was a stale/mid-flip linked-factory `dist` that wrote NATIVE but still read LEGACY `timeItems`.

- Un-skips journeys **60/61/63/64** and removes the skip-pointer comments
- **18/18** deterministic (`--repeat-each=3 --retries=0`), **6/6** with a cold `node_modules/.vite`

## nonRandom everywhere

Rolls `nonRandom: 1` out to **all 16 journey seed sites** + `e2e/helpers/seed.ts` (defaulted, overridable via profile; `MockProfile.nonRandom` documented) — the ecosystem determinism rule, now codified in Mentat coding-standards.

## Verification

- Full journey suite: **285 passed**
- e2e type-check clean (`tsc -p e2e/tsconfig.json`)