### PR TITLE
chore: local calendar store + typescript 6.0.3 pin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  typescript: 6.0.3
   '@courthive/provider-config': link:../provider-config
   '@courthive/scoring-visualizations': link:../scoringVisualizations
   '@xmldom/xmldom': ^0.9.0
@@ -1789,20 +1790,20 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.63.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/parser@8.63.0':
     resolution: {integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/project-service@8.63.0':
     resolution: {integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/scope-manager@8.63.0':
     resolution: {integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==}
@@ -1812,14 +1813,14 @@ packages:
     resolution: {integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/type-utils@8.63.0':
     resolution: {integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/types@8.63.0':
     resolution: {integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==}
@@ -1829,14 +1830,14 @@ packages:
     resolution: {integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/utils@8.63.0':
     resolution: {integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/visitor-keys@8.63.0':
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
@@ -2314,13 +2315,13 @@ packages:
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=9'
-      typescript: '>=5'
+      typescript: 6.0.3
 
   cosmiconfig@9.0.2:
     resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2988,7 +2989,7 @@ packages:
   i18next@26.3.6:
     resolution: {integrity: sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==}
     peerDependencies:
-      typescript: ^5 || ^6 || ^7
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4332,7 +4333,7 @@ packages:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: 6.0.3
 
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ allowBuilds:
   electron: false           # ~250MB binary; only needed for desktop mode
 
 overrides:
+  typescript: 6.0.3 # block native TS7 (no classic JS API — crashes tsc/nest/sonarjs); pairs with renovate TS-major block
   '@courthive/provider-config': link:../provider-config
   '@courthive/scoring-visualizations': link:../scoringVisualizations
   '@xmldom/xmldom': ^0.9.0

--- a/src/components/tables/tournamentsTable/createTournamentsTable.ts
+++ b/src/components/tables/tournamentsTable/createTournamentsTable.ts
@@ -24,7 +24,7 @@ import { destroyTable } from 'pages/tournament/destroyTable';
 import { getTournamentColumns } from './getTournamentColumn';
 import { listPicker } from 'components/modals/listPicker';
 import { displayConfig } from 'config/displayConfig';
-import { tmx2db } from 'services/storage/tmx2db';
+import { readLocalCalendarEntries } from 'services/storage/localCalendar';
 import { context } from 'services/context';
 import {
   filterTournaments,
@@ -221,8 +221,11 @@ function renderRows(anchor: HTMLElement, rows: TournamentRow[], onCreated: () =>
 }
 
 function fromLocalDb(anchor: HTMLElement, onCreated: () => void): Promise<TournamentsView> {
-  return tmx2db.findAllTournaments().then(
-    (data: any[]) => renderRows(anchor, data.map(mapTournamentRecord), onCreated),
+  // Read maintained lightweight calendar entries rather than loading every full
+  // tournament record. Same shape as the server calendar, so it flows through
+  // the shared fromCalendarTournaments mapper.
+  return readLocalCalendarEntries().then(
+    (entries: any[]) => fromCalendarTournaments(anchor, [{ tournaments: entries }], onCreated),
     () => renderRows(anchor, [], onCreated)
   );
 }

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -8,6 +8,7 @@ import { resetActivityTimer } from 'services/staleness/stalenessGuard';
 import { clearUserContext, fetchUserContext } from './getUserContext';
 import { clearActiveProvider } from 'services/provider/providerState';
 import { validateToken } from 'services/authentication/validateToken';
+import { resetLocalCalendar } from 'services/storage/localCalendar';
 import { disconnectSocket } from 'services/messaging/socketIo';
 import { refreshAccessToken } from 'services/apis/baseApi';
 import { tournamentEngine } from 'services/factory/engine';
@@ -92,9 +93,12 @@ export function logOut(): void {
   // fallback in createTournamentsTable. Demo/scratchpad tournaments (no
   // parentOrganisation) are preserved — per the explicit requirement in
   // Mentat/planning/USER_TOURNAMENT_ACCESS_MODEL.md PR 11.
-  void tmx2db.deleteProviderBoundTournaments().catch((err) => {
-    console.error('[auth] failed to clear provider-bound tournaments on logout', err);
-  });
+  void tmx2db
+    .deleteProviderBoundTournaments()
+    .then(() => resetLocalCalendar())
+    .catch((err) => {
+      console.error('[auth] failed to clear provider-bound tournaments on logout', err);
+    });
   // Stop the staleness timer so a leftover scheduled check can't fire after
   // logout and toast a "Missing tournamentRecord" error for a local-only
   // tournament that was never on the server.
@@ -133,9 +137,12 @@ export function logIn({
     // tab close / browser reopen without an intervening explicit logout, so
     // a previous user's provider-bound tournaments may still be in IDB.
     // Demo/scratchpad tournaments are preserved.
-    void tmx2db.deleteProviderBoundTournaments().catch((err) => {
-      console.error('[auth] failed to clear provider-bound tournaments on login', err);
-    });
+    void tmx2db
+      .deleteProviderBoundTournaments()
+      .then(() => resetLocalCalendar())
+      .catch((err) => {
+        console.error('[auth] failed to clear provider-bound tournaments on login', err);
+      });
     // Fire-and-forget: fetch the multi-provider user context from the server.
     // The context will be available by the time the user interacts with the
     // tournaments table or any provider-scoped UI element.

--- a/src/services/storage/localCalendar.test.ts
+++ b/src/services/storage/localCalendar.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  getTournamentCalendarEntry: vi.fn(),
+  upsertCalendarEntry: vi.fn(),
+  findAllTournaments: vi.fn(),
+  findAllProviders: vi.fn(),
+  clearAllProviderCalendars: vi.fn(),
+}));
+
+vi.mock('services/factory/engine', () => ({
+  tournamentEngine: { getTournamentCalendarEntry: h.getTournamentCalendarEntry },
+}));
+vi.mock('./tmx2db', () => ({
+  tmx2db: {
+    upsertCalendarEntry: h.upsertCalendarEntry,
+    findAllTournaments: h.findAllTournaments,
+    findAllProviders: h.findAllProviders,
+    clearAllProviderCalendars: h.clearAllProviderCalendars,
+  },
+}));
+
+import { maintainLocalCalendarEntry, readLocalCalendarEntries, resetLocalCalendar } from './localCalendar';
+
+const store: Record<string, string> = {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(store)) delete store[key];
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+  };
+  h.getTournamentCalendarEntry.mockImplementation(({ tournamentRecord }: any) => ({
+    tournamentId: tournamentRecord.tournamentId,
+    providerId: tournamentRecord.parentOrganisation?.organisationId,
+    searchText: (tournamentRecord.tournamentName || '').toLowerCase(),
+    tournament: { tournamentName: tournamentRecord.tournamentName },
+  }));
+  h.upsertCalendarEntry.mockResolvedValue(undefined);
+  h.findAllTournaments.mockResolvedValue([]);
+  h.findAllProviders.mockResolvedValue([]);
+  h.clearAllProviderCalendars.mockResolvedValue(0);
+});
+
+afterEach(() => {
+  delete (globalThis as any).localStorage;
+});
+
+describe('maintainLocalCalendarEntry', () => {
+  it('upserts a derived entry under the provider bucket', async () => {
+    await maintainLocalCalendarEntry({
+      tournamentId: 't1',
+      tournamentName: 'Open',
+      parentOrganisation: { organisationId: 'prov-1' },
+    });
+    expect(h.upsertCalendarEntry).toHaveBeenCalledWith('prov-1', expect.objectContaining({ tournamentId: 't1' }));
+  });
+
+  it('buckets provider-less (demo) tournaments under __local__', async () => {
+    await maintainLocalCalendarEntry({ tournamentId: 't2', tournamentName: 'Demo' });
+    expect(h.upsertCalendarEntry).toHaveBeenCalledWith('__local__', expect.objectContaining({ tournamentId: 't2' }));
+  });
+
+  it('no-ops without a tournamentId', async () => {
+    await maintainLocalCalendarEntry({ tournamentName: 'x' });
+    expect(h.upsertCalendarEntry).not.toHaveBeenCalled();
+  });
+
+  it('never throws when derivation fails (save must not break)', async () => {
+    h.getTournamentCalendarEntry.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    await expect(maintainLocalCalendarEntry({ tournamentId: 't3' })).resolves.toBeUndefined();
+    expect(h.upsertCalendarEntry).not.toHaveBeenCalled();
+  });
+});
+
+describe('readLocalCalendarEntries', () => {
+  it('migrates full records into entries once, then flattens provider calendars', async () => {
+    h.findAllTournaments.mockResolvedValue([
+      { tournamentId: 't1', tournamentName: 'A', parentOrganisation: { organisationId: 'p1' } },
+      { tournamentId: 't2', tournamentName: 'B' },
+    ]);
+    h.findAllProviders.mockResolvedValue([
+      { providerId: 'p1', calendar: [{ tournamentId: 't1' }] },
+      { providerId: '__local__', calendar: [{ tournamentId: 't2' }] },
+      { providerId: 'p9' }, // no calendar array — tolerated
+    ]);
+    const entries = await readLocalCalendarEntries();
+    expect(h.upsertCalendarEntry).toHaveBeenCalledTimes(2); // one per migrated record
+    expect(entries.map((e: any) => e.tournamentId).sort()).toEqual(['t1', 't2']);
+    expect(localStorage.getItem('tmx_local_calendar_migrated')).toBe('1');
+  });
+
+  it('skips the full-record migration once flagged (no full-load)', async () => {
+    localStorage.setItem('tmx_local_calendar_migrated', '1');
+    h.findAllProviders.mockResolvedValue([{ providerId: 'p1', calendar: [{ tournamentId: 't1' }] }]);
+    const entries = await readLocalCalendarEntries();
+    expect(h.findAllTournaments).not.toHaveBeenCalled();
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe('resetLocalCalendar (privacy clear on logout/login)', () => {
+  it('clears provider calendars and the migration flag so entries re-derive', async () => {
+    localStorage.setItem('tmx_local_calendar_migrated', '1');
+    await resetLocalCalendar();
+    expect(h.clearAllProviderCalendars).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('tmx_local_calendar_migrated')).toBeNull();
+  });
+});

--- a/src/services/storage/localCalendar.ts
+++ b/src/services/storage/localCalendar.ts
@@ -1,0 +1,76 @@
+/**
+ * Local (IndexedDB) mirror of the server's provider-calendar side-effect.
+ *
+ * The tournaments list is meant to render from lightweight calendar entries, not
+ * by loading every full tournament record. Connected mode already does this via
+ * `getMyCalendars`; this module gives local/offline mode the same optimization:
+ * every local save maintains the provider's `calendar` entry, and the list reads
+ * those entries instead of `findAllTournaments()` (a full-record load of all).
+ *
+ * The entry shape is derived by the factory (`getTournamentCalendarEntry`) so the
+ * local entry is byte-identical to the one the server persists — no drift.
+ */
+import { tournamentEngine } from 'services/factory/engine';
+import { tmx2db } from './tmx2db';
+
+// Bucket for tournaments with no provider (demo / scratchpad) so they still get a
+// lightweight list entry without a separate store.
+const LOCAL_BUCKET = '__local__';
+const MIGRATED_KEY = 'tmx_local_calendar_migrated';
+
+function providerBucket(tournamentRecord: any): string {
+  return tournamentRecord?.parentOrganisation?.organisationId || LOCAL_BUCKET;
+}
+
+/**
+ * Derive and persist the lightweight calendar entry for one record into the
+ * local provider calendar (upsert). The local mirror of the server's
+ * `addToOrUpdateCalendar`. Best-effort — a failure here must never break a save.
+ */
+export async function maintainLocalCalendarEntry(tournamentRecord: any): Promise<void> {
+  if (!tournamentRecord?.tournamentId) return;
+  try {
+    const entry = tournamentEngine.getTournamentCalendarEntry({ tournamentRecord });
+    if (entry?.tournamentId) await tmx2db.upsertCalendarEntry(providerBucket(tournamentRecord), entry);
+  } catch (err) {
+    console.error('[localCalendar] failed to maintain entry', err);
+  }
+}
+
+/**
+ * One-time: build local calendars from the full records already in IndexedDB so
+ * the list can read entries without ever full-loading again. Idempotent via a
+ * localStorage flag; the flag is cleared automatically when IDB is wiped on a
+ * major schema change (see tmx2db).
+ */
+async function ensureLocalCalendarMigrated(): Promise<void> {
+  if (typeof localStorage !== 'undefined' && localStorage.getItem(MIGRATED_KEY) === '1') return;
+  const tournaments = await tmx2db.findAllTournaments();
+  for (const tournamentRecord of tournaments) await maintainLocalCalendarEntry(tournamentRecord);
+  if (typeof localStorage !== 'undefined') localStorage.setItem(MIGRATED_KEY, '1');
+}
+
+/**
+ * Wipe the maintained local calendars and clear the migration flag. Called on the
+ * same logout/login transitions as `deleteProviderBoundTournaments` so provider
+ * calendar entries never leak across users; the next list read re-derives the
+ * surviving (demo) tournaments' entries.
+ */
+export async function resetLocalCalendar(): Promise<void> {
+  if (typeof localStorage !== 'undefined') localStorage.removeItem(MIGRATED_KEY);
+  try {
+    await tmx2db.clearAllProviderCalendars();
+  } catch (err) {
+    console.error('[localCalendar] reset failed', err);
+  }
+}
+
+/**
+ * All maintained local calendar entries (lightweight) — the list read source in
+ * local/offline mode, replacing a full-record load of every tournament.
+ */
+export async function readLocalCalendarEntries(): Promise<any[]> {
+  await ensureLocalCalendarMigrated();
+  const providers = await tmx2db.findAllProviders();
+  return providers.flatMap((provider: any) => (Array.isArray(provider?.calendar) ? provider.calendar : []));
+}

--- a/src/services/storage/saveTournamentRecord.ts
+++ b/src/services/storage/saveTournamentRecord.ts
@@ -1,3 +1,4 @@
+import { maintainLocalCalendarEntry } from './localCalendar';
 import { tournamentEngine } from 'services/factory/engine';
 import { serverConfig } from 'config/serverConfig';
 import { debugConfig } from 'config/debugConfig';
@@ -16,4 +17,8 @@ export async function saveTournamentRecord(params?: { tournamentRecord?: any }):
 
   debugConfig.get().log?.verbose && console.log('%c localSave', 'color: yellow');
   await tmx2db.addTournament(tournamentRecord);
+  // Maintain the lightweight local calendar entry so the tournaments list renders
+  // from entries instead of loading every full record (mirror of the server's
+  // calendar side-effect). Kept in step with what is actually in IndexedDB.
+  await maintainLocalCalendarEntry(tournamentRecord);
 }

--- a/src/services/storage/tmx2db.ts
+++ b/src/services/storage/tmx2db.ts
@@ -91,6 +91,16 @@ export class TMXDatabase {
     return this.dex['providers'].where('providerId').equals(key).delete();
   };
 
+  // Empty every provider's local calendar. Paired with deleteProviderBoundTournaments
+  // on logout/login: the calendar entries are the lightweight mirror of
+  // provider-bound tournaments and must not leak across users on a shared browser.
+  // The surviving (demo) tournaments are re-derived lazily on the next list read.
+  clearAllProviderCalendars = (): Promise<number> => {
+    return this.dex['providers'].toCollection().modify((provider: any) => {
+      provider.calendar = [];
+    });
+  };
+
   deleteAllTournamentAttr = (attr: string): Promise<void> => {
     return this.dex['tournaments']
       .toCollection()
@@ -138,6 +148,19 @@ export class TMXDatabase {
   };
   addProvider = (provider: any): Promise<string | any> => {
     return this.modifyOrAddUnique('providers', 'providerId', provider.providerId, provider);
+  };
+
+  // Upsert a single lightweight calendar entry into a provider's local calendar
+  // (replace by tournamentId, else append). This is the local mirror of the
+  // server's addToOrUpdateCalendar side-effect: it lets the tournaments list
+  // render from calendar entries instead of loading every full record.
+  upsertCalendarEntry = async (providerId: string, entry: any): Promise<void> => {
+    const provider = await this.findProvider(providerId);
+    const calendar = Array.isArray(provider?.calendar) ? provider.calendar.slice() : [];
+    const index = calendar.findIndex((existing: any) => existing?.tournamentId === entry?.tournamentId);
+    if (index >= 0) calendar[index] = entry;
+    else calendar.push(entry);
+    await this.addProvider({ providerId, calendar });
   };
 
   modify = async (tbl: string, attr: string, val: any, fx: (params: any) => void, params: any): Promise<any> => {


### PR DESCRIPTION
Commits the TMX working-tree changes that were blocking the ecosystem factory-consumer bump. Two commits:

- **fix(deps): pin typescript to 6.0.3** — matches the ecosystem TS7 pin (pnpm-workspace override + lockfile).
- **feat(storage): local calendar store** — `localCalendar.ts` (+ 7-test suite) wired into `tmx2db`, `saveTournamentRecord`, `loginState`, and the tournaments table.

Note: this is the **local-calendar workstream** (distinct from the already-merged linked-tournaments work #1218). check-types + lint + build + local-calendar test all green.