### PR TITLE
refactor(entries): centralize accepted-status set + e2e for manual seeding

### DIFF
--- a/e2e/journeys/84-manual-seeding-confirmed-status.spec.ts
+++ b/e2e/journeys/84-manual-seeding-confirmed-status.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Journey 84 — Manual seeding for CONFIRMED entries + seeding controls stay visible
+ *
+ * Regression coverage for PR #1209:
+ *
+ *  1. Entries with a factory-selected status the old hand-rolled list omitted
+ *     (CONFIRMED / LUCKY_LOSER / QUALIFIER) used to fall through to segment
+ *     rank 5 — rendering the red "?" badge and disabling the seed editor via
+ *     the `_segmentRank <= 1` gate. They must now rank as "Accepted" and be
+ *     seedable.
+ *
+ *  2. With `selectableRows: true`, clicking a seed cell also selected the row,
+ *     which swapped the controlBar to selection-overlay actions and hid the
+ *     Save/Cancel seeding buttons. Selection is now suspended while manual
+ *     seeding is active, so those buttons stay visible while entering values.
+ *
+ * @see segmentSorter.ts, createUnifiedEntriesPanel.ts (selectableRowsCheck),
+ *      enableManualSeeding.ts
+ */
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { seedTournament, MockProfile } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/* ─── Seed profile ──────────────────────────────────────────────────────── */
+
+// 16 scaled participants entered into a singles event (generate: false leaves
+// them as MAIN accepted entries) — flipped to CONFIRMED after seeding below.
+const PROFILE_CONFIRMED: MockProfile = {
+  tournamentName: 'E2E Confirmed Seeding',
+  tournamentAttributes: { tournamentId: 'e2e-confirmed-seeding' },
+  participantsProfile: { scaledParticipantsCount: 16 },
+  drawProfiles: [{ eventName: 'Singles', drawSize: 16, generate: false }],
+};
+
+/* ─── Helpers ───────────────────────────────────────────────────────────── */
+
+/** Seed the tournament, flip every accepted MAIN entry to CONFIRMED, open Entries. */
+async function navigateToConfirmedEntries(page: any): Promise<string> {
+  const tournamentId = await seedTournament(page, PROFILE_CONFIRMED);
+
+  // Flip the mock's DIRECT_ACCEPTANCE entries to CONFIRMED — the status the
+  // old accepted-list omitted. This is the exact shape produced by external
+  // signup/import flows that surfaced the bug.
+  await page.evaluate(() => {
+    const tournament = dev.getTournament();
+    const event = tournament.events?.[0];
+    if (!event) return;
+    for (const entry of event.entries || []) {
+      if (entry.entryStatus === 'DIRECT_ACCEPTANCE') entry.entryStatus = 'CONFIRMED';
+    }
+    dev.factory.tournamentEngine.setState(tournament);
+  });
+
+  const tournamentPage = new TournamentPage(page);
+  await tournamentPage.goto(tournamentId);
+  await tournamentPage.navigateToEvents();
+  await tournamentPage.eventsTable.locator('.tabulator-row').first().click();
+  await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
+
+  const entriesVisible = await page
+    .locator(S.ENTRIES_VIEW)
+    .isVisible()
+    .catch(() => false);
+  if (!entriesVisible) {
+    await page.locator('#eventTabsBar').getByText('Entries').click();
+  }
+  await page.waitForSelector(S.ENTRIES_VIEW, { state: 'visible', timeout: 10_000 });
+  // Wait for the Grouping badges to render.
+  await page.locator(`${S.ENTRIES_VIEW} .tabulator-cell[tabulator-field="segment"] .tag`).first().waitFor({
+    state: 'visible',
+    timeout: 5_000,
+  });
+  return tournamentId;
+}
+
+const segmentBadges = (page: any) => page.locator(`${S.ENTRIES_VIEW} .tabulator-cell[tabulator-field="segment"] .tag`);
+
+async function enableManualSeeding(page: any): Promise<void> {
+  await page.getByText('Seeding', { exact: true }).click();
+  const manualOption = page.getByText('Manual seeding', { exact: true }).first();
+  await manualOption.waitFor({ state: 'visible', timeout: 3_000 });
+  await manualOption.click();
+  // seedNumber column is shown (table.showColumn) once seeding is active.
+  await page
+    .locator(`${S.ENTRIES_VIEW} .tabulator-cell[tabulator-field="seedNumber"]`)
+    .first()
+    .waitFor({ state: 'attached', timeout: 3_000 });
+}
+
+// Only rows whose `editable` gate passes get Tabulator's `tabulator-editable`
+// class — i.e. accepted/qualifying seed cells under active manual seeding.
+// Pre-fix, CONFIRMED rows ranked 5 and never matched this.
+const editableSeedCells = (page: any) =>
+  page.locator(`${S.ENTRIES_VIEW} .tabulator-cell.tabulator-editable[tabulator-field="seedNumber"]`);
+
+/* ─── Tests ─────────────────────────────────────────────────────────────── */
+
+test.describe('Journey 84 — Manual seeding for CONFIRMED entries', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('CONFIRMED entries render the "Accepted" badge, never the "?" fallback', async ({ page }) => {
+    await navigateToConfirmedEntries(page);
+
+    const labels = (await segmentBadges(page).allTextContents()).map((label: string) => label.trim());
+    console.log('84: segment badges:', JSON.stringify(labels));
+
+    // Regression: CONFIRMED used to rank 5 → "?". It must rank 0 → "Accepted".
+    expect(labels).toContain('Accepted');
+    expect(labels).not.toContain('?');
+  });
+
+  test('CONFIRMED seed cell opens an editor under manual seeding', async ({ page }) => {
+    await navigateToConfirmedEntries(page);
+    await enableManualSeeding(page);
+
+    // Pre-fix regression: with CONFIRMED at rank 5 the editable gate rejected
+    // every seed cell, so none carried `tabulator-editable`.
+    await expect(editableSeedCells(page).first()).toBeVisible({ timeout: 3_000 });
+    expect(await editableSeedCells(page).count()).toBeGreaterThan(0);
+
+    await editableSeedCells(page).first().click();
+    // The numericEditor input (not a row-selection checkbox) mounts into the cell.
+    const editor = page.locator(`${S.ENTRIES_VIEW} input:not([type="checkbox"])`);
+    await expect(editor).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('Save/Cancel seeding stay visible and no row is selected while entering a value', async ({ page }) => {
+    await navigateToConfirmedEntries(page);
+    await enableManualSeeding(page);
+
+    const saveBtn = page.getByText('Save seeding');
+    const cancelBtn = page.getByText('Cancel', { exact: true });
+    await expect(saveBtn).toBeVisible({ timeout: 3_000 });
+    await expect(cancelBtn).toBeVisible();
+
+    // Type a seed value into the first CONFIRMED row's seed cell.
+    await expect(editableSeedCells(page).first()).toBeVisible({ timeout: 3_000 });
+    await editableSeedCells(page).first().click();
+    const editor = page.locator(`${S.ENTRIES_VIEW} input:not([type="checkbox"])`);
+    await expect(editor).toBeVisible({ timeout: 3_000 });
+    await editor.fill('1');
+    await editor.press('Enter');
+
+    // Pre-fix: the cell click also selected the row, swapping the controlBar to
+    // selection-overlay actions and hiding these buttons. Both must still show.
+    await expect(saveBtn).toBeVisible();
+    await expect(cancelBtn).toBeVisible();
+
+    // And selection must have been suspended entirely (selectableRowsCheck).
+    const selectedCount = await page.locator(`${S.ENTRIES_VIEW} .tabulator-row.tabulator-selected`).count();
+    expect(selectedCount).toBe(0);
+  });
+});

--- a/src/components/tables/eventsTable/seeding/canceManuallSeeding.ts
+++ b/src/components/tables/eventsTable/seeding/canceManuallSeeding.ts
@@ -1,16 +1,12 @@
-import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-factory';
+import { drawDefinitionConstants } from 'tods-competition-factory';
 import { tournamentEngine } from 'services/factory/engine';
 import { hideSaveSeeding } from './hideSaveSeeding';
 import { removeSeeding } from './removeSeeding';
 
+import { acceptedStatusSet } from 'constants/acceptedEntryStatuses';
 import { RIGHT } from 'constants/tmxConstants';
 
-const { STRUCTURE_SELECTED_STATUSES } = entryStatusConstants;
 const { QUALIFYING } = drawDefinitionConstants;
-
-// Aligned with the factory's STRUCTURE_SELECTED_STATUSES so seed values are
-// restored for all accepted statuses (e.g. CONFIRMED), not only DIRECT_ACCEPTANCE
-const ACCEPTED_STATUSES = new Set(STRUCTURE_SELECTED_STATUSES);
 
 const getSeedNumber = (participant: any, eventType: string, scaleName: string) => {
   const seedings = participant?.seedings?.[eventType];
@@ -25,7 +21,7 @@ const onCancelManualSeedingClick = (e: any, table: any, eventId: string) => {
   const event = tournamentEngine.q.event({ eventId });
   if (!event) return;
   const entries = (event.entries ?? []).filter(
-    (entry: any) => entry.entryStage === entryStage && ACCEPTED_STATUSES.has(entry.entryStatus),
+    (entry: any) => entry.entryStage === entryStage && acceptedStatusSet.has(entry.entryStatus),
   );
   const participantIds = entries.map(({ participantId }: any) => participantId);
   const { participants = [] } = tournamentEngine.getParticipants({

--- a/src/components/tables/eventsTable/unified/segmentSorter.ts
+++ b/src/components/tables/eventsTable/unified/segmentSorter.ts
@@ -4,17 +4,14 @@
  * then by a user-selected secondary column within each segment.
  */
 import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-factory';
+import { acceptedStatusSet } from 'constants/acceptedEntryStatuses';
 
 const { QUALIFYING } = drawDefinitionConstants;
-const { STRUCTURE_SELECTED_STATUSES, ALTERNATE, UNGROUPED, WITHDRAWN } = entryStatusConstants;
-
-// Aligned with the factory's STRUCTURE_SELECTED_STATUSES so statuses like
-// CONFIRMED, LUCKY_LOSER and QUALIFIER rank as accepted (and stay seedable)
-const ACCEPTED_STATUSES = new Set(STRUCTURE_SELECTED_STATUSES);
+const { ALTERNATE, UNGROUPED, WITHDRAWN } = entryStatusConstants;
 
 export function segmentRank(entryStage: string, entryStatus: string): number {
-  if (entryStage === QUALIFYING && ACCEPTED_STATUSES.has(entryStatus)) return 1;
-  if (ACCEPTED_STATUSES.has(entryStatus)) return 0; // MAIN accepted
+  if (entryStage === QUALIFYING && acceptedStatusSet.has(entryStatus)) return 1;
+  if (acceptedStatusSet.has(entryStatus)) return 0; // MAIN accepted
   if (entryStatus === ALTERNATE) return 2;
   if (entryStatus === UNGROUPED) return 3;
   if (entryStatus === WITHDRAWN) return 4;

--- a/src/constants/acceptedEntryStatuses.test.ts
+++ b/src/constants/acceptedEntryStatuses.test.ts
@@ -1,4 +1,4 @@
-import { acceptedEntryStatuses } from './acceptedEntryStatuses';
+import { acceptedEntryStatuses, acceptedStatusSet } from './acceptedEntryStatuses';
 import { describe, expect, it } from 'vitest';
 
 describe('acceptedEntryStatuses', () => {
@@ -36,5 +36,29 @@ describe('acceptedEntryStatuses', () => {
 
   it('returns consistent count for any stage', () => {
     expect(acceptedEntryStatuses('CONSOLATION')).toHaveLength(8);
+  });
+});
+
+describe('acceptedStatusSet', () => {
+  it('is the shared set of the 8 unprefixed structure-selected statuses', () => {
+    expect(acceptedStatusSet.size).toBe(8);
+    for (const status of [
+      'CONFIRMED',
+      'DIRECT_ACCEPTANCE',
+      'JUNIOR_EXEMPT',
+      'LUCKY_LOSER',
+      'QUALIFIER',
+      'ORGANISER_ACCEPTANCE',
+      'SPECIAL_EXEMPT',
+      'WILDCARD',
+    ]) {
+      expect(acceptedStatusSet.has(status)).toBe(true);
+    }
+  });
+
+  it('excludes non-accepted statuses', () => {
+    expect(acceptedStatusSet.has('ALTERNATE')).toBe(false);
+    expect(acceptedStatusSet.has('WITHDRAWN')).toBe(false);
+    expect(acceptedStatusSet.has('REGISTERED')).toBe(false);
   });
 });

--- a/src/constants/acceptedEntryStatuses.ts
+++ b/src/constants/acceptedEntryStatuses.ts
@@ -5,5 +5,12 @@ import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-
 const { STRUCTURE_SELECTED_STATUSES } = entryStatusConstants;
 const { MAIN } = drawDefinitionConstants;
 
+// Single source of truth for the "accepted" (structure-selected) entry statuses.
+// Import this set rather than re-deriving `new Set(STRUCTURE_SELECTED_STATUSES)`
+// at each call site — that hand-rolled duplication is exactly what drifted out
+// of alignment before (CONFIRMED/LUCKY_LOSER/QUALIFIER were silently dropped,
+// breaking manual seeding for those statuses).
+export const acceptedStatusSet: ReadonlySet<string> = new Set(STRUCTURE_SELECTED_STATUSES);
+
 export const acceptedEntryStatuses = (stage: string = MAIN): string[] =>
   STRUCTURE_SELECTED_STATUSES.map((status: string) => `${stage}.${status}`);


### PR DESCRIPTION
## Follow-up to #1209

Applies the two review follow-ups called out on #1209.

### 1. Centralize the accepted-status set (end the recurring bug class)
#1209 fixed a hardcoded 5-status list that omitted `CONFIRMED`/`LUCKY_LOSER`/`QUALIFIER` — but the same `new Set(STRUCTURE_SELECTED_STATUSES)` was still derived independently in **two** places (`segmentSorter.ts`, `canceManuallSeeding.ts`), with a third shape in `constants/acceptedEntryStatuses.ts`. This was the *third* time a hardcoded accepted-status list had to be corrected.

- Adds a single `acceptedStatusSet` export to `constants/acceptedEntryStatuses.ts`.
- `segmentSorter.ts` and `canceManuallSeeding.ts` now import it instead of re-deriving it, so the list can't drift out of alignment again.
- Behavior is unchanged (same 8 statuses); this is a pure de-duplication.

### 2. e2e coverage for the interaction fixes
#1209's two interaction fixes were only manually verified. New **journey 84** (`e2e/journeys/84-manual-seeding-confirmed-status.spec.ts`) guards them:

1. CONFIRMED entries render the **Accepted** badge (never the `?` fallback).
2. Under manual seeding, a CONFIRMED seed cell is **editable** and opens the editor (pre-fix: rank 5 → no editor).
3. **Save/Cancel seeding stay visible and no row is selected** while entering a seed value (pre-fix: the cell click selected the row and the controlBar swapped, hiding the buttons).

Each guard was falsified against a reverted fix to confirm it actually fails without the change.

### Verification
- `tsc --noEmit` (src + e2e) clean
- `eslint src` + `prettier --check` clean on touched files
- Unit: `acceptedEntryStatuses.test.ts` (+ new `acceptedStatusSet` cases) and `segmentSorter.test.ts` pass
- e2e: journey 84 — 3/3 pass; test 3 confirmed to fail when the selection-suspension fix is reverted