### PR TITLE
fix(login): wrap credentials in a real <form> so Enter and password managers log in

### DIFF
--- a/src/components/modals/loginModal.ts
+++ b/src/components/modals/loginModal.ts
@@ -7,7 +7,7 @@ import { logIn, logOut } from 'services/authentication/loginState';
 import { firstLoginPasswordModal } from './firstLoginPassword';
 import { renderForm, validators } from 'courthive-components';
 import { tmxToast } from 'services/notifications/tmxToast';
-import { openModal } from './baseModal/baseModal';
+import { openModal, closeModal } from './baseModal/baseModal';
 import { t } from 'i18n';
 
 export function loginModal(callback?: () => void): void {
@@ -30,9 +30,29 @@ export function loginModal(callback?: () => void): void {
     },
   ];
 
-  const content = (elem: HTMLElement) =>
-    (inputs = renderForm(
-      elem,
+  // Render the email/password fields inside a real <form>. The modal's action
+  // buttons live in the footer, outside this form, so without it there is no
+  // form for a password manager (1Password, etc.) to recognise. 1Password's
+  // fill-and-submit then guesses a submit control and clicks the wrong footer
+  // button — e.g. requesting a magic link instead of logging in. A genuine
+  // <form> + submit button gives both native Enter and password-manager
+  // submission an unambiguous target that runs the password login.
+  const content = (elem: HTMLElement) => {
+    const form = document.createElement('form');
+    form.style.margin = '0';
+    // Route native submission (Enter, or a password manager's fill-and-submit)
+    // to the password-login path — never the magic-link path.
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const emailValid = validators.emailValidator(inputs.email.value);
+      if (!emailValid || !inputs.password.value) return;
+      closeModal();
+      submitCredentials();
+    });
+    elem.appendChild(form);
+
+    inputs = renderForm(
+      form,
       [
         {
           iconLeft: 'fa-regular fa-envelope',
@@ -53,7 +73,20 @@ export function loginModal(callback?: () => void): void {
         },
       ],
       relationships,
-    ));
+    );
+
+    // A real submit button is what makes Enter submit the form and what
+    // password managers target. Kept visually hidden — the visible actions
+    // remain the modal footer buttons.
+    const submit = document.createElement('button');
+    submit.type = 'submit';
+    submit.tabIndex = -1;
+    submit.setAttribute('aria-hidden', 'true');
+    submit.style.cssText = 'position:absolute;width:1px;height:1px;padding:0;border:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);';
+    form.appendChild(submit);
+
+    return inputs;
+  };
 
   const submitCredentials = () => {
     const email = inputs.email.value;


### PR DESCRIPTION
<img width="483" height="318" alt="Screenshot_2026-07-13_12-16-34" src="https://github.com/user-attachments/assets/9dbcb90d-56ea-4f71-a479-133b375045bc" />

## Problem

The login modal breaks password managers — and I quite like 1Password, so this is worth fixing.

The modal renders the email + password inputs with `renderForm`, but its action buttons (`Cancel` / `Magic Link` / `Login`) live in the modal footer, **outside any `<form>` element**. There is no form at all in the login modal.

Password managers are built around `<form>` semantics. With no form to anchor to, 1Password's fill-and-submit falls back to a heuristic and clicks the wrong footer button — it lands on **Magic Link** (`/auth/magic/request`) instead of **Login** (`/auth/login`). The user, who entered perfectly valid credentials, is met with *"If an account exists for that email, a login link is on its way"* and never actually logs in. A plain <kbd>Enter</kbd> keypress has no deterministic submit target either.

## Fix

Wrap the email/password inputs in a genuine `<form>` with a hidden submit button and an `onsubmit` handler that runs the password login (guarded on a valid email + non-empty password). This gives every submission path — native <kbd>Enter</kbd>, a password manager's submit-button click, and `form.requestSubmit()` — one unambiguous target that performs a password login.

The footer buttons are unchanged and the magic-link flow remains available via its own button.

## Testing

- `pnpm check-types` and `pnpm build` pass.
- Driven against a live deployment with a headless browser:
  - `<form>` + submit button present in the DOM.
  - <kbd>Enter</kbd> in the password field → `POST /auth/login` (200, session issued).
  - Clicking the form's submit button (what 1Password does) → `POST /auth/login`.
  - `form.requestSubmit()` → `POST /auth/login`.
  - Magic Link button still → `POST /auth/magic/request`.
- Verified in the browser with 1Password itself: fill-and-submit now logs in via the password path.