### PR TITLE
feat(scheduling): publish cues, footer publish toggle, policy re-apply fix

### DIFF
--- a/e2e/journeys/78-schedule-footer-publish-toggle.spec.ts
+++ b/e2e/journeys/78-schedule-footer-publish-toggle.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { createMutationCollector } from '../helpers/mutation-collector';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 78 — Schedule grid footer: order-of-play publish toggle.
+ *
+ * The grid action bar (bottom strip) carries a two-state publish pill for the
+ * currently-viewed date, right of the Call Timing shortcut:
+ *
+ *   - not published → muted "Not published" (`.spl-publish-pill`)
+ *   - published     → green, glowing "Published" (`.spl-publish-pill--on`)
+ *
+ * Clicking it opens a confirm dialog; confirming drives the SAME mutation path
+ * as the publishing tab's per-date chips (`publishOrderOfPlay` /
+ * `unPublishOrderOfPlay`). This journey pins that contract end to end:
+ *
+ *  - A freshly-seeded tournament starts on "Not published".
+ *  - Publish → confirm → `publishOrderOfPlay` fires with the viewed date, the
+ *    pill flips to the glowing published state, and the date-selector button
+ *    grows its green published dot.
+ *  - Unpublish the only published date → confirm → `unPublishOrderOfPlay`
+ *    fires and the pill returns to "Not published".
+ *
+ * The pill lives in DOM the node vitest suite can't exercise; the pure toggle
+ * logic (which methods, which dates) is unit-tested in
+ * `services/publishing/orderOfPlayPublish.test.ts`. jsdom/happy-dom are not
+ * introduced — Playwright is this ecosystem's single DOM test layer.
+ */
+
+const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+
+const PUBLISH_PILL = 'button.spl-publish-pill';
+const PUBLISH_PILL_ON = 'button.spl-publish-pill.spl-publish-pill--on';
+const PUBLISHED_DOT = '[title="Order of play published"]';
+const OK_BUTTON = { role: 'button' as const, name: 'Ok' };
+
+/**
+ * Seed an 8-draw SE event on the schedule date with a venue so the grid view
+ * mounts with its action bar. No scheduling needed — the publish pill toggles
+ * the date's order-of-play publish status, independent of placed matchUps.
+ *
+ * Bundled into one page.evaluate so the IDB write can't race the seed helper's
+ * fire-and-forget load (same gotcha Journey 29/38 document).
+ */
+async function seedTournament(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(async (date: string) => {
+    try {
+      await dev.tmx2db.initDB();
+
+      const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'E2E Footer Publish',
+        tournamentAttributes: {
+          tournamentId: 'e2e-footer-publish',
+          startDate: date,
+          endDate: date,
+        },
+        participantsProfile: { scaledParticipantsCount: 8 },
+        drawProfiles: [{ eventName: 'Singles', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' }],
+        venueProfiles: [{ courtsCount: 2, venueName: 'Footer Publish Venue' }],
+      });
+
+      await dev.tmx2db.addTournament(dev.factory.tournamentEngine.getTournament().tournamentRecord);
+      return tournamentRecord.tournamentId as string;
+    } catch (err: any) {
+      throw new Error(`${err?.name || 'Error'}: ${err?.message || String(err)}`);
+    }
+  }, SCHEDULE_DATE);
+}
+
+test.describe('Journey 78 — schedule footer publish toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('publish then unpublish the viewed date from the footer pill', async ({ page }) => {
+    const tournamentId = await seedTournament(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToScheduling();
+
+    const pill = page.locator(PUBLISH_PILL);
+    await expect(pill).toBeVisible();
+    // Fresh tournament: order of play unpublished.
+    await expect(pill).toHaveText(/Not published/);
+    await expect(page.locator(PUBLISH_PILL_ON)).toHaveCount(0);
+    await expect(page.locator(PUBLISHED_DOT)).toHaveCount(0);
+
+    // ── Publish ──────────────────────────────────────────────────────────
+    const collector = createMutationCollector(page);
+    await pill.click();
+    await page.getByRole(OK_BUTTON.role, { name: OK_BUTTON.name }).click();
+
+    const publishMutation = await collector.waitForMethod('publishOrderOfPlay');
+    const publishMethod = publishMutation.methods.find((m) => m.method === 'publishOrderOfPlay');
+    expect((publishMethod?.params as any)?.scheduledDates).toContain(SCHEDULE_DATE);
+
+    // Pill flips to the glowing published state; the date-selector button grows
+    // its green published dot (the selector recomputes via onMutationApplied).
+    await expect(page.locator(PUBLISH_PILL_ON)).toHaveCount(1);
+    await expect(page.locator(PUBLISH_PILL)).toHaveText(/^Published/);
+    await expect(page.locator(PUBLISHED_DOT).first()).toBeVisible();
+
+    // ── Unpublish (removing the only published date) ─────────────────────
+    collector.clear();
+    await page.locator(PUBLISH_PILL).click();
+    await page.getByRole(OK_BUTTON.role, { name: OK_BUTTON.name }).click();
+
+    await collector.waitForMethod('unPublishOrderOfPlay');
+
+    await expect(page.locator(PUBLISH_PILL_ON)).toHaveCount(0);
+    await expect(page.locator(PUBLISH_PILL)).toHaveText(/Not published/);
+    await expect(page.locator(PUBLISHED_DOT)).toHaveCount(0);
+
+    collector.detach();
+  });
+});

--- a/e2e/journeys/79-tippy-dyncontent-no-warning.spec.ts
+++ b/e2e/journeys/79-tippy-dyncontent-no-warning.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 79 — tippy `dynContent` plugin emits no invalid-prop warning.
+ *
+ * The sidebar navigation tooltips pass a custom `dynContent` prop backed by the
+ * `enhancedContentFunction` plugin. The plugin previously lacked a top-level
+ * `name`, so tippy's dev-only `validateProps` warned "`dynContent` is not a
+ * valid prop" on the first tooltip instance. Aligning the plugin's top-level
+ * `name` with the prop name silences it without changing behavior.
+ *
+ * CRITICAL: tippy's `warnWhen` dedupes via a module-level `visitedMessages` Set
+ * — it warns ONCE per unique message for the whole page lifetime. The first nav
+ * render (the home sidebar on app boot) is what fires it, so the console
+ * listener MUST be attached before the very first navigation or the warning is
+ * already "visited" and suppressed (a false negative). Hence no navigation in
+ * beforeEach — everything is driven here after the listener is live.
+ *
+ * The plugin's lazy-content contract is unit-tested in
+ * `services/dom/toolTip/plugins.test.ts`.
+ */
+
+const INVALID_PROP_MARKER = 'is not a valid prop';
+const DYNCONTENT_MARKER = 'dynContent';
+
+async function seedTournament(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(async () => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      tournamentName: 'E2E Tippy DynContent',
+      tournamentAttributes: { tournamentId: 'e2e-tippy-dyncontent' },
+      drawProfiles: [{ eventName: 'Singles', drawSize: 4, drawType: 'SINGLE_ELIMINATION' }],
+    });
+    await dev.tmx2db.addTournament(dev.factory.tournamentEngine.getTournament().tournamentRecord);
+    return tournamentRecord.tournamentId as string;
+  });
+}
+
+test.describe('Journey 79 — tippy dynContent no invalid-prop warning', () => {
+  test('nav tooltips render without a dynContent invalid-prop warning', async ({ page }) => {
+    // Attach the console listener BEFORE any navigation — the warning fires once
+    // on the first nav render and tippy suppresses repeats.
+    const warnings: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'warning' || msg.type() === 'error') warnings.push(msg.text());
+    });
+
+    // App boot renders the home sidebar nav (homeNavigation.ts → dynContent
+    // tooltips); this is the first place the warning would fire.
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+
+    // Also exercise the tournament nav (navigation.ts → dynContent tooltips).
+    const tournamentId = await seedTournament(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await expect(page.locator('#o-route')).toBeVisible();
+
+    // Give console messages a tick to flush to the Playwright listener.
+    await page.waitForTimeout(500);
+
+    const dynContentWarnings = warnings.filter(
+      (w) => w.includes(INVALID_PROP_MARKER) && w.includes(DYNCONTENT_MARKER),
+    );
+    expect(dynContentWarnings, `Unexpected tippy warnings:\n${dynContentWarnings.join('\n')}`).toHaveLength(0);
+
+    // Belt-and-braces: no tippy invalid-prop warning of any kind slipped in.
+    expect(warnings.filter((w) => w.includes(INVALID_PROP_MARKER))).toHaveLength(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "axios": "1.18.1",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.7.0",
+    "courthive-components": "3.8.0",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.4",

--- a/src/components/schedule/scheduleDateSelector.ts
+++ b/src/components/schedule/scheduleDateSelector.ts
@@ -14,7 +14,7 @@
  * reliably (the header renders via a path that skipped it). Behaviour is
  * locked by Playwright journey 59.
  */
-import { countForDate, dateButtonHtml, formatDateLabel } from './scheduleDateSelectorLogic';
+import { countForDate, dateButtonHtml, formatDateLabel, isPublishedForDate } from './scheduleDateSelectorLogic';
 import { onMutationApplied } from 'services/mutation/mutationObservers';
 import tippy, { Instance as TippyInstance } from 'tippy.js';
 import { ScheduleDate } from 'courthive-components';
@@ -55,7 +55,11 @@ export function buildScheduleDateSelector(params: ScheduleDateSelectorParams): S
     'align-items: center',
     'gap: 6px',
   ].join('; ');
-  dateBtn.innerHTML = dateButtonHtml(selectedDate, countForDate(dates, selectedDate));
+  dateBtn.innerHTML = dateButtonHtml(
+    selectedDate,
+    countForDate(dates, selectedDate),
+    isPublishedForDate(dates, selectedDate),
+  );
 
   let dateTippy: TippyInstance | undefined;
   let destroyed = false;
@@ -89,7 +93,7 @@ export function buildScheduleDateSelector(params: ScheduleDateSelectorParams): S
   });
 
   const applyDates = (next: ScheduleDate[]): void => {
-    dateBtn.innerHTML = dateButtonHtml(selectedDate, countForDate(next, selectedDate));
+    dateBtn.innerHTML = dateButtonHtml(selectedDate, countForDate(next, selectedDate), isPublishedForDate(next, selectedDate));
     datePopoverContent = buildPopover(next);
     dateTippy?.setContent(datePopoverContent);
   };
@@ -145,12 +149,22 @@ function buildDatePopover(dates: ScheduleDate[], selectedDate: string, onSelect:
     dateLabel.textContent = formatDateLabel(d.date);
     const statusLabel = document.createElement('div');
     statusLabel.style.cssText = `font-size: 0.6875rem; ${isSelected ? 'color: rgba(255,255,255,0.8);' : 'color: var(--tmx-muted);'}`;
-    statusLabel.textContent = d.isActive ? 'Active' : 'Inactive';
+    // Positive-only publish cue: append "· Published" when the date's order of
+    // play is published; never a negative for unpublished dates.
+    statusLabel.textContent = `${d.isActive ? 'Active' : 'Inactive'}${d.isPublished ? ' · Published' : ''}`;
     leftSide.appendChild(dateLabel);
     leftSide.appendChild(statusLabel);
 
     const badges = document.createElement('div');
     badges.style.cssText = 'display: flex; gap: 4px; align-items: center;';
+
+    if (d.isPublished) {
+      const dot = document.createElement('span');
+      dot.title = 'Order of play published';
+      dot.style.cssText =
+        'width: 7px; height: 7px; border-radius: 50%; background: var(--tmx-accent-green, #22c55e); flex: 0 0 auto;';
+      badges.appendChild(dot);
+    }
 
     if (d.matchUpCount != null && d.matchUpCount > 0) {
       const b = document.createElement('span');

--- a/src/components/schedule/scheduleDateSelectorLogic.test.ts
+++ b/src/components/schedule/scheduleDateSelectorLogic.test.ts
@@ -5,18 +5,26 @@
  * happy-dom are deliberately NOT proposed
  * (see feedback_one_dom_test_layer_per_ecosystem.md).
  */
-import { countForDate, dateButtonHtml, formatDateLabel } from './scheduleDateSelectorLogic';
+import {
+  countForDate,
+  dateButtonHtml,
+  formatDateLabel,
+  isPublishedForDate,
+  publishedDotHtml,
+} from './scheduleDateSelectorLogic';
 import type { ScheduleDate } from 'courthive-components';
 import { describe, expect, it } from 'vitest';
 
 // 2026-07-15 is a Wednesday.
 const D15 = '2026-07-15';
+const D16 = '2026-07-16';
+const GREEN = '--tmx-accent-green';
 const D15_LABEL = 'Wed Jul 15';
 
 function dates(): ScheduleDate[] {
   return [
     { date: D15, isActive: true, matchUpCount: 1 },
-    { date: '2026-07-16', isActive: false, matchUpCount: 0 },
+    { date: D16, isActive: false, matchUpCount: 0 },
     { date: '2026-07-17', isActive: false, matchUpCount: 3 },
   ];
 }
@@ -28,7 +36,7 @@ describe('scheduleDateSelectorLogic — countForDate', () => {
   });
 
   it('returns 0 for a date present with a zero count', () => {
-    expect(countForDate(dates(), '2026-07-16')).toBe(0);
+    expect(countForDate(dates(), D16)).toBe(0);
   });
 
   it('returns 0 for a date absent from the list', () => {
@@ -79,5 +87,40 @@ describe('scheduleDateSelectorLogic — dateButtonHtml', () => {
     const after = dateButtonHtml(D15, countForDate(recomputed, D15));
     expect(after).toContain('>2</span>');
     expect(after).not.toContain('>1</span>');
+  });
+
+  it('appends the green published dot only when isPublished is true', () => {
+    expect(dateButtonHtml(D15, 1, true)).toContain(GREEN);
+    expect(dateButtonHtml(D15, 1, false)).not.toContain(GREEN);
+    // Defaults to unpublished when the flag is omitted (backward compatible).
+    expect(dateButtonHtml(D15, 1)).not.toContain(GREEN);
+  });
+});
+
+describe('scheduleDateSelectorLogic — isPublishedForDate', () => {
+  it('reflects the isPublished flag of the matching date', () => {
+    const list: ScheduleDate[] = [
+      { date: D15, isActive: true, isPublished: true },
+      { date: D16, isActive: false, isPublished: false },
+    ];
+    expect(isPublishedForDate(list, D15)).toBe(true);
+    expect(isPublishedForDate(list, D16)).toBe(false);
+  });
+
+  it('is false for an absent date or a missing flag', () => {
+    expect(isPublishedForDate(dates(), '2026-07-99')).toBe(false);
+    expect(isPublishedForDate([{ date: D15, isActive: true }], D15)).toBe(false);
+  });
+});
+
+describe('scheduleDateSelectorLogic — publishedDotHtml', () => {
+  it('renders a green dot span when published', () => {
+    const html = publishedDotHtml(true);
+    expect(html).toContain(GREEN);
+    expect(html).toContain('<span');
+  });
+
+  it('renders nothing when not published', () => {
+    expect(publishedDotHtml(false)).toBe('');
   });
 });

--- a/src/components/schedule/scheduleDateSelectorLogic.ts
+++ b/src/components/schedule/scheduleDateSelectorLogic.ts
@@ -15,6 +15,25 @@ export function countForDate(dates: ScheduleDate[], date: string): number {
   return dates.find((d) => d.date === date)?.matchUpCount ?? 0;
 }
 
+/** Whether `date` is flagged as published in the supplied per-date list. */
+export function isPublishedForDate(dates: ScheduleDate[], date: string): boolean {
+  return !!dates.find((d) => d.date === date)?.isPublished;
+}
+
+/**
+ * Small "published" dot — a filled green circle used beside a date's match
+ * count to signal that its order of play is published. Empty string when not
+ * published so callers can unconditionally concatenate it.
+ */
+export function publishedDotHtml(isPublished: boolean): string {
+  if (!isPublished) return '';
+  return (
+    ' <span title="Order of play published" aria-label="Order of play published"' +
+    ' style="display: inline-block; width: 7px; height: 7px; border-radius: 50%;' +
+    ' background: var(--tmx-accent-green, #22c55e); vertical-align: middle;"></span>'
+  );
+}
+
 /**
  * Weekday + month + day label, e.g. "Wed Jul 15". Anchored at noon so a
  * date-only string never renders the previous day west of UTC
@@ -33,7 +52,7 @@ export function formatDateLabel(dateStr: string): string {
  * count badge (hidden when the count is 0) + chevron. The single source of the
  * badge markup that previously diverged across the two headers.
  */
-export function dateButtonHtml(selectedDate: string, count: number): string {
+export function dateButtonHtml(selectedDate: string, count: number, isPublished = false): string {
   const badge =
     count > 0
       ? ` <span style="font-size: 0.625rem; font-weight: 600; padding: 1px 6px; border-radius: 10px; background: rgba(127,127,127,0.25); color: currentColor;">${count}</span>`
@@ -41,6 +60,7 @@ export function dateButtonHtml(selectedDate: string, count: number): string {
   return (
     `<i class="fa-solid fa-calendar-days" style="font-size: 0.75rem;"></i>${formatDateLabel(selectedDate)}` +
     badge +
+    publishedDotHtml(isPublished) +
     ' <i class="fa-solid fa-chevron-down" style="font-size: 0.5625rem; opacity: 0.6;"></i>'
   );
 }

--- a/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
+++ b/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
@@ -4,6 +4,7 @@
  */
 import { getTournamentPublishData, getPublishingTableData } from './publishingData';
 import { renderPublishingTab, isAnythingPublished } from './renderPublishingTab';
+import { buildOrderOfPlayDateToggleMethods } from 'services/publishing/orderOfPlayPublish';
 import { getPublicTournamentUrl } from 'services/publishing/publicUrl';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { eventConstants, fixtures } from 'tods-competition-factory';
@@ -299,25 +300,12 @@ function buildOopDateChips(data: any): HTMLElement {
     chip.textContent = dayjs(date).format('ddd MMM D');
 
     chip.addEventListener('click', () => {
-      const isPublished = chip.classList.contains('active');
-      const effectiveDates = allDatesPublished ? [...data.tournamentDateRange] : [...publishedDates];
-      const newDates = isPublished
-        ? effectiveDates.filter((d) => d !== date)
-        : [...effectiveDates, date];
-
-      if (newDates.length) {
-        mutationRequest({
-          methods: [
-            { method: PUBLISH_ORDER_OF_PLAY, params: { scheduledDates: newDates, removePriorValues: true } },
-          ],
-          callback: () => renderPublishingTab(),
-        });
-      } else {
-        mutationRequest({
-          methods: [{ method: UNPUBLISH_ORDER_OF_PLAY }],
-          callback: () => renderPublishingTab(),
-        });
-      }
+      const { methods } = buildOrderOfPlayDateToggleMethods(date, data.tournamentDateRange, {
+        published: data.oopPublished,
+        allPublished: allDatesPublished,
+        publishedDates,
+      });
+      mutationRequest({ methods, callback: () => renderPublishingTab() });
     });
 
     dateGrid.appendChild(chip);

--- a/src/pages/tournament/tabs/scheduleViews/applyGridModal.ts
+++ b/src/pages/tournament/tabs/scheduleViews/applyGridModal.ts
@@ -2,85 +2,47 @@
  * Apply Grid modal — pick a scheduling policy (or "No policy") before
  * running the pro scheduler.
  *
- * Mirrors `applyTimesModal` (used by the Garman flow). The pro scheduler
- * is policy-blind by default; selecting a scheduling policy here enables
- * per-participant daily-limit enforcement (`defaultDailyLimits` from the
- * policy) for that run only.
+ * Mirrors `applyTimesModal` (the Garman flow) and shares selection/identity/
+ * compare logic via `schedulingPolicyChoices.ts`. The pro scheduler is
+ * policy-blind by default; selecting a scheduling policy here enables
+ * per-participant daily-limit enforcement (`defaultDailyLimits`) for that run.
  *
- * Creating or editing scheduling policies lives on the `/policies` page
- * and persists through `policyBridge`.
+ * Unlike Apply Times, this modal defaults to "No policy" to preserve the
+ * intentional unconstrained grid behavior — the attached policy is offered as
+ * a first-class selectable entry, but the operator must opt into it.
+ *
+ * Creating or editing scheduling policies lives on the `/policies` page.
  */
-import { competitionEngine } from 'services/factory/engine';
-import { PolicyCatalogItem } from 'courthive-components';
-
-import { getBuiltinPolicies, loadUserPolicies } from 'pages/policies/policyBridge';
 import { openModal, closeModal } from 'components/modals/baseModal/baseModal';
 
-const POLICY_TYPE_SCHEDULING = 'scheduling';
-const NO_POLICY_ID = '__no_policy__';
+import {
+  ATTACHED_POLICY_ID,
+  PolicyChoice,
+  appendChoiceGroup,
+  buildAttachedChoice,
+  getAttachedSchedulingPolicy,
+  loadSchedulingChoices,
+  resolveAttachedChoiceId,
+} from './schedulingPolicyChoices';
 
-export interface PolicyChoice {
-  id: string;
-  label: string;
-  /** attachPolicies({ policyDefinitions }) input shape: `{ scheduling: {...} }`. */
-  definition: Record<string, any>;
-  source: 'builtin' | 'user';
-}
+export type { PolicyChoice } from './schedulingPolicyChoices';
+
+const NO_POLICY_ID = '__no_policy__';
 
 export interface ApplyGridModalParams {
   onApply: (params: { selected: PolicyChoice | null; mustAttach: boolean }) => void;
   onCancel?: () => void;
 }
 
-function fingerprint(policy: Record<string, any> | undefined | null): string {
-  if (!policy) return '';
-  try {
-    return JSON.stringify(policy);
-  } catch {
-    return '';
-  }
-}
-
-function getAttachedSchedulingPolicy(): Record<string, any> | null {
-  try {
-    const result: any = competitionEngine.findPolicy?.({ policyType: POLICY_TYPE_SCHEDULING });
-    return result?.policy ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function toChoice(item: PolicyCatalogItem): PolicyChoice {
-  return {
-    id: item.id,
-    label: item.name,
-    definition: { [POLICY_TYPE_SCHEDULING]: item.policyData },
-    source: item.source === 'builtin' ? 'builtin' : 'user',
-  };
-}
-
 export async function openApplyGridModal(params: ApplyGridModalParams): Promise<void> {
-  const builtins = getBuiltinPolicies().filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
-  let userPolicies: PolicyCatalogItem[] = [];
-  try {
-    const all = await loadUserPolicies();
-    userPolicies = all.filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
-  } catch (err) {
-    console.error('loadUserPolicies failed', err);
-  }
-
-  const choices: PolicyChoice[] = [...builtins.map(toChoice), ...userPolicies.map(toChoice)];
+  const choices = await loadSchedulingChoices();
 
   const attached = getAttachedSchedulingPolicy();
-  const attachedFp = fingerprint(attached ?? undefined);
+  const matchingChoiceId = resolveAttachedChoiceId(attached, choices);
+  const matchedLabel = matchingChoiceId ? choices.find((c) => c.id === matchingChoiceId)?.label ?? null : null;
+  const attachedChoice = attached ? buildAttachedChoice(attached, matchedLabel) : null;
 
-  const matchingChoiceId = (() => {
-    if (!attachedFp) return null;
-    for (const c of choices) {
-      if (fingerprint(c.definition[POLICY_TYPE_SCHEDULING]) === attachedFp) return c.id;
-    }
-    return null;
-  })();
+  const allChoices: PolicyChoice[] = attachedChoice ? [attachedChoice, ...choices] : choices;
 
   // Default to "No policy" so the legacy unconstrained behavior is preserved
   // unless the operator explicitly opts into limits.
@@ -97,13 +59,11 @@ export async function openApplyGridModal(params: ApplyGridModalParams): Promise<
     intro.style.cssText = 'line-height: 1.45;';
     root.appendChild(intro);
 
-    if (attached) {
+    if (attachedChoice) {
       const summary = document.createElement('div');
       summary.style.cssText =
         'padding: 8px 12px; background: var(--tmx-bg-secondary, rgba(0,0,0,0.04)); border-radius: 6px; font-size: 0.75rem;';
-      const attachedLabel = matchingChoiceId
-        ? choices.find((c) => c.id === matchingChoiceId)?.label ?? 'Custom policy'
-        : 'Custom policy (not from this list)';
+      const attachedLabel = matchedLabel ?? 'Custom policy (not from this list)';
       summary.innerHTML = `<strong>Currently attached:</strong> ${attachedLabel}`;
       root.appendChild(summary);
     }
@@ -132,8 +92,9 @@ export async function openApplyGridModal(params: ApplyGridModalParams): Promise<
     noneOpt.selected = true;
     select.appendChild(noneOpt);
 
-    appendChoiceGroup(select, 'Built-in', choices, 'builtin', selectedId);
-    appendChoiceGroup(select, 'Saved', choices, 'user', selectedId);
+    appendChoiceGroup(select, 'Attached', allChoices, 'attached', selectedId);
+    appendChoiceGroup(select, 'Built-in', allChoices, 'builtin', selectedId);
+    appendChoiceGroup(select, 'Saved', allChoices, 'user', selectedId);
     select.addEventListener('change', () => {
       selectedId = select.value;
     });
@@ -162,38 +123,17 @@ export async function openApplyGridModal(params: ApplyGridModalParams): Promise<
             params.onApply({ selected: null, mustAttach: false });
             return;
           }
-          const selected = choices.find((c) => c.id === selectedId);
+          const selected = allChoices.find((c) => c.id === selectedId);
           if (!selected) {
             closeModal();
             return;
           }
-          params.onApply({
-            selected,
-            mustAttach: selected.id !== matchingChoiceId,
-          });
+          // The "Attached" entry and the catalog choice that equals the
+          // attached policy both re-apply what's already there → no re-attach.
+          const mustAttach = selected.id !== ATTACHED_POLICY_ID && selected.id !== matchingChoiceId;
+          params.onApply({ selected, mustAttach });
         },
       },
     ],
   });
-}
-
-function appendChoiceGroup(
-  select: HTMLSelectElement,
-  label: string,
-  choices: PolicyChoice[],
-  source: 'builtin' | 'user',
-  selectedId: string,
-): void {
-  const filtered = choices.filter((c) => c.source === source);
-  if (!filtered.length) return;
-  const group = document.createElement('optgroup');
-  group.label = label;
-  for (const choice of filtered) {
-    const opt = document.createElement('option');
-    opt.value = choice.id;
-    opt.textContent = choice.label;
-    if (choice.id === selectedId) opt.selected = true;
-    group.appendChild(opt);
-  }
-  select.appendChild(group);
 }

--- a/src/pages/tournament/tabs/scheduleViews/applyTimesModal.ts
+++ b/src/pages/tournament/tabs/scheduleViews/applyTimesModal.ts
@@ -3,92 +3,48 @@
  * the Garman scheduler.
  *
  * Reads the currently-attached scheduling policy from the tournament and
- * shows it for confirmation, then offers a <select> over the policies
- * registered with the `/policies` page: factory built-ins plus any user
- * policies persisted to IndexedDB via `policyBridge.saveUserPolicy`.
+ * offers it as the default, pre-selected choice ("Attached — …"), then lists
+ * the policies registered with the `/policies` page (factory built-ins plus
+ * any user policies persisted via `policyBridge.saveUserPolicy`) for switching.
  *
- * Creating or editing a scheduling policy is out of scope here — that
- * lives on the `/policies` page and persists through `policyBridge`.
+ * Selection/identity/compare logic is shared with the Apply Grid modal in
+ * `schedulingPolicyChoices.ts`. Creating or editing a scheduling policy is out
+ * of scope here — that lives on the `/policies` page.
  */
-import { competitionEngine } from 'services/factory/engine';
-import { PolicyCatalogItem } from 'courthive-components';
-
-import { getBuiltinPolicies, loadUserPolicies } from 'pages/policies/policyBridge';
 import { openModal, closeModal } from 'components/modals/baseModal/baseModal';
 
-const POLICY_TYPE_SCHEDULING = 'scheduling';
+import {
+  ATTACHED_POLICY_ID,
+  PolicyChoice,
+  appendChoiceGroup,
+  buildAttachedChoice,
+  getAttachedSchedulingPolicy,
+  loadSchedulingChoices,
+  resolveAttachedChoiceId,
+} from './schedulingPolicyChoices';
 
-export interface PolicyChoice {
-  id: string;
-  label: string;
-  /** attachPolicies({ policyDefinitions }) input shape: `{ scheduling: {...} }`. */
-  definition: Record<string, any>;
-  source: 'builtin' | 'user';
-}
+export type { PolicyChoice } from './schedulingPolicyChoices';
 
 export interface ApplyTimesModalParams {
   onApply: (params: { selected: PolicyChoice; mustAttach: boolean }) => void;
   onCancel?: () => void;
 }
 
-/** JSON fingerprint to compare a choice against the currently-attached
- *  scheduling policy. JSON.stringify is fine — policies are small,
- *  deterministic, JSON-safe objects. */
-function fingerprint(policy: Record<string, any> | undefined | null): string {
-  if (!policy) return '';
-  try {
-    return JSON.stringify(policy);
-  } catch {
-    return '';
-  }
-}
-
-function getAttachedSchedulingPolicy(): Record<string, any> | null {
-  try {
-    const result: any = competitionEngine.findPolicy?.({ policyType: POLICY_TYPE_SCHEDULING });
-    return result?.policy ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function toChoice(item: PolicyCatalogItem): PolicyChoice {
-  return {
-    id: item.id,
-    label: item.name,
-    // policyBridge stores policyData as the INNER block (not wrapped in
-    // a `{ scheduling: ... }` key); attachPolicies expects the wrapper.
-    definition: { [POLICY_TYPE_SCHEDULING]: item.policyData },
-    source: item.source === 'builtin' ? 'builtin' : 'user',
-  };
-}
-
 export async function openApplyTimesModal(params: ApplyTimesModalParams): Promise<void> {
-  const builtins = getBuiltinPolicies().filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
-  let userPolicies: PolicyCatalogItem[] = [];
-  try {
-    const all = await loadUserPolicies();
-    userPolicies = all.filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
-  } catch (err) {
-    console.error('loadUserPolicies failed', err);
-  }
-
-  const choices: PolicyChoice[] = [...builtins.map(toChoice), ...userPolicies.map(toChoice)];
+  const choices = await loadSchedulingChoices();
 
   const attached = getAttachedSchedulingPolicy();
-  const attachedFp = fingerprint(attached ?? undefined);
+  const matchingChoiceId = resolveAttachedChoiceId(attached, choices);
+  const matchedLabel = matchingChoiceId ? choices.find((c) => c.id === matchingChoiceId)?.label ?? null : null;
+  const attachedChoice = attached ? buildAttachedChoice(attached, matchedLabel) : null;
 
-  // Identify which choice matches what's already attached (if any).
-  const matchingChoiceId = (() => {
-    if (!attachedFp) return null;
-    for (const c of choices) {
-      if (fingerprint(c.definition[POLICY_TYPE_SCHEDULING]) === attachedFp) return c.id;
-    }
-    return null;
-  })();
+  // Everything the operator can pick, in display order: the attached policy
+  // first (when present), then the catalog.
+  const allChoices: PolicyChoice[] = attachedChoice ? [attachedChoice, ...choices] : choices;
 
-  // Default selection: the matching choice if any, else the first option.
-  let selectedId = matchingChoiceId ?? choices[0]?.id ?? '';
+  // Default: the attached policy (iterative re-apply is a no-op), else the
+  // matching catalog choice, else the first option.
+  let selectedId = attachedChoice?.id ?? matchingChoiceId ?? choices[0]?.id ?? '';
 
   const content = (root: HTMLElement) => {
     root.style.cssText = 'display: flex; flex-direction: column; gap: 12px; padding: 16px; font-size: 0.8125rem;';
@@ -96,10 +52,8 @@ export async function openApplyTimesModal(params: ApplyTimesModalParams): Promis
     const summary = document.createElement('div');
     summary.style.cssText =
       'padding: 8px 12px; background: var(--tmx-bg-secondary, rgba(0,0,0,0.04)); border-radius: 6px; font-size: 0.75rem;';
-    if (attached) {
-      const attachedLabel = matchingChoiceId
-        ? choices.find((c) => c.id === matchingChoiceId)?.label ?? 'Custom policy'
-        : 'Custom policy (not from this list)';
+    if (attachedChoice) {
+      const attachedLabel = matchedLabel ?? 'Custom policy (not from this list)';
       summary.innerHTML = `<strong>Currently attached:</strong> ${attachedLabel}`;
     } else {
       summary.innerHTML =
@@ -127,9 +81,10 @@ export async function openApplyTimesModal(params: ApplyTimesModalParams): Promis
       'color: var(--tmx-color-primary)',
       'cursor: pointer',
     ].join('; ');
-    if (choices.length) {
-      appendChoiceGroup(select, 'Built-in', choices, 'builtin', selectedId);
-      appendChoiceGroup(select, 'Saved', choices, 'user', selectedId);
+    if (allChoices.length) {
+      appendChoiceGroup(select, 'Attached', allChoices, 'attached', selectedId);
+      appendChoiceGroup(select, 'Built-in', allChoices, 'builtin', selectedId);
+      appendChoiceGroup(select, 'Saved', allChoices, 'user', selectedId);
       select.addEventListener('change', () => {
         selectedId = select.value;
       });
@@ -160,43 +115,19 @@ export async function openApplyTimesModal(params: ApplyTimesModalParams): Promis
         label: 'Apply',
         intent: 'is-primary',
         close: true,
-        disabled: !choices.length,
+        disabled: !allChoices.length,
         onClick: () => {
-          const selected = choices.find((c) => c.id === selectedId);
+          const selected = allChoices.find((c) => c.id === selectedId);
           if (!selected) {
             closeModal();
             return;
           }
-          params.onApply({
-            selected,
-            mustAttach: selected.id !== matchingChoiceId,
-          });
+          // The "Attached" entry and the catalog choice that equals the
+          // attached policy both re-apply what's already there → no re-attach.
+          const mustAttach = selected.id !== ATTACHED_POLICY_ID && selected.id !== matchingChoiceId;
+          params.onApply({ selected, mustAttach });
         },
       },
     ],
   });
-}
-
-/** Append a labelled `<optgroup>` for one source ("builtin" or "user")
- *  containing only choices from that source. Empty groups are skipped so
- *  the select doesn't show an empty "Saved" header when there are none. */
-function appendChoiceGroup(
-  select: HTMLSelectElement,
-  label: string,
-  choices: PolicyChoice[],
-  source: 'builtin' | 'user',
-  selectedId: string,
-): void {
-  const filtered = choices.filter((c) => c.source === source);
-  if (!filtered.length) return;
-  const group = document.createElement('optgroup');
-  group.label = label;
-  for (const choice of filtered) {
-    const opt = document.createElement('option');
-    opt.value = choice.id;
-    opt.textContent = choice.label;
-    if (choice.id === selectedId) opt.selected = true;
-    group.appendChild(opt);
-  }
-  select.appendChild(group);
 }

--- a/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
@@ -26,6 +26,7 @@ const COLOR_PRIMARY = 'color: var(--tmx-color-primary)';
 const BORDER_PRIMARY = 'border: 1px solid var(--tmx-border-primary)';
 const BG_PRIMARY = 'background: var(--tmx-bg-primary)';
 const BORDER_RADIUS_6 = 'border-radius: 6px';
+const CURSOR_POINTER = 'cursor: pointer';
 
 export interface GridActionBarParams {
   issues: ScheduleIssue[];
@@ -38,6 +39,10 @@ export interface GridActionBarParams {
   timingAvailable?: boolean;
   /** Open the Call Timing Variance report. When omitted, the shortcut never renders. */
   onOpenTimingReport?: () => void;
+  /** Whether the currently-viewed date's order of play is published. */
+  datePublished?: boolean;
+  /** Toggle publication of the viewed date. When omitted, the publish pill never renders. */
+  onTogglePublish?: () => void;
 }
 
 export interface GridActionBar {
@@ -53,11 +58,16 @@ export interface GridActionBar {
    * clears (e.g. after a match is called to court). No-op without onOpenTimingReport.
    */
   setTimingAvailable: (available: boolean) => void;
+  /**
+   * Re-render the publish pill after a publish/unpublish toggle so the footer
+   * reflects the new state without rebuilding the bar. No-op without onTogglePublish.
+   */
+  setDatePublished: (published: boolean) => void;
 }
 
 export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
   const { issues, bulkMode, minCourtWidth, onMinCourtWidthChange, onBulkModeChange, onClearSchedule } = params;
-  const { timingAvailable, onOpenTimingReport } = params;
+  const { timingAvailable, onOpenTimingReport, datePublished, onTogglePublish } = params;
 
   const bar = document.createElement('div');
   bar.style.cssText =
@@ -90,6 +100,20 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
   bar.appendChild(timingSlot);
   setTimingAvailable(!!timingAvailable);
 
+  // Order-of-play publish pill — immediately right of the timing shortcut. Its
+  // own `display: contents` slot so setDatePublished can re-render it in place
+  // after a toggle without disturbing neighbouring controls.
+  const publishSlot = document.createElement('div');
+  publishSlot.style.display = 'contents';
+  let publishState = !!datePublished;
+  const setDatePublished = (published: boolean): void => {
+    publishState = published;
+    publishSlot.replaceChildren();
+    if (onTogglePublish) publishSlot.appendChild(buildPublishPill(published, onTogglePublish));
+  };
+  bar.appendChild(publishSlot);
+  setDatePublished(publishState);
+
   // Spacer pushes the right cluster (bulk-mode toggle + clear button) flush
   // right while the left cluster stays anchored at the start of the bar.
   const spacer = document.createElement('div');
@@ -104,7 +128,58 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
     bar.appendChild(buildClearButton(bulkMode, onClearSchedule));
   }
 
-  return { element: bar, setIssues, setTimingAvailable };
+  return { element: bar, setIssues, setTimingAvailable, setDatePublished };
+}
+
+// ── Order-of-play publish pill ──
+
+const PUBLISH_GLOW_STYLE_ID = 'spl-publish-glow-style';
+
+// Inject the green publish-glow keyframes once (inline styles can't declare @keyframes).
+function ensurePublishGlowStyle(): void {
+  if (document.getElementById(PUBLISH_GLOW_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = PUBLISH_GLOW_STYLE_ID;
+  style.textContent =
+    '@keyframes spl-publish-glow{0%,100%{box-shadow:0 0 0 0 rgba(34,197,94,0)}50%{box-shadow:0 0 8px 2px rgba(34,197,94,0.55)}}' +
+    '.spl-publish-pill--on{animation:spl-publish-glow 2.6s ease-in-out infinite}' +
+    '@media (prefers-reduced-motion: reduce){.spl-publish-pill--on{animation:none}}';
+  document.head.appendChild(style);
+}
+
+/**
+ * Two-state pill for the viewed date's order-of-play publish status:
+ *   - published → green, softly glowing "Published" (click to unpublish)
+ *   - not       → muted grey "Not published" (click to publish)
+ * Click routes to the confirm dialog owned by the caller.
+ */
+function buildPublishPill(published: boolean, onToggle: () => void): HTMLElement {
+  ensurePublishGlowStyle();
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = published ? 'spl-publish-pill spl-publish-pill--on' : 'spl-publish-pill';
+  const accent = published ? 'var(--tmx-accent-green, #22c55e)' : 'var(--tmx-text-muted, #9ca3af)';
+  btn.style.cssText = [
+    'font-size: 0.75rem',
+    'font-weight: 600',
+    'padding: 4px 10px',
+    BORDER_RADIUS_6,
+    `border: 1px solid ${published ? accent : 'var(--tmx-border-primary)'}`,
+    BG_PRIMARY,
+    CURSOR_POINTER,
+    `color: ${accent}`,
+    DISPLAY_INLINE_FLEX,
+    ALIGN_ITEMS_CENTER,
+    'gap: 6px',
+  ].join('; ');
+  btn.title = published
+    ? 'Order of play for this date is published — click to unpublish'
+    : 'Order of play for this date is not published — click to publish';
+  btn.setAttribute('aria-label', btn.title);
+  const dot = published ? '<i class="fa-solid fa-circle" style="font-size: 0.5rem;"></i>' : '<i class="fa-regular fa-circle" style="font-size: 0.5rem;"></i>';
+  btn.innerHTML = `${dot}<span>${published ? 'Published' : 'Not published'}</span>`;
+  btn.addEventListener('click', onToggle);
+  return btn;
 }
 
 // ── Call Timing Variance shortcut ──
@@ -134,7 +209,7 @@ function buildTimingReportButton(onOpen: () => void): HTMLElement {
     BORDER_RADIUS_6,
     BORDER_PRIMARY,
     BG_PRIMARY,
-    'cursor: pointer',
+    CURSOR_POINTER,
     'color: var(--tmx-accent-blue, #3b82f6)',
     DISPLAY_INLINE_FLEX,
     ALIGN_ITEMS_CENTER,
@@ -173,7 +248,7 @@ function buildIssuesButton(issues: ScheduleIssue[]): HTMLElement {
     BORDER_RADIUS_6,
     BORDER_PRIMARY,
     BG_PRIMARY,
-    'cursor: pointer',
+    CURSOR_POINTER,
     'color: var(--tmx-accent-orange, #f59e0b)',
     DISPLAY_INLINE_FLEX,
     ALIGN_ITEMS_CENTER,

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -30,6 +30,12 @@ import { getActiveRegistrationNamesByCourtId } from './practiceRegistrationStrip
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { printCourtMatchUpCards } from 'components/modals/printCourtCards';
 import { buildGridActionBar, type GridActionBar } from './gridActionBar';
+import {
+  getOrderOfPlayPublishState,
+  isOrderOfPlayDatePublished,
+  buildOrderOfPlayDateToggleMethods,
+} from 'services/publishing/orderOfPlayPublish';
+import { formatDateLabel } from 'components/schedule/scheduleDateSelectorLogic';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { buildInlineNotice } from 'components/notices/inlineNotice';
@@ -130,6 +136,8 @@ const DATA_MATCHUP_ID = 'data-matchup-id';
 const DATA_DRAW_ID = 'data-draw-id';
 const DATA_SCHEDULED_TIME = 'data-scheduled-time';
 const INTENT_WARNING = 'is-warning';
+const INTENT_SUCCESS = 'is-success';
+const INTENT_DANGER = 'is-danger';
 // Custom drag MIME marker — present only on grid-sourced drags. The payload
 // itself is unreadable mid-drag (browsers block getData during dragover), but
 // dataTransfer.types is readable, so this marker lets the Now-strip affordance
@@ -409,8 +417,47 @@ export function renderGridView(
     onClearSchedule: options?.onClearSchedule,
     timingAvailable: hasCallTimingData(),
     onOpenTimingReport: openTimingVarianceReport,
+    datePublished: isOrderOfPlayDatePublished(currentDate, getOrderOfPlayPublishState()),
+    onTogglePublish: () => confirmTogglePublish(),
   });
   gridActionBar = actionBar;
+
+  // Confirm + apply publish/unpublish of the viewed date's order of play,
+  // reusing the same mutation path as the publishing tab. On success the footer
+  // pill updates in place; the date selector refreshes via its own
+  // onMutationApplied subscription.
+  function confirmTogglePublish(): void {
+    const publishState = getOrderOfPlayPublishState();
+    const fullRange = dateRange(
+      getCachedCompetitionDateRange().startDate ?? '',
+      getCachedCompetitionDateRange().endDate ?? '',
+    );
+    const { methods, willPublish } = buildOrderOfPlayDateToggleMethods(currentDate, fullRange, publishState);
+    const label = formatDateLabel(currentDate);
+    confirmModal({
+      title: willPublish ? 'Publish order of play' : 'Unpublish order of play',
+      query: willPublish
+        ? `Publish the order of play for ${label}? It will become visible to the public.`
+        : `Unpublish the order of play for ${label}? It will no longer be visible to the public.`,
+      okIntent: willPublish ? INTENT_SUCCESS : INTENT_WARNING,
+      okAction: () => {
+        mutationRequest({
+          methods,
+          callback: (result: any) => {
+            if (result?.error) {
+              scheduleToast({ message: 'Publish change failed', intent: INTENT_DANGER });
+              return;
+            }
+            actionBar.setDatePublished(willPublish);
+            scheduleToast({
+              message: willPublish ? `Order of play published for ${label}` : `Order of play unpublished for ${label}`,
+              intent: willPublish ? INTENT_SUCCESS : INTENT_WARNING,
+            });
+          },
+        });
+      },
+    });
+  }
   panelWrapper.appendChild(actionBar.element);
 
   // Wire the strip's visibility toggle through the schedule page store, and
@@ -802,6 +849,9 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   sidebar.insertBefore(controlBar, sidebar.firstChild);
   sidebar.appendChild(scheduledPanel);
 
+  // Default sidebar tab is resolved after the scheduled-orphan helpers are
+  // declared (see `resolveInitialTab` below), so we can land on "Scheduled"
+  // when the selected date already has scheduled-but-unplaced matchUps.
   let activeTab: SidebarTab = readSidebarTab();
 
   // Single source of truth for "scheduled but not placed" — used by both the
@@ -962,9 +1012,21 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
     }
   }
 
-  function setTab(tab: SidebarTab): void {
+  // The default tab reflects the selected date's schedule state; the operator's
+  // last *explicit* tab choice (persisted) is only the fallback. Land on
+  // "Scheduled" when that date already has scheduled-but-unplaced matchUps — the
+  // same set that drives the tab's "(#)" badge — so the actionable list shows
+  // first. renderGridView re-runs on every date/mode change, so this is a
+  // per-mount view decision and is applied without persisting (see setTab).
+  function resolveInitialTab(): SidebarTab {
+    return getScheduledNotPlacedOnCourt().length > 0 ? 'scheduled' : readSidebarTab();
+  }
+
+  function setTab(tab: SidebarTab, options?: { persist?: boolean }): void {
     activeTab = tab;
-    writeSidebarTab(tab);
+    // Persist only explicit operator choices, not the auto-resolved default, so
+    // `readSidebarTab()` keeps meaning "the last tab the operator clicked".
+    if (options?.persist !== false) writeSidebarTab(tab);
     unschedTab.style.cssText = tabStyle(tab === 'unscheduled');
     schedTab.style.cssText = tabStyle(tab === 'scheduled');
 
@@ -992,9 +1054,11 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   attachUnscheduleDropTarget(schedTab, refresh);
   attachUnscheduleDropTarget(scheduledPanel, refresh);
 
-  // Apply the persisted tab (also restores Scheduled view + populates panel
-  // on a date change when the user was already on the Scheduled tab).
-  setTab(activeTab);
+  // Apply the resolved default tab (Scheduled when the selected date has
+  // scheduled-but-unplaced matchUps, else the operator's last explicit choice).
+  // Not persisted — this is a per-mount view decision, not a preference change.
+  activeTab = resolveInitialTab();
+  setTab(activeTab, { persist: false });
   updateBadge();
 
   // Hook into refresh to update scheduled panel when visible. The badge
@@ -1290,7 +1354,7 @@ function executeMethods(methods: any[], onRefresh: () => void): void {
   const result = competitionEngine.executionQueue(directives, true);
   if (result?.error) {
     console.error('[schedule2] local execution error', result);
-    scheduleToast({ message: 'Schedule change failed locally', intent: 'is-danger' });
+    scheduleToast({ message: 'Schedule change failed locally', intent: INTENT_DANGER });
     return;
   }
 
@@ -1335,10 +1399,10 @@ async function savePending(): Promise<void> {
     engine: COMPETITION_ENGINE,
     callback: (result: any) => {
       if (result?.success || !result?.error) {
-        scheduleToast({ message: `Saved ${allMethods.length} scheduling changes`, intent: 'is-success' });
+        scheduleToast({ message: `Saved ${allMethods.length} scheduling changes`, intent: INTENT_SUCCESS });
       } else {
         console.error('[schedule2] bulk save error', result);
-        scheduleToast({ message: 'Failed to save scheduling changes to server', intent: 'is-danger' });
+        scheduleToast({ message: 'Failed to save scheduling changes to server', intent: INTENT_DANGER });
       }
       updateActionBar();
     },
@@ -2407,7 +2471,7 @@ export function resolveColumnConflicts(): void {
         (issue.issueType === CONFLICT_PARTICIPANTS || issue.issueType === CONFLICT_POTENTIAL_PARTICIPANTS),
     );
   if (!participantConflicts.length) {
-    scheduleToast({ message: 'No player conflicts to resolve on this day', intent: 'is-success' });
+    scheduleToast({ message: 'No player conflicts to resolve on this day', intent: INTENT_SUCCESS });
     return;
   }
 
@@ -2964,9 +3028,12 @@ export function buildScheduleDates(selectedDate: string): ScheduleDate[] {
     if (d) dateCounts.set(d, (dateCounts.get(d) || 0) + 1);
   }
 
+  const publishState = getOrderOfPlayPublishState();
+
   return dates.map((date: string) => ({
     date,
     isActive: date === selectedDate,
+    isPublished: isOrderOfPlayDatePublished(date, publishState),
     matchUpCount: dateCounts.get(date) ?? 0,
   }));
 }

--- a/src/pages/tournament/tabs/scheduleViews/profileView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/profileView.ts
@@ -671,7 +671,7 @@ function runScheduleWithPolicy(
 
     const methods: any[] = [];
     if (mustAttach) {
-      methods.push({ method: 'attachPolicies', params: { policyDefinitions } });
+      methods.push({ method: 'attachPolicies', params: { policyDefinitions, allowReplacement: true } });
     }
     methods.push({ method: 'scheduleProfileRounds', params });
 
@@ -787,7 +787,10 @@ function runGridWithPolicy(
 
     const methods: any[] = [];
     if (selectedPolicy && mustAttach) {
-      methods.push({ method: 'attachPolicies', params: { policyDefinitions: selectedPolicy.definition } });
+      methods.push({
+        method: 'attachPolicies',
+        params: { policyDefinitions: selectedPolicy.definition, allowReplacement: true },
+      });
     }
     methods.push({ method: 'scheduleProfileGrid', params });
 

--- a/src/pages/tournament/tabs/scheduleViews/schedulingPolicyChoices.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedulingPolicyChoices.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Coverage for the shared scheduling-policy selection helpers behind the
+ * Apply Times / Apply Grid modals.
+ *
+ * The load-bearing behaviors under test:
+ *   1. normalizedFingerprint — key-order & policyName independence, and that
+ *      genuinely different shapes still differ (the honest stopgap boundary).
+ *   2. Identity stamping — toDefinition/choiceIdentity carry a policyName so it
+ *      travels with the tournamentRecord.
+ *   3. resolveAttachedChoiceId — identity match first, structural fallback, and
+ *      the drift case that resolves to "no match" (→ Custom / Attached entry).
+ *   4. buildAttachedChoice — label precedence and no-re-attach sentinel id.
+ *
+ * DOM assembly (appendChoiceGroup, openApply*Modal) is intentionally NOT tested
+ * here: the vitest env is node, and Playwright is the ecosystem's DOM layer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { findPolicyMock, getBuiltinPoliciesMock, loadUserPoliciesMock } = vi.hoisted(() => ({
+  findPolicyMock: vi.fn(),
+  getBuiltinPoliciesMock: vi.fn(),
+  loadUserPoliciesMock: vi.fn(),
+}));
+
+vi.mock('services/factory/engine', () => ({
+  competitionEngine: { findPolicy: findPolicyMock },
+}));
+
+vi.mock('pages/policies/policyBridge', () => ({
+  getBuiltinPolicies: getBuiltinPoliciesMock,
+  loadUserPolicies: loadUserPoliciesMock,
+}));
+
+import {
+  ATTACHED_POLICY_ID,
+  POLICY_TYPE_SCHEDULING,
+  buildAttachedChoice,
+  choiceIdentity,
+  getAttachedSchedulingPolicy,
+  loadSchedulingChoices,
+  normalizedFingerprint,
+  resolveAttachedChoiceId,
+  toChoice,
+  toDefinition,
+} from './schedulingPolicyChoices';
+
+const BUILTIN_ID = 'builtin-scheduling';
+const BUILTIN_NAME = 'Default Scheduling';
+
+const builtinItem = (over: Record<string, any> = {}) => ({
+  id: BUILTIN_ID,
+  name: BUILTIN_NAME,
+  policyType: POLICY_TYPE_SCHEDULING,
+  source: 'builtin' as const,
+  description: '',
+  policyData: { defaultDailyLimits: { total: 3, SINGLES: 2, DOUBLES: 2 } },
+  ...over,
+});
+
+const userItem = (over: Record<string, any> = {}) => ({
+  id: 'user-1',
+  name: 'My Policy',
+  policyType: POLICY_TYPE_SCHEDULING,
+  source: 'user' as const,
+  description: '',
+  policyData: { defaultDailyLimits: { total: 4 } },
+  ...over,
+});
+
+beforeEach(() => {
+  findPolicyMock.mockReset();
+  getBuiltinPoliciesMock.mockReset();
+  loadUserPoliciesMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('normalizedFingerprint', () => {
+  it('is independent of key ordering', () => {
+    const a = { defaultDailyLimits: { total: 3, SINGLES: 2 }, defaultTimes: { minutes: 90 } };
+    const b = { defaultTimes: { minutes: 90 }, defaultDailyLimits: { SINGLES: 2, total: 3 } };
+    expect(normalizedFingerprint(a)).toBe(normalizedFingerprint(b));
+  });
+
+  it('ignores policyName (identity is matched separately)', () => {
+    const bare = { defaultDailyLimits: { total: 3 } };
+    const stamped = { defaultDailyLimits: { total: 3 }, policyName: BUILTIN_NAME };
+    expect(normalizedFingerprint(stamped)).toBe(normalizedFingerprint(bare));
+  });
+
+  it('distinguishes genuinely different shapes (the stopgap boundary)', () => {
+    const withField = { defaultDailyLimits: { total: 3 }, allowModificationWhenMatchUpsScheduled: { courts: false } };
+    const without = { defaultDailyLimits: { total: 3 } };
+    expect(normalizedFingerprint(withField)).not.toBe(normalizedFingerprint(without));
+  });
+
+  it('distinguishes differing scalar values and array order', () => {
+    expect(normalizedFingerprint({ total: 3 })).not.toBe(normalizedFingerprint({ total: 4 }));
+    expect(normalizedFingerprint({ a: [1, 2] })).not.toBe(normalizedFingerprint({ a: [2, 1] }));
+  });
+
+  it('returns empty string for null / undefined / non-object', () => {
+    expect(normalizedFingerprint(null)).toBe('');
+    expect(normalizedFingerprint(undefined)).toBe('');
+    expect(normalizedFingerprint(42 as any)).toBe('');
+  });
+});
+
+describe('choiceIdentity / toDefinition', () => {
+  it('uses the catalog name when policyData has no embedded policyName', () => {
+    expect(choiceIdentity(builtinItem())).toBe(BUILTIN_NAME);
+  });
+
+  it('prefers an embedded policyName over the catalog name', () => {
+    const item = builtinItem({ name: 'Display Name', policyData: { total: 3, policyName: 'Embedded' } });
+    expect(choiceIdentity(item)).toBe('Embedded');
+  });
+
+  it('stamps the identity into the wrapped definition', () => {
+    const def = toDefinition(builtinItem());
+    expect(def[POLICY_TYPE_SCHEDULING].policyName).toBe(BUILTIN_NAME);
+    expect(def[POLICY_TYPE_SCHEDULING].defaultDailyLimits).toEqual({ total: 3, SINGLES: 2, DOUBLES: 2 });
+  });
+
+  it('does not mutate the source policyData', () => {
+    const item = builtinItem();
+    toDefinition(item);
+    expect(item.policyData).not.toHaveProperty('policyName');
+  });
+});
+
+describe('toChoice', () => {
+  it('maps a builtin catalog item to a stamped, sourced choice', () => {
+    const choice = toChoice(builtinItem());
+    expect(choice).toMatchObject({ id: BUILTIN_ID, label: BUILTIN_NAME, source: 'builtin' });
+    expect(choice.definition[POLICY_TYPE_SCHEDULING].policyName).toBe(BUILTIN_NAME);
+  });
+
+  it('maps any non-builtin source to "user"', () => {
+    expect(toChoice(userItem({ source: 'imported' })).source).toBe('user');
+  });
+});
+
+describe('resolveAttachedChoiceId', () => {
+  it('returns null when nothing is attached', () => {
+    expect(resolveAttachedChoiceId(null, [toChoice(builtinItem())])).toBeNull();
+  });
+
+  it('matches by identity (policyName) even when the shape has drifted', () => {
+    const choices = [toChoice(builtinItem())];
+    // Attached carries the stamped identity but an OLDER shape (extra field the
+    // current builtin no longer has) — identity match must still win.
+    const attached = { defaultDailyLimits: { total: 3 }, legacyField: true, policyName: BUILTIN_NAME };
+    expect(resolveAttachedChoiceId(attached, choices)).toBe(BUILTIN_ID);
+  });
+
+  it('falls back to structural match when no policyName is present', () => {
+    const choices = [toChoice(builtinItem()), toChoice(userItem())];
+    // Same shape as the builtin's policyData, minus identity (pre-stamping).
+    const attached = { defaultDailyLimits: { total: 3, SINGLES: 2, DOUBLES: 2 } };
+    expect(resolveAttachedChoiceId(attached, choices)).toBe(BUILTIN_ID);
+  });
+
+  it('returns null for a drifted custom policy that matches nothing (→ Attached entry)', () => {
+    const choices = [toChoice(builtinItem())];
+    const attached = { defaultDailyLimits: { total: 3 }, allowModificationWhenMatchUpsScheduled: { courts: false } };
+    expect(resolveAttachedChoiceId(attached, choices)).toBeNull();
+  });
+
+  it('does not match by identity when the attached policyName is unknown', () => {
+    const choices = [toChoice(builtinItem())];
+    const attached = { defaultDailyLimits: { total: 999 }, policyName: 'Nonexistent' };
+    expect(resolveAttachedChoiceId(attached, choices)).toBeNull();
+  });
+});
+
+describe('buildAttachedChoice', () => {
+  it('uses the matched catalog label when provided', () => {
+    const choice = buildAttachedChoice({ policyName: BUILTIN_NAME }, BUILTIN_NAME);
+    expect(choice.label).toBe(`Attached — ${BUILTIN_NAME}`);
+    expect(choice.id).toBe(ATTACHED_POLICY_ID);
+    expect(choice.source).toBe('attached');
+  });
+
+  it('falls back to the attached policyName when unmatched', () => {
+    const choice = buildAttachedChoice({ policyName: 'Custom Name' }, null);
+    expect(choice.label).toBe('Attached — Custom Name');
+  });
+
+  it('falls back to "Custom policy" when there is no name at all', () => {
+    const choice = buildAttachedChoice({ defaultDailyLimits: { total: 3 } }, null);
+    expect(choice.label).toBe('Attached — Custom policy');
+  });
+
+  it('wraps the raw attached policy as its definition', () => {
+    const attached = { defaultDailyLimits: { total: 3 } };
+    expect(buildAttachedChoice(attached, null).definition[POLICY_TYPE_SCHEDULING]).toBe(attached);
+  });
+});
+
+describe('getAttachedSchedulingPolicy', () => {
+  it('returns the policy from the engine', () => {
+    findPolicyMock.mockReturnValue({ policy: { defaultDailyLimits: { total: 3 } } });
+    expect(getAttachedSchedulingPolicy()).toEqual({ defaultDailyLimits: { total: 3 } });
+    expect(findPolicyMock).toHaveBeenCalledWith({ policyType: POLICY_TYPE_SCHEDULING });
+  });
+
+  it('returns null when no policy is attached', () => {
+    findPolicyMock.mockReturnValue({});
+    expect(getAttachedSchedulingPolicy()).toBeNull();
+  });
+
+  it('returns null (never throws) when the engine call throws', () => {
+    findPolicyMock.mockImplementation(() => {
+      throw new Error('engine unavailable');
+    });
+    expect(getAttachedSchedulingPolicy()).toBeNull();
+  });
+});
+
+describe('loadSchedulingChoices', () => {
+  it('returns only scheduling policies from builtins + user policies, stamped', async () => {
+    getBuiltinPoliciesMock.mockReturnValue([
+      builtinItem(),
+      { id: 'builtin-scoring', name: 'Scoring', policyType: 'scoring', source: 'builtin', description: '', policyData: {} },
+    ]);
+    loadUserPoliciesMock.mockResolvedValue([userItem()]);
+
+    const choices = await loadSchedulingChoices();
+
+    expect(choices.map((c) => c.id)).toEqual([BUILTIN_ID, 'user-1']);
+    expect(choices[0].definition[POLICY_TYPE_SCHEDULING].policyName).toBe(BUILTIN_NAME);
+    expect(choices[1].source).toBe('user');
+  });
+
+  it('degrades to builtins when loading user policies rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    getBuiltinPoliciesMock.mockReturnValue([builtinItem()]);
+    loadUserPoliciesMock.mockRejectedValue(new Error('idb blocked'));
+
+    const choices = await loadSchedulingChoices();
+
+    expect(choices.map((c) => c.id)).toEqual([BUILTIN_ID]);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/schedulingPolicyChoices.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedulingPolicyChoices.ts
@@ -1,0 +1,166 @@
+/**
+ * Shared scheduling-policy selection logic for the Apply Times / Apply Grid
+ * modals.
+ *
+ * Three concerns live here so the two modals cannot drift apart:
+ *
+ *  1. Identity stamping — a catalog policy is attached with a `policyName`
+ *     stamped into its data, so the identity travels with the tournamentRecord
+ *     and later re-opens can match it independently of structural drift.
+ *  2. Normalized compare — a stopgap fallback for policies attached before
+ *     identity stamping existed. Tolerates key ordering/formatting but NOT the
+ *     addition/removal of fields (a genuinely different shape stays "Custom").
+ *  3. The "Attached" entry — a first-class, selectable option representing the
+ *     policy already on the tournament, so re-applying it is a clean no-op
+ *     rather than a forced re-attach.
+ *
+ * Creating/editing scheduling policies is out of scope — that lives on the
+ * `/policies` page and persists through `policyBridge`.
+ */
+import { competitionEngine } from 'services/factory/engine';
+import { PolicyCatalogItem } from 'courthive-components';
+
+import { getBuiltinPolicies, loadUserPolicies } from 'pages/policies/policyBridge';
+
+export const POLICY_TYPE_SCHEDULING = 'scheduling';
+/** Sentinel id for the synthetic "Attached" entry (the policy already on the
+ *  tournamentRecord). Selecting it never re-attaches. */
+export const ATTACHED_POLICY_ID = '__attached__';
+
+export type PolicySource = 'builtin' | 'user' | 'attached';
+
+export interface PolicyChoice {
+  id: string;
+  label: string;
+  /** attachPolicies({ policyDefinitions }) input shape: `{ scheduling: {...} }`. */
+  definition: Record<string, any>;
+  source: PolicySource;
+}
+
+/** Identity/volatile keys ignored by the structural compare. `policyName` is
+ *  identity (matched separately); ignoring it here means stamping it onto a
+ *  catalog choice never perturbs the structural fallback. */
+const IGNORED_COMPARE_KEYS = new Set(['policyName']);
+
+function stableStringify(value: any): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .filter((k) => !IGNORED_COMPARE_KEYS.has(k))
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+/** Key-sorted serialization that ignores identity keys — stopgap replacement
+ *  for exact JSON.stringify matching. Two policies that differ only in key
+ *  order (or in `policyName`) compare equal; a different set of fields does not. */
+export function normalizedFingerprint(policy: Record<string, any> | undefined | null): string {
+  if (!policy || typeof policy !== 'object') return '';
+  return stableStringify(policy);
+}
+
+/** The identity token for a catalog item: an explicit `policyName` embedded in
+ *  the data, else the catalog display name. */
+export function choiceIdentity(item: PolicyCatalogItem): string {
+  const embedded = (item.policyData as any)?.policyName;
+  return typeof embedded === 'string' && embedded ? embedded : item.name;
+}
+
+/** attachPolicies definition for a catalog item, with the identity stamped in
+ *  so it travels with the tournamentRecord once attached. */
+export function toDefinition(item: PolicyCatalogItem): Record<string, any> {
+  return { [POLICY_TYPE_SCHEDULING]: { ...item.policyData, policyName: choiceIdentity(item) } };
+}
+
+export function toChoice(item: PolicyCatalogItem): PolicyChoice {
+  return {
+    id: item.id,
+    label: item.name,
+    definition: toDefinition(item),
+    source: item.source === 'builtin' ? 'builtin' : 'user',
+  };
+}
+
+/** The scheduling policy currently attached to the (active) tournament, or null. */
+export function getAttachedSchedulingPolicy(): Record<string, any> | null {
+  try {
+    const result: any = competitionEngine.findPolicy?.({ policyType: POLICY_TYPE_SCHEDULING });
+    return result?.policy ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Load the scheduling policies registered with the `/policies` page: factory
+ *  built-ins plus any user policies persisted to IndexedDB. */
+export async function loadSchedulingChoices(): Promise<PolicyChoice[]> {
+  const builtins = getBuiltinPolicies().filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
+  let userPolicies: PolicyCatalogItem[] = [];
+  try {
+    const all = await loadUserPolicies();
+    userPolicies = all.filter((p) => p.policyType === POLICY_TYPE_SCHEDULING);
+  } catch (err) {
+    console.error('loadUserPolicies failed', err);
+  }
+  return [...builtins.map(toChoice), ...userPolicies.map(toChoice)];
+}
+
+/** Resolve which catalog choice (if any) equals the attached policy. Identity
+ *  (`policyName`) match first; structural normalized compare as fallback. */
+export function resolveAttachedChoiceId(
+  attached: Record<string, any> | null,
+  choices: PolicyChoice[],
+): string | null {
+  if (!attached) return null;
+
+  const attachedName = typeof attached.policyName === 'string' ? attached.policyName : '';
+  if (attachedName) {
+    const byName = choices.find((c) => (c.definition[POLICY_TYPE_SCHEDULING]?.policyName ?? '') === attachedName);
+    if (byName) return byName.id;
+  }
+
+  const attachedFp = normalizedFingerprint(attached);
+  if (!attachedFp) return null;
+  const byShape = choices.find((c) => normalizedFingerprint(c.definition[POLICY_TYPE_SCHEDULING]) === attachedFp);
+  return byShape?.id ?? null;
+}
+
+/** First-class entry for the policy already attached to the tournament.
+ *  `matchedLabel` is the catalog label when the attached policy resolves to a
+ *  known choice, else null (shown as its `policyName` or "Custom policy"). */
+export function buildAttachedChoice(attached: Record<string, any>, matchedLabel: string | null): PolicyChoice {
+  const name =
+    matchedLabel ?? (typeof attached.policyName === 'string' && attached.policyName ? attached.policyName : 'Custom policy');
+  return {
+    id: ATTACHED_POLICY_ID,
+    label: `Attached — ${name}`,
+    definition: { [POLICY_TYPE_SCHEDULING]: attached },
+    source: 'attached',
+  };
+}
+
+/** Append a labelled `<optgroup>` for one source, containing only choices from
+ *  that source. Empty groups are skipped so the select shows no empty header. */
+export function appendChoiceGroup(
+  select: HTMLSelectElement,
+  label: string,
+  choices: PolicyChoice[],
+  source: PolicySource,
+  selectedId: string,
+): void {
+  const filtered = choices.filter((c) => c.source === source);
+  if (!filtered.length) return;
+  const group = document.createElement('optgroup');
+  group.label = label;
+  for (const choice of filtered) {
+    const opt = document.createElement('option');
+    opt.value = choice.id;
+    opt.textContent = choice.label;
+    if (choice.id === selectedId) opt.selected = true;
+    group.appendChild(opt);
+  }
+  select.appendChild(group);
+}

--- a/src/services/dom/toolTip/plugins.test.ts
+++ b/src/services/dom/toolTip/plugins.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Contract for the `dynContent` tippy plugin.
+ *
+ * Two invariants, both load-bearing:
+ *   1. The top-level `name` equals the custom prop name (`dynContent`) — this is
+ *      what makes tippy whitelist the prop (silences the dev-only "not a valid
+ *      prop" warning) AND include it in getExtendedPassedProps.
+ *   2. `onShow` pushes the result of `props.dynContent(reference)` into the
+ *      tooltip via `setContent`, and no-ops when `dynContent` is absent — the
+ *      lazy-content behavior the sidebar tooltips rely on.
+ */
+import { enhancedContentFunction } from './plugins';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('enhancedContentFunction (dynContent plugin)', () => {
+  it('exposes a top-level name matching the custom prop', () => {
+    expect(enhancedContentFunction.name).toBe('dynContent');
+  });
+
+  it('onShow sets content from the dynContent function, passing the reference', () => {
+    const reference = { id: 'ref' };
+    const setContent = vi.fn();
+    const dynContent = vi.fn(() => 'computed');
+    const instance = { props: { dynContent }, reference, setContent };
+
+    enhancedContentFunction.fn(instance).onShow();
+
+    expect(dynContent).toHaveBeenCalledWith(reference);
+    expect(setContent).toHaveBeenCalledWith('computed');
+  });
+
+  it('onShow is a no-op when dynContent is not a function', () => {
+    const setContent = vi.fn();
+    const instance = { props: {}, reference: {}, setContent };
+
+    enhancedContentFunction.fn(instance).onShow();
+
+    expect(setContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/dom/toolTip/plugins.ts
+++ b/src/services/dom/toolTip/plugins.ts
@@ -1,7 +1,19 @@
+/**
+ * tippy.js plugin that lazily computes tooltip content on show via a custom
+ * `dynContent` prop (used by the sidebar navigation tooltips).
+ *
+ * The top-level `name` MUST equal the custom prop name (`dynContent`): tippy's
+ * `validateProps` whitelists a custom prop only when some plugin's top-level
+ * `name` matches it, and `getExtendedPassedProps` reads the top-level
+ * `name`/`defaultValue`. A mismatch (the plugin previously had no top-level
+ * `name`) triggered the dev-only "`dynContent` is not a valid prop" warning.
+ *
+ * The lifecycle object returned by `fn` is dispatched by hook method key
+ * (`onShow`), never by any `name` field on it — so no inner name is needed.
+ */
 export const enhancedContentFunction = {
+  name: 'dynContent',
   fn: (instance: any) => ({
-    name: 'dynamicContent',
-    default: true,
     onShow() {
       if (typeof instance.props.dynContent === 'function') {
         instance.setContent(instance.props.dynContent(instance.reference));

--- a/src/services/publishing/orderOfPlayPublish.test.ts
+++ b/src/services/publishing/orderOfPlayPublish.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Coverage for order-of-play publish state + per-date toggle logic.
+ *
+ * The toggle logic is the load-bearing part (the footer publish control and the
+ * publishing-tab chips both drive mutations from it), so its branches are
+ * exercised directly: publish, unpublish-one-of-many, unpublish-the-last, and
+ * the "all dates published" materialization. `getOrderOfPlayPublishState` reads
+ * the engine, which is mocked.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PUBLISH_ORDER_OF_PLAY, UNPUBLISH_ORDER_OF_PLAY } from 'constants/mutationConstants';
+
+const { publishStateMock } = vi.hoisted(() => ({ publishStateMock: vi.fn() }));
+
+vi.mock('services/factory/engine', () => ({
+  tournamentEngine: { q: { publishState: publishStateMock } },
+}));
+
+import {
+  buildOrderOfPlayDateToggleMethods,
+  getOrderOfPlayPublishState,
+  isOrderOfPlayDatePublished,
+  type OrderOfPlayPublishState,
+} from './orderOfPlayPublish';
+
+const D1 = '2026-07-01';
+const D2 = '2026-07-02';
+const D3 = '2026-07-03';
+const RANGE = [D1, D2, D3];
+
+const state = (over: Partial<OrderOfPlayPublishState> = {}): OrderOfPlayPublishState => ({
+  published: false,
+  allPublished: false,
+  publishedDates: [],
+  ...over,
+});
+
+beforeEach(() => publishStateMock.mockReset());
+afterEach(() => vi.restoreAllMocks());
+
+describe('isOrderOfPlayDatePublished', () => {
+  it('is false when order of play is not published', () => {
+    expect(isOrderOfPlayDatePublished(D1, state())).toBe(false);
+  });
+
+  it('is true for every date when all dates are published', () => {
+    expect(isOrderOfPlayDatePublished('2026-12-31', state({ published: true, allPublished: true }))).toBe(true);
+  });
+
+  it('reflects membership of the published-dates list', () => {
+    const s = state({ published: true, publishedDates: [D1] });
+    expect(isOrderOfPlayDatePublished(D1, s)).toBe(true);
+    expect(isOrderOfPlayDatePublished(D2, s)).toBe(false);
+  });
+});
+
+describe('buildOrderOfPlayDateToggleMethods', () => {
+  it('publishes an unpublished date by adding it to the list (no duplicates)', () => {
+    const s = state({ published: true, publishedDates: [D2] });
+    const { methods, willPublish } = buildOrderOfPlayDateToggleMethods(D1, RANGE, s);
+    expect(willPublish).toBe(true);
+    expect(methods).toEqual([
+      { method: PUBLISH_ORDER_OF_PLAY, params: { scheduledDates: [D2, D1], removePriorValues: true } },
+    ]);
+  });
+
+  it('unpublishes one of several published dates by removing it, keeping the rest', () => {
+    const s = state({ published: true, publishedDates: [D1, D2] });
+    const { methods, willPublish } = buildOrderOfPlayDateToggleMethods(D1, RANGE, s);
+    expect(willPublish).toBe(false);
+    expect(methods).toEqual([
+      { method: PUBLISH_ORDER_OF_PLAY, params: { scheduledDates: [D2], removePriorValues: true } },
+    ]);
+  });
+
+  it('fully unpublishes when removing the last published date', () => {
+    const s = state({ published: true, publishedDates: [D1] });
+    const { methods, willPublish } = buildOrderOfPlayDateToggleMethods(D1, RANGE, s);
+    expect(willPublish).toBe(false);
+    expect(methods).toEqual([{ method: UNPUBLISH_ORDER_OF_PLAY }]);
+  });
+
+  it('materializes the full range (minus the toggled date) when all dates are published', () => {
+    const s = state({ published: true, allPublished: true });
+    const { methods, willPublish } = buildOrderOfPlayDateToggleMethods(D2, RANGE, s);
+    expect(willPublish).toBe(false);
+    expect(methods).toEqual([
+      {
+        method: PUBLISH_ORDER_OF_PLAY,
+        params: { scheduledDates: [D1, D3], removePriorValues: true },
+      },
+    ]);
+  });
+
+  it('unpublishes when the whole (single-date) range is un-toggled', () => {
+    const s = state({ published: true, allPublished: true });
+    const { methods } = buildOrderOfPlayDateToggleMethods(D1, [D1], s);
+    expect(methods).toEqual([{ method: UNPUBLISH_ORDER_OF_PLAY }]);
+  });
+});
+
+describe('getOrderOfPlayPublishState', () => {
+  it('parses a published-with-dates order of play', () => {
+    publishStateMock.mockReturnValue({ tournament: { orderOfPlay: { published: true, scheduledDates: [D1, D2] } } });
+    expect(getOrderOfPlayPublishState()).toEqual({ published: true, allPublished: false, publishedDates: [D1, D2] });
+  });
+
+  it('treats published with no scheduledDates as all-published', () => {
+    publishStateMock.mockReturnValue({ tournament: { orderOfPlay: { published: true } } });
+    expect(getOrderOfPlayPublishState()).toEqual({ published: true, allPublished: true, publishedDates: [] });
+  });
+
+  it('returns an unpublished state when nothing is published', () => {
+    publishStateMock.mockReturnValue({});
+    expect(getOrderOfPlayPublishState()).toEqual({ published: false, allPublished: false, publishedDates: [] });
+  });
+
+  it('tolerates a missing publishState result', () => {
+    publishStateMock.mockReturnValue(undefined);
+    expect(getOrderOfPlayPublishState().published).toBe(false);
+  });
+});

--- a/src/services/publishing/orderOfPlayPublish.ts
+++ b/src/services/publishing/orderOfPlayPublish.ts
@@ -1,0 +1,62 @@
+/**
+ * Order-of-play publish state + per-date toggle logic.
+ *
+ * One home for "is this date's order of play published?" and "what mutation
+ * toggles it?", shared by the schedule page (date selector cue + footer
+ * publish control) and the publishing tab's per-date chips so the two cannot
+ * drift (they previously each inlined the `allDatesPublished` rule).
+ *
+ * DOM-free and engine-injectable so the toggle logic is unit-testable in the
+ * node vitest env.
+ */
+import { PUBLISH_ORDER_OF_PLAY, UNPUBLISH_ORDER_OF_PLAY } from 'constants/mutationConstants';
+import { tournamentEngine } from 'services/factory/engine';
+
+export interface OrderOfPlayPublishState {
+  /** Order of play is published at all. */
+  published: boolean;
+  /** Published with an empty `scheduledDates` list → every date is public. */
+  allPublished: boolean;
+  /** Explicitly-published dates (empty when `allPublished`). */
+  publishedDates: string[];
+}
+
+/** Read the tournament's order-of-play publish status from the engine. */
+export function getOrderOfPlayPublishState(): OrderOfPlayPublishState {
+  const publishState: any = tournamentEngine.q?.publishState?.() ?? {};
+  const oop = publishState?.tournament?.orderOfPlay;
+  const published = !!oop?.published;
+  const scheduledDates: string[] = Array.isArray(oop?.scheduledDates) ? oop.scheduledDates : [];
+  return { published, allPublished: published && scheduledDates.length === 0, publishedDates: scheduledDates };
+}
+
+/** Whether a specific date's order of play is published. */
+export function isOrderOfPlayDatePublished(date: string, state: OrderOfPlayPublishState): boolean {
+  if (!state.published) return false;
+  return state.allPublished || state.publishedDates.includes(date);
+}
+
+/**
+ * Mutation methods that toggle publication of a single order-of-play date,
+ * mirroring the publishing tab's per-date chip logic. `dateRange` materializes
+ * the full published set when the tournament is currently "all dates published"
+ * (empty `scheduledDates`) so removing one date keeps the others public.
+ * Returns `willPublish` so callers can phrase a confirmation dialog.
+ */
+export function buildOrderOfPlayDateToggleMethods(
+  date: string,
+  dateRange: string[],
+  state: OrderOfPlayPublishState,
+): { methods: { method: string; params?: any }[]; willPublish: boolean } {
+  const currentlyPublished = isOrderOfPlayDatePublished(date, state);
+  const effectiveDates = state.allPublished ? [...dateRange] : [...state.publishedDates];
+  const newDates = currentlyPublished
+    ? effectiveDates.filter((d) => d !== date)
+    : [...new Set([...effectiveDates, date])];
+
+  const methods = newDates.length
+    ? [{ method: PUBLISH_ORDER_OF_PLAY, params: { scheduledDates: newDates, removePriorValues: true } }]
+    : [{ method: UNPUBLISH_ORDER_OF_PLAY }];
+
+  return { methods, willPublish: !currentlyPublished };
+}


### PR DESCRIPTION
## Summary

Schedule-page scheduling UX across three areas:

- **fix(scheduling): Apply Times/Grid policy** — pass `allowReplacement` so
  re-applying a different scheduling policy no longer fails with
  `ERR_EXISTING_POLICY_TYPE` when one is already attached. Adds a shared
  `schedulingPolicyChoices` helper (normalized compare, `policyName` identity
  stamping, first-class "Attached" selector entry). Apply Times defaults to the
  attached policy (re-apply is a no-op); Apply Grid keeps its No-policy default.
- **feat(scheduling): order-of-play publish cues + footer toggle** — date
  selector button/popover show a green "published" dot and a "Published" status
  line; the grid footer gains a two-state publish pill that toggles publication
  for the viewed date via a confirm dialog; the grid sidebar defaults to the
  Scheduled tab when the viewed date has scheduled-but-unplaced matchUps. A
  shared `orderOfPlayPublish` helper is reused by the publishing tab's per-date
  chips so the two surfaces cannot diverge.
- **fix(tooltip): tippy `dynContent` plugin** — give the plugin a top-level
  `name` so tippy's `validateProps` stops warning "not a valid prop"; behavior
  unchanged.

## Tests

- Unit: `schedulingPolicyChoices`, `orderOfPlayPublish`, `scheduleDateSelectorLogic`,
  tippy `plugins`. Full TMX suite green (904 tests).
- e2e: journey 78 (footer publish/unpublish toggle) and journey 79 (no tippy
  `dynContent` warning; falsified by reverting the fix).

## ⚠️ Blocked on courthive-components 3.8.0

This branch references `ScheduleDate.isPublished`, added in
CourtHive/courthive-components#465. CI strips the local `link:` override and
installs published `courthive-components@3.7.0`, so **check-types will be red
until** cc 3.8.0 ships and this PR bumps the `courthive-components` pin
(`3.7.0` → `3.8.0`). Draft until then.
