### PR TITLE
fix(entries): manual seeding for CONFIRMED entries + keep seeding controls visible

### DIFF
--- a/src/components/tables/eventsTable/seeding/canceManuallSeeding.ts
+++ b/src/components/tables/eventsTable/seeding/canceManuallSeeding.ts
@@ -5,8 +5,12 @@ import { removeSeeding } from './removeSeeding';
 
 import { RIGHT } from 'constants/tmxConstants';
 
-const { DIRECT_ACCEPTANCE } = entryStatusConstants;
+const { STRUCTURE_SELECTED_STATUSES } = entryStatusConstants;
 const { QUALIFYING } = drawDefinitionConstants;
+
+// Aligned with the factory's STRUCTURE_SELECTED_STATUSES so seed values are
+// restored for all accepted statuses (e.g. CONFIRMED), not only DIRECT_ACCEPTANCE
+const ACCEPTED_STATUSES = new Set(STRUCTURE_SELECTED_STATUSES);
 
 const getSeedNumber = (participant: any, eventType: string, scaleName: string) => {
   const seedings = participant?.seedings?.[eventType];
@@ -15,19 +19,13 @@ const getSeedNumber = (participant: any, eventType: string, scaleName: string) =
   return scaleItem?.scaleValue;
 };
 
-const onCancelManualSeedingClick = (
-  e: any,
-  table: any,
-  eventId: string,
-  DIRECT_ACCEPTANCE: string,
-  QUALIFYING: string,
-) => {
+const onCancelManualSeedingClick = (e: any, table: any, eventId: string) => {
   hideSaveSeeding(e, table);
   const entryStage = removeSeeding({ table });
   const event = tournamentEngine.q.event({ eventId });
   if (!event) return;
   const entries = (event.entries ?? []).filter(
-    (entry: any) => entry.entryStage === entryStage && entry.entryStatus === DIRECT_ACCEPTANCE,
+    (entry: any) => entry.entryStage === entryStage && ACCEPTED_STATUSES.has(entry.entryStatus),
   );
   const participantIds = entries.map(({ participantId }: any) => participantId);
   const { participants = [] } = tournamentEngine.getParticipants({
@@ -63,7 +61,7 @@ export const cancelManualSeeding =
   (table: any): any => {
     const eventId = event?.eventId;
 
-    const onClick = (e: any) => onCancelManualSeedingClick(e, table, eventId, DIRECT_ACCEPTANCE, QUALIFYING);
+    const onClick = (e: any) => onCancelManualSeedingClick(e, table, eventId);
 
     return {
       class: 'cancelManualSeeding',

--- a/src/components/tables/eventsTable/seeding/enableManualSeeding.ts
+++ b/src/components/tables/eventsTable/seeding/enableManualSeeding.ts
@@ -6,6 +6,9 @@ import { NONE } from 'constants/tmxConstants';
 const SEEDING_BUTTON_CLASSES = ['saveSeeding', 'cancelManualSeeding'];
 
 export function enableManualSeeding(e: any, table: any): void {
+  // Clear any selection first — the controlBar shows selection overlay actions
+  // instead of the right-side items (Save/Cancel seeding) while rows are selected
+  table.deselectRow();
   setSeedingEnabled(table, true);
 
   const optionsRight = findAncestor(e.target, 'options_right');

--- a/src/components/tables/eventsTable/unified/createUnifiedEntriesPanel.ts
+++ b/src/components/tables/eventsTable/unified/createUnifiedEntriesPanel.ts
@@ -5,6 +5,7 @@
  */
 import { drawDefinitionConstants, entryStatusConstants, eventConstants } from 'tods-competition-factory';
 import { segmentRank, SEGMENT_LABELS, handleHeaderClick } from './segmentSorter';
+import { isSeedingEnabled } from '../seeding/seedingState';
 import { editAvoidances } from 'components/drawers/avoidances/editAvoidances';
 import { headerSortElement } from '../../common/sorters/headerSortElement';
 import { addFlights } from 'components/modals/addFlights/addFlights';
@@ -293,7 +294,12 @@ export function createUnifiedEntriesPanel({
     // with a stale click listener; selecting it crashes _selectRow at
     // `row.getElement().classList.add`. This is the same gate Tabulator's
     // toggleRow consults, so failing it here prevents that crash entirely.
-    selectableRowsCheck: (row: any) => !!row.getElement() && !row.getData()._isSeparator,
+    //
+    // Selection is also suspended during manual seeding: clicking a seed cell
+    // would otherwise also select the row, and the controlBar swaps to selection
+    // overlay actions — hiding the Save/Cancel seeding buttons.
+    selectableRowsCheck: (row: any) =>
+      !!row.getElement() && !row.getData()._isSeparator && !isSeedingEnabled(table),
     columns,
     responsiveLayout: 'collapse',
     index: 'participantId',

--- a/src/components/tables/eventsTable/unified/segmentSorter.test.ts
+++ b/src/components/tables/eventsTable/unified/segmentSorter.test.ts
@@ -1,0 +1,46 @@
+import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-factory';
+import { segmentRank, SEGMENT_LABELS } from './segmentSorter';
+import { describe, expect, it } from 'vitest';
+
+const { QUALIFYING, MAIN } = drawDefinitionConstants;
+const {
+  STRUCTURE_SELECTED_STATUSES,
+  DIRECT_ACCEPTANCE,
+  CONFIRMED,
+  ALTERNATE,
+  UNGROUPED,
+  WITHDRAWN,
+  REGISTERED,
+} = entryStatusConstants;
+
+describe('segmentRank', () => {
+  it('ranks every STRUCTURE_SELECTED_STATUS as accepted', () => {
+    for (const status of STRUCTURE_SELECTED_STATUSES) {
+      expect(segmentRank(MAIN, status)).toBe(0);
+      expect(segmentRank(QUALIFYING, status)).toBe(1);
+    }
+  });
+
+  it('ranks CONFIRMED entries as accepted, keeping them seedable', () => {
+    // regression: CONFIRMED previously fell through to rank 5 ("?"),
+    // which disabled the manual seeding editor for those rows
+    expect(segmentRank(MAIN, CONFIRMED)).toBe(0);
+    expect(SEGMENT_LABELS[segmentRank(MAIN, CONFIRMED)]).toBe('Accepted');
+  });
+
+  it('ranks non-accepted statuses in display order', () => {
+    expect(segmentRank(MAIN, ALTERNATE)).toBe(2);
+    expect(segmentRank(MAIN, UNGROUPED)).toBe(3);
+    expect(segmentRank(MAIN, WITHDRAWN)).toBe(4);
+  });
+
+  it('ranks unknown statuses last', () => {
+    expect(segmentRank(MAIN, REGISTERED)).toBe(5);
+    expect(segmentRank(MAIN, 'NOT_A_STATUS')).toBe(5);
+  });
+
+  it('does not treat non-accepted statuses as qualifying at QUALIFYING stage', () => {
+    expect(segmentRank(QUALIFYING, ALTERNATE)).toBe(2);
+    expect(segmentRank(QUALIFYING, DIRECT_ACCEPTANCE)).toBe(1);
+  });
+});

--- a/src/components/tables/eventsTable/unified/segmentSorter.ts
+++ b/src/components/tables/eventsTable/unified/segmentSorter.ts
@@ -6,10 +6,11 @@
 import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-factory';
 
 const { QUALIFYING } = drawDefinitionConstants;
-const { DIRECT_ACCEPTANCE, ORGANISER_ACCEPTANCE, SPECIAL_EXEMPT, JUNIOR_EXEMPT, WILDCARD, ALTERNATE, UNGROUPED, WITHDRAWN } =
-  entryStatusConstants;
+const { STRUCTURE_SELECTED_STATUSES, ALTERNATE, UNGROUPED, WITHDRAWN } = entryStatusConstants;
 
-const ACCEPTED_STATUSES = new Set([DIRECT_ACCEPTANCE, ORGANISER_ACCEPTANCE, SPECIAL_EXEMPT, JUNIOR_EXEMPT, WILDCARD]);
+// Aligned with the factory's STRUCTURE_SELECTED_STATUSES so statuses like
+// CONFIRMED, LUCKY_LOSER and QUALIFIER rank as accepted (and stay seedable)
+const ACCEPTED_STATUSES = new Set(STRUCTURE_SELECTED_STATUSES);
 
 export function segmentRank(entryStage: string, entryStatus: string): number {
   if (entryStage === QUALIFYING && ACCEPTED_STATUSES.has(entryStatus)) return 1;


### PR DESCRIPTION
## Problem

Two related issues in the unified entries table's manual seeding flow:

1. **Entries with `CONFIRMED` status cannot be manually seeded.** `segmentSorter.ts` builds its accepted-status set from a hand-rolled 5-status list (`DIRECT_ACCEPTANCE`, `ORGANISER_ACCEPTANCE`, `SPECIAL_EXEMPT`, `JUNIOR_EXEMPT`, `WILDCARD`). Statuses the factory considers selected — `CONFIRMED`, `LUCKY_LOSER`, `QUALIFIER` — fall through to segment rank 5, rendering the red `?` badge, and the `seedNumber` column's `editable` gate (`_segmentRank <= 1`) rejects them, so no editor appears when clicking the seed cell. Doubles pairs created in TMX get `DIRECT_ACCEPTANCE` and are unaffected, but entries confirmed via external signup/import flows can't be seeded at all.

2. **Entering seed numbers hides the Save/Cancel seeding buttons.** With `selectableRows: true`, clicking a seed cell to type a value also toggles row selection. The controlBar then swaps to selection overlay actions, hiding the right-side items — including *Save seeding* / *Cancel* — and selections accumulate with every cell edited.

## Fix

- `segmentSorter.ts`: build `ACCEPTED_STATUSES` from the factory's `STRUCTURE_SELECTED_STATUSES` (same alignment as `constants/acceptedEntryStatuses.ts`, which fixed this list once before).
- `canceManuallSeeding.ts`: restore persisted seed values for all accepted statuses instead of only `DIRECT_ACCEPTANCE`.
- `createUnifiedEntriesPanel.ts`: suspend row selection while manual seeding is active (re-enabled on save/cancel); `enableManualSeeding` clears any existing selection so the seeding buttons are always visible.

## Testing

- New unit tests for `segmentRank` covering every `STRUCTURE_SELECTED_STATUSES` member at MAIN and QUALIFYING stages, plus the non-accepted and unknown ranks.
- `TZ=UTC vitest`: full suite passes; `tsc --noEmit` clean.
- Verified in a deployed environment: CONFIRMED singles entries now show the seed editor with the *Accepted* badge, and Save/Cancel seeding remain visible while entering values.