### PR TITLE
fix(session): re-login banner instead of "server not responding" on expiry

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -780,6 +780,10 @@
     "acceptrankings": "Accept Rankings",
     "reglink": "Set Link"
   },
+  "session": {
+    "expiredMessage": "Your session has expired. Changes will not be saved until you log in again.",
+    "logInAgain": "Log in again"
+  },
   "schedule": {
     "column": "Column",
     "rows": "Schedule Rows",

--- a/src/initialState.ts
+++ b/src/initialState.ts
@@ -11,6 +11,7 @@ import { factoryConstants, globalState } from 'tods-competition-factory';
 import { initTheme, initThemeToggle } from 'services/theme/themeService';
 import { loadUserCompositions } from 'pages/templates/compositionBridge';
 import { initStalenessGuard } from 'services/staleness/stalenessGuard';
+import { initSessionGuard } from 'services/session/sessionGuard';
 import { initTmxVersionCheck } from 'services/version/checkTmxVersion';
 import { initLoginToggle } from 'services/authentication/loginState';
 import { ensureLocaleCurrent, getCachedLocale, i18next } from 'i18n';
@@ -169,6 +170,7 @@ function tmxReady(): void {
   registerMenuHandler();
   initRemoteMutationHandler();
   initStalenessGuard();
+  initSessionGuard();
   initTmxVersionCheck();
   // Populate the user-composition cache so resolveCompositionByName() can
   // find custom compositions on the first draw render. Fire-and-forget;

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -2,6 +2,7 @@ import { getToken, removeToken, setToken, getRefreshToken, setRefreshToken, remo
 import { renderSettingsTab } from 'pages/tournament/tabs/settingsTab/renderSettingsTab';
 import { renderOverview } from 'pages/tournament/tabs/overviewTab/renderOverview';
 import { initProviderSwitcher } from 'services/provider/initProviderSwitcher';
+import { notifySessionRecovered } from 'services/session/sessionGuard';
 import { setupChatIndicator } from 'navigation';
 import { resetActivityTimer } from 'services/staleness/stalenessGuard';
 import { clearUserContext, fetchUserContext } from './getUserContext';
@@ -150,6 +151,11 @@ export function logIn({
     // Reveal the chat indicator now that a server session exists (the nav may
     // have first rendered logged-out / with an expired token).
     setupChatIndicator();
+    // Clear any session-expiry banner and replay edits that were preserved
+    // while the session was lost. No-op on a first/fresh login (nothing
+    // pending, no banner) — the guard's own silent-refresh path covers the
+    // automatic case.
+    notifySessionRecovered();
     if (isFunction(callback)) {
       callback();
     } else if (!tournamentInState) {

--- a/src/services/messaging/socketIo.ts
+++ b/src/services/messaging/socketIo.ts
@@ -4,6 +4,7 @@
  */
 import { checkFactoryVersion, resetFactoryVersionCheck } from 'services/version/checkFactoryVersion';
 import { showOSNotification } from 'services/notifications/osNotification';
+import { handleSocketException } from 'services/session/sessionGuard';
 import { getLoginState } from 'services/authentication/loginState';
 import { getToken } from 'services/authentication/tokenManagement';
 import { processDirective } from 'services/processDirective';
@@ -106,6 +107,15 @@ function handleTournamentMutation(data: any): void {
 
 export function connectSocket(callback?: () => void): void {
   const connectionOptions: any = {
+    // `auth` is a function so socket.io-client re-invokes it before every
+    // (re)connect, always presenting the *current* token. The server's
+    // SocketGuard prefers handshake.auth.token over the Authorization header
+    // precisely because the header is baked in at initial connect and goes
+    // stale on the first reconnect after a token refresh — which is what left
+    // an expired-then-refreshed /tmx session silently rejected on every
+    // executionQueue (the /hiveid socket clients got this fix on 2026-06-01;
+    // /tmx did not until now). extraHeaders is kept for the polling handshake.
+    auth: (cb: (data: { token?: string }) => void) => cb({ token: getToken() ?? undefined }),
     transportOptions: { polling: { extraHeaders: getAuthorization() } },
     'force new connection': true,
     reconnectionDelay: 1000,
@@ -146,7 +156,14 @@ export function connectSocket(callback?: () => void): void {
       showOSNotification({ title: 'TMX', body: 'Server connection lost' });
     });
     oi.socket.on('exception', (data: any) => {
-      console.warn('[socket] server exception:', data);
+      // The server's SocketGuard emits `exception` when it rejects a message —
+      // most commonly for an expired/absent/wrong-audience token. Route those
+      // to the session guard so the user gets a "log in again" banner and their
+      // edit is preserved, instead of the message silently dying and surfacing
+      // 10s later as a misleading "Server not responding". Non-auth exceptions
+      // still surface here rather than being swallowed (A2).
+      const handledAsAuth = handleSocketException(data);
+      if (!handledAsAuth) console.warn('[socket] server exception:', data);
     });
     oi.socket.on('timestamp', (data: any) => (oi.timestampOffset = Date.now() - data.timestamp));
     oi.socket.on('connect_error', (data: any) => {
@@ -165,6 +182,22 @@ export function disconnectSocket(): void {
   slog('[socket] disconnectSocket called');
   oi?.socket?.disconnect();
   setTimeout(() => delete oi.socket, 1000);
+}
+
+/**
+ * Force a fresh handshake so the `auth` callback re-presents the current token.
+ * Used after a silent refresh / re-login to shed a socket that is still holding
+ * a stale (now-expired) token. Reconnecting fires `connectionEvent`, which — on
+ * a post-drop reconnect — runs the registered reconnect listeners (the session
+ * guard replays any preserved edits there).
+ */
+export function reconnectSocket(): void {
+  if (oi.socket) {
+    oi.socket.disconnect();
+    oi.socket.connect();
+  } else {
+    connectSocket();
+  }
 }
 
 /**

--- a/src/services/mutation/mutationRequest.ts
+++ b/src/services/mutation/mutationRequest.ts
@@ -3,6 +3,7 @@
  * Handles tournament modifications with authentication and permission checks.
  */
 import { getUserContext, ensureUserContext } from 'services/authentication/getUserContext';
+import { isSessionValid, reportSessionLost } from 'services/session/sessionGuard';
 import { isStale, resetActivityTimer } from 'services/staleness/stalenessGuard';
 import { getLoginState, styleLogin } from 'services/authentication/loginState';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
@@ -291,6 +292,19 @@ async function makeMutation({
       setTimeout(() => {
         if (ackReceived) return;
         timedOut = true;
+        // Distinguish an auth failure from a genuine outage. A logged-out /
+        // expired session produces the same "no ack" symptom as a down server,
+        // but the fix is completely different: the user must log in again, and
+        // the tournament they're looking at (loaded from IndexedDB) is fine.
+        // Preserve the edit and replay it once the session is restored, rather
+        // than dropping it and blaming the server.
+        if (!isSessionValid()) {
+          reportSessionLost({
+            source: 'mutation-timeout',
+            retry: () => replayServerMutation({ methods, factoryEngine, tournamentIds, saveLocal }),
+          });
+          return completion({ error: { message: 'Session expired', code: 'SESSION_EXPIRED' } });
+        }
         tmxToast({ message: t('toasts.serverNotResponding'), intent: 'is-danger' });
         completion({ error: { message: 'Server not responding' } });
       }, serverConfig.get().serverTimeout ?? 10000);
@@ -298,6 +312,42 @@ async function makeMutation({
   }
 
   if (strategy === LOCAL_FIRST) return completion(factoryResult);
+}
+
+/**
+ * Re-issue a server-first mutation that was preserved when the session expired.
+ * Self-contained: it re-emits the executionQueue and, on a successful ack,
+ * applies the methods locally and saves — WITHOUT re-invoking the original
+ * caller's completion/callback (that already resolved with SESSION_EXPIRED so
+ * the UI could move on). The session guard invokes this after the session is
+ * restored and the socket has reconnected with a fresh token, so the user's
+ * edit lands instead of being lost. Mirrors the ack-success branch of
+ * makeMutation minus the completion call.
+ */
+export function replayServerMutation({
+  methods,
+  factoryEngine,
+  tournamentIds,
+  saveLocal,
+}: {
+  methods: any[];
+  factoryEngine: any;
+  tournamentIds: string[];
+  saveLocal?: boolean;
+}): void {
+  const ackCallback = (ack: any) => {
+    const missingTournament = ack?.error?.code === 'ERR_MISSING_TOURNAMENT';
+    if (!serverConfig.get().serverFirst || !(ack?.success || missingTournament)) return;
+    const serverMethods = Array.isArray(ack?.appliedServerMethods) ? ack.appliedServerMethods : [];
+    const methodsToApply = serverMethods.length ? [...methods, ...serverMethods] : methods;
+    const result = engineExecution({ factoryEngine, methods: methodsToApply });
+    if (result.error) return;
+    void localSave(saveLocal || missingTournament);
+  };
+  emitTmx({
+    data: { type: 'executionQueue', payload: { methods, tournamentIds, rollbackOnError: true } },
+    ackCallback,
+  });
 }
 
 // Provider mutation gating lives at constants/mutationPermissions.ts

--- a/src/services/session/sessionGuard.test.ts
+++ b/src/services/session/sessionGuard.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getLoginState: vi.fn(),
+  attemptSilentRefresh: vi.fn(),
+  getToken: vi.fn(),
+  getRefreshToken: vi.fn(),
+  reconnectSocket: vi.fn(),
+  onSocketReconnect: vi.fn(),
+  loginModal: vi.fn(),
+  buildInlineNotice: vi.fn(() => ({ id: '', remove: vi.fn() })),
+  getTournament: vi.fn(() => ({ tournamentRecord: { parentOrganisation: { organisationId: 'prov-1' } } })),
+  reconnectListeners: [] as Array<() => void>,
+}));
+
+vi.mock('services/authentication/loginState', () => ({
+  getLoginState: h.getLoginState,
+  attemptSilentRefresh: h.attemptSilentRefresh,
+}));
+vi.mock('services/authentication/tokenManagement', () => ({
+  getToken: h.getToken,
+  getRefreshToken: h.getRefreshToken,
+}));
+vi.mock('services/messaging/socketIo', () => ({
+  reconnectSocket: h.reconnectSocket,
+  onSocketReconnect: h.onSocketReconnect,
+}));
+vi.mock('components/notices/inlineNotice', () => ({ buildInlineNotice: h.buildInlineNotice }));
+vi.mock('components/modals/loginModal', () => ({ loginModal: h.loginModal }));
+vi.mock('services/factory/engine', () => ({ tournamentEngine: { getTournament: h.getTournament } }));
+vi.mock('i18n', () => ({ t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key }));
+
+import {
+  isSessionValid,
+  reportSessionLost,
+  handleSocketException,
+  notifySessionRecovered,
+  isSessionBannerVisible,
+  initSessionGuard,
+  __resetSessionGuardForTest,
+} from './sessionGuard';
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.reconnectListeners = [];
+  h.onSocketReconnect.mockImplementation((l: () => void) => h.reconnectListeners.push(l));
+  // Default: a valid session, provider work loaded, refresh token available.
+  h.getLoginState.mockReturnValue({ email: 'user@x.com', exp: 9_999_999_999 });
+  h.getToken.mockReturnValue('access-token');
+  h.getRefreshToken.mockReturnValue('refresh-token');
+  h.attemptSilentRefresh.mockResolvedValue(true);
+  __resetSessionGuardForTest();
+});
+
+afterEach(() => {
+  __resetSessionGuardForTest();
+});
+
+describe('isSessionValid', () => {
+  it('mirrors getLoginState', () => {
+    h.getLoginState.mockReturnValue({ email: 'a' });
+    expect(isSessionValid()).toBe(true);
+    h.getLoginState.mockReturnValue(undefined);
+    expect(isSessionValid()).toBe(false);
+  });
+});
+
+describe('handleSocketException — auth classification', () => {
+  it('treats a token/expiry/unauthorized message as auth and shows the banner', () => {
+    h.getLoginState.mockReturnValue(undefined);
+    expect(handleSocketException({ message: 'Not logged in or token expired' })).toBe(true);
+    expect(isSessionBannerVisible()).toBe(true);
+  });
+
+  it('recognizes an audience rejection', () => {
+    h.getLoginState.mockReturnValue(undefined);
+    expect(handleSocketException({ message: 'Token audience not accepted on this namespace' })).toBe(true);
+  });
+
+  it('does NOT treat an unrelated exception as auth (no banner)', () => {
+    expect(handleSocketException({ message: 'Draw generation failed' })).toBe(false);
+    expect(isSessionBannerVisible()).toBe(false);
+  });
+
+  it('accepts a bare string payload', () => {
+    h.getLoginState.mockReturnValue(undefined);
+    expect(handleSocketException('jwt malformed')).toBe(true);
+  });
+});
+
+describe('reportSessionLost — recovery + edit preservation', () => {
+  it('shows the banner and attempts silent refresh, then reconnects on success', async () => {
+    h.getLoginState.mockReturnValue(undefined);
+    reportSessionLost({ source: 'test' });
+    expect(isSessionBannerVisible()).toBe(true);
+    await flush();
+    expect(h.attemptSilentRefresh).toHaveBeenCalledTimes(1);
+    // Refresh succeeded → banner cleared + fresh-token reconnect forced.
+    expect(h.reconnectSocket).toHaveBeenCalledTimes(1);
+    expect(isSessionBannerVisible()).toBe(false);
+  });
+
+  it('keeps the banner up when silent refresh fails (no reconnect)', async () => {
+    h.getLoginState.mockReturnValue(undefined);
+    h.attemptSilentRefresh.mockResolvedValue(false);
+    reportSessionLost({ source: 'test' });
+    await flush();
+    expect(h.reconnectSocket).not.toHaveBeenCalled();
+    expect(isSessionBannerVisible()).toBe(true);
+  });
+
+  it('coalesces concurrent reports into a single recovery attempt', async () => {
+    h.getLoginState.mockReturnValue(undefined);
+    h.attemptSilentRefresh.mockReturnValue(new Promise(() => {})); // never resolves
+    reportSessionLost({ source: 'a' });
+    reportSessionLost({ source: 'b' });
+    reportSessionLost({ source: 'c' });
+    await flush();
+    expect(h.attemptSilentRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the retry and replays it on the next socket reconnect', () => {
+    initSessionGuard();
+    h.getLoginState.mockReturnValue(undefined);
+    h.attemptSilentRefresh.mockResolvedValue(false); // don't auto-recover in this test
+    const retry = vi.fn();
+    reportSessionLost({ source: 'mutation', retry });
+    expect(retry).not.toHaveBeenCalled();
+    // Simulate the socket coming back — the flush listener registered at init runs.
+    expect(h.reconnectListeners.length).toBe(1);
+    h.reconnectListeners[0]();
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains each preserved retry only once', () => {
+    initSessionGuard();
+    h.getLoginState.mockReturnValue(undefined);
+    h.attemptSilentRefresh.mockResolvedValue(false);
+    const retry = vi.fn();
+    reportSessionLost({ source: 'mutation', retry });
+    h.reconnectListeners[0]();
+    h.reconnectListeners[0]();
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('notifySessionRecovered', () => {
+  it('hides the banner and forces a fresh-token reconnect', () => {
+    h.getLoginState.mockReturnValue(undefined);
+    handleSocketException('token expired');
+    expect(isSessionBannerVisible()).toBe(true);
+    notifySessionRecovered();
+    expect(isSessionBannerVisible()).toBe(false);
+    expect(h.reconnectSocket).toHaveBeenCalled();
+  });
+});
+
+describe('proactive watcher', () => {
+  it('banners stranded provider work that cannot silently recover', () => {
+    vi.useFakeTimers();
+    try {
+      initSessionGuard();
+      // Session invalid, provider work loaded, and NO refresh token → unrecoverable.
+      h.getLoginState.mockReturnValue(undefined);
+      h.getRefreshToken.mockReturnValue(null);
+      h.attemptSilentRefresh.mockResolvedValue(false);
+      vi.advanceTimersByTime(30_000);
+      expect(isSessionBannerVisible()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT banner when a refresh token is still available (recovery in flight)', () => {
+    vi.useFakeTimers();
+    try {
+      initSessionGuard();
+      h.getLoginState.mockReturnValue(undefined);
+      h.getRefreshToken.mockReturnValue('refresh-token'); // silent refresh can still recover
+      vi.advanceTimersByTime(30_000);
+      expect(isSessionBannerVisible()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT banner when no provider work is loaded (e.g. deliberate logout)', () => {
+    vi.useFakeTimers();
+    try {
+      initSessionGuard();
+      h.getLoginState.mockReturnValue(undefined);
+      h.getRefreshToken.mockReturnValue(null);
+      h.getTournament.mockReturnValue({ tournamentRecord: undefined } as any); // no provider tournament
+      vi.advanceTimersByTime(30_000);
+      expect(isSessionBannerVisible()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/services/session/sessionGuard.ts
+++ b/src/services/session/sessionGuard.ts
@@ -1,0 +1,281 @@
+/**
+ * Session guard — turns a silent, expired-session failure into a clear,
+ * recoverable UX.
+ *
+ * The bug this closes: a user whose access token expires while a
+ * provider-bound tournament is still on screen (loaded from IndexedDB) used to
+ * get a misleading "Server not responding" toast when a save failed — implying
+ * our infrastructure was down — with no indication they needed to log back in,
+ * and the edit was silently dropped. The socket also kept presenting the stale
+ * token after a refresh, so nothing they did would save.
+ *
+ * Responsibilities:
+ *  - Surface a persistent, theme-aware banner the moment the session is known
+ *    to be lost (server auth rejection, mutation auth failure, or a proactive
+ *    expiry check) — never a "server down" message for an auth problem.
+ *  - Attempt automatic recovery (silent refresh + fresh-token socket reconnect)
+ *    before asking the user to do anything.
+ *  - Preserve the in-flight edit and replay it once the session is restored, so
+ *    the user does not lose work.
+ *
+ * All auth-state reads go through loginState/tokenManagement; the socket is the
+ * only transport touched. No factory mutation happens here — callers hand us a
+ * self-contained replay thunk, so this module never needs to know what an edit
+ * does (and there is no import cycle through mutationRequest).
+ */
+import { getToken, getRefreshToken } from 'services/authentication/tokenManagement';
+import { getLoginState, attemptSilentRefresh } from 'services/authentication/loginState';
+import { reconnectSocket, onSocketReconnect } from 'services/messaging/socketIo';
+import { buildInlineNotice } from 'components/notices/inlineNotice';
+import { tournamentEngine } from 'services/factory/engine';
+import { t } from 'i18n';
+
+const MOUNT_ID = 'navMain';
+const BANNER_ID = 'session-expiry-banner';
+const MAX_PENDING_RETRIES = 25;
+const PROACTIVE_INTERVAL_MS = 30_000;
+
+/** Replay thunks for edits that failed while the session was lost. Flushed on
+ * the next successful socket reconnect (see `initSessionGuard`). */
+const pendingRetries: Array<() => void> = [];
+
+let bannerEl: HTMLElement | undefined;
+/** Banner visibility tracked independently of the DOM node so the flow is
+ * unit-testable in a node (no-DOM) environment; the node is created lazily only
+ * when a document is present. */
+let bannerVisible = false;
+/** Coalesce concurrent recovery attempts — many rejected messages can arrive
+ * in a burst; we only run one silent-refresh/reconnect cycle at a time. */
+let recovering = false;
+let proactiveTimer: ReturnType<typeof setInterval> | undefined;
+
+// ── Observability (architectural-standards A2: fail-soft must surface) ──
+let authFailureCount = 0;
+let sawFailureSinceRecovery = false;
+
+function noteAuthFailure(source: string): void {
+  authFailureCount += 1;
+  sawFailureSinceRecovery = true;
+  // First failure loud; then powers-of-ten; then every 50th. Avoids spamming a
+  // line per rejected message during a burst while never going fully silent.
+  const milestone =
+    authFailureCount === 1 ||
+    authFailureCount === 10 ||
+    authFailureCount === 100 ||
+    authFailureCount === 1000 ||
+    authFailureCount % 50 === 0;
+  if (milestone) {
+    console.warn(`[sessionGuard] auth failure #${authFailureCount} (source: ${source}) — session lost`);
+  }
+}
+
+function noteRecovery(): void {
+  if (sawFailureSinceRecovery) {
+    console.warn(`[sessionGuard] session recovered after ${authFailureCount} auth failure(s)`);
+    sawFailureSinceRecovery = false;
+  }
+}
+
+// ── Session-state predicates ──
+
+/** A valid, unexpired access token is present. */
+export function isSessionValid(): boolean {
+  return !!getLoginState();
+}
+
+/** The engine currently holds a provider-bound tournament — i.e. the user has
+ * real, server-backed work loaded that a lost session would strand. Local-only
+ * scratch tournaments (no parentOrganisation) are excluded, so a deliberate
+ * logout to the tournaments list never triggers the banner. */
+function hasProviderWorkLoaded(): boolean {
+  try {
+    return !!tournamentEngine.getTournament().tournamentRecord?.parentOrganisation?.organisationId;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the session is invalid AND cannot silently recover on its own
+ * (no token at all, or an expired token with no refresh token to exchange). */
+function isUnrecoverable(): boolean {
+  if (isSessionValid()) return false;
+  const hasRefresh = !!getRefreshToken();
+  const hasAccess = !!getToken();
+  // A refresh token present means validateToken() has already kicked off a
+  // silent refresh — give it a chance rather than bannering mid-exchange.
+  return !hasRefresh || !hasAccess;
+}
+
+// ── Banner ──
+
+function mountBanner(el: HTMLElement): void {
+  const anchor = document.getElementById(MOUNT_ID);
+  const parent = anchor?.parentNode ?? document.body;
+  if (anchor?.parentNode) parent.insertBefore(el, anchor);
+  else parent.appendChild(el);
+}
+
+function showBanner(): void {
+  if (bannerVisible) return;
+  bannerVisible = true;
+  if (typeof document === 'undefined') return;
+  bannerEl = buildInlineNotice({
+    intent: 'danger',
+    message: t('session.expiredMessage', {
+      defaultValue: 'Your session has expired. Changes will not be saved until you log in again.',
+    }),
+    action: {
+      label: t('session.logInAgain', { defaultValue: 'Log in again' }),
+      // Lazy-load the login modal only on click — keeps courthive-components (a
+      // DOM-touching module) out of this guard's static import graph so it stays
+      // node-testable and cheap to load at boot.
+      onClick: () => void import('components/modals/loginModal').then((m) => m.loginModal()),
+    },
+  });
+  bannerEl.id = BANNER_ID;
+  mountBanner(bannerEl);
+}
+
+function hideBanner(): void {
+  bannerVisible = false;
+  bannerEl?.remove();
+  bannerEl = undefined;
+}
+
+/** Test/inspection helper: is the session-expiry banner currently shown? */
+export function isSessionBannerVisible(): boolean {
+  return bannerVisible;
+}
+
+// ── Recovery ──
+
+function flushPendingRetries(): void {
+  if (!pendingRetries.length) return;
+  const batch = pendingRetries.splice(0, pendingRetries.length);
+  for (const retry of batch) {
+    try {
+      retry();
+    } catch (err) {
+      console.error('[sessionGuard] pending mutation replay failed', err);
+    }
+  }
+}
+
+/** Attempt to restore the session without user interaction: exchange the
+ * refresh token, then force a fresh-token socket reconnect (which fires the
+ * reconnect listener that flushes preserved edits). Coalesced. */
+async function attemptRecovery(): Promise<void> {
+  if (recovering) return;
+  recovering = true;
+  try {
+    if (isSessionValid()) {
+      onRecovered();
+      return;
+    }
+    const refreshed = await attemptSilentRefresh();
+    if (refreshed) {
+      onRecovered();
+    }
+    // On failure, attemptSilentRefresh() has already logged out; the banner
+    // stays up and its "Log in again" action drives manual recovery.
+  } finally {
+    recovering = false;
+  }
+}
+
+function onRecovered(): void {
+  noteRecovery();
+  hideBanner();
+  // Present the fresh token on the wire and replay preserved edits once the
+  // socket is back (the reconnect listener registered in initSessionGuard runs
+  // flushPendingRetries).
+  reconnectSocket();
+}
+
+// ── Public entry points ──
+
+/**
+ * Report that the session is (or may be) lost. Idempotent and safe to call
+ * repeatedly during a burst of rejected messages. Optionally accepts a
+ * self-contained `retry` thunk that re-issues the failed edit; it is preserved
+ * and replayed after the session is restored.
+ */
+export function reportSessionLost(opts?: { retry?: () => void; source?: string }): void {
+  noteAuthFailure(opts?.source ?? 'unknown');
+  if (opts?.retry) {
+    pendingRetries.push(opts.retry);
+    // Cap the buffer so a wedged session can't grow it without bound.
+    if (pendingRetries.length > MAX_PENDING_RETRIES) pendingRetries.shift();
+  }
+  showBanner();
+  void attemptRecovery();
+}
+
+/**
+ * Classify a raw socket `exception` payload and, when it is an authentication
+ * failure, drive the session-lost flow. Non-auth exceptions are returned as
+ * `false` so the caller can handle them (e.g. log) without triggering the
+ * banner.
+ */
+export function handleSocketException(payload: any): boolean {
+  const message = typeof payload === 'string' ? payload : (payload?.message ?? payload?.name ?? '');
+  const text = String(message).toLowerCase();
+  const isAuth =
+    text.includes('token') ||
+    text.includes('logged') ||
+    text.includes('unauthorized') ||
+    text.includes('jwt') ||
+    text.includes('expired') ||
+    text.includes('audience');
+  if (!isAuth) return false;
+  reportSessionLost({ source: 'socket-exception' });
+  return true;
+}
+
+/**
+ * Called by the auth layer whenever a login (interactive or silent) succeeds,
+ * so any banner clears and preserved edits replay regardless of how the user
+ * recovered (banner action, login menu, or an automatic refresh elsewhere).
+ */
+export function notifySessionRecovered(): void {
+  onRecovered();
+}
+
+/** Proactive tick: banner the moment provider work is stranded by a session
+ * that cannot silently recover — before the user even attempts a save. */
+function proactiveCheck(): void {
+  if (recovering) return;
+  if (isSessionValid()) {
+    hideBanner();
+    return;
+  }
+  if (!hasProviderWorkLoaded()) return;
+  if (isUnrecoverable()) {
+    reportSessionLost({ source: 'proactive' });
+  }
+}
+
+/** Start the guard. Registers the reconnect-driven replay flush and a
+ * conservative proactive expiry watcher. Safe to call once at boot. */
+export function initSessionGuard(): void {
+  onSocketReconnect(flushPendingRetries);
+  if (proactiveTimer) return;
+  if (typeof setInterval !== 'function') return;
+  proactiveTimer = setInterval(() => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+    proactiveCheck();
+  }, PROACTIVE_INTERVAL_MS);
+}
+
+/** Test-only: reset all module state. */
+export function __resetSessionGuardForTest(): void {
+  pendingRetries.length = 0;
+  hideBanner();
+  recovering = false;
+  authFailureCount = 0;
+  sawFailureSinceRecovery = false;
+  if (proactiveTimer) {
+    clearInterval(proactiveTimer);
+    proactiveTimer = undefined;
+  }
+}


### PR DESCRIPTION
Turns an expired-session save failure into a clear, recoverable UX instead of a misleading "Server not responding" toast with the edit silently dropped.

## Root causes
- The `/tmx` socket presented a token captured **once** at connect time (`extraHeaders`), never the per-reconnect `auth` callback. The server `SocketGuard` prefers `handshake.auth.token`, so a refreshed/expired session kept being rejected on every `executionQueue` (the /hiveid clients got this fix 2026-06-01; /tmx did not).
- `mutationRequest` timeout treated any missing ack as "Server not responding" without consulting auth state.
- The socket `exception` (server auth rejection) was `console.warn`-ed and otherwise swallowed (A2 violation).

## Fix
- Fresh-token socket auth (`auth` callback) + `reconnectSocket()`.
- Auth-aware mutation timeout: preserve the edit, drive re-login, replay on recovery (`replayServerMutation`).
- New `sessionGuard`: persistent themed "log in again" banner, silent-refresh + fresh-token reconnect, preserved-edit replay, proactive expiry watcher.
- `notifySessionRecovered` on interactive login; boot `initSessionGuard()`; `session.*` i18n keys.

## Tests
New `sessionGuard` spec (14). Full suite **925 green**, eslint **0 warnings**, types clean.