### PR TITLE
fix(draws): sunburst structure selection + composite draw-type label

### DIFF
--- a/e2e/journeys/85-draw-composite-structures.spec.ts
+++ b/e2e/journeys/85-draw-composite-structures.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Journey 85 — Composite draw structures (RR + elimination) in the draws views
+ *
+ * Two regressions when a draw combines round-robin and single-elimination:
+ *
+ *  1. Draws TABLE "Draw type" column read just "SINGLE_ELIMINATION" for a draw
+ *     that is really a round-robin QUALIFYING feeding a single-elimination MAIN
+ *     (drawDefinition.drawType names only the MAIN structure). It must now read
+ *     "Single Elimination (Round Robin Qualifying)".
+ *
+ *  2. Draws GRID progression sunburst rendered `structures[0]` as a single-
+ *     elimination bracket. For composite draws that grabbed the round-robin
+ *     structure and force-fit its non-halving rounds into an SE bracket, lumping
+ *     in every RR matchUp unconnected. The sunburst must render the ELIMINATION
+ *     structure (MAIN SE, or the playoff) and render NOTHING for a pure
+ *     round-robin draw (no bracket exists).
+ */
+import { test, expect } from '@playwright/test';
+import {
+  ensureDrawsGridMode,
+  ensureDrawsTableMode,
+  initDevBridge,
+  resetDrawsViewState,
+  resetEventsViewMode,
+  resetState,
+  waitForAppReady,
+} from '../helpers/dev-bridge';
+import { seedTournament } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+
+const DRAW_CARD = '.chc-dc-card';
+const VIZ_ZONE = '.chc-dc-viz';
+
+// One event, two SE draws — one with a round-robin QUALIFYING stage feeding the
+// SE main (qualifyingPositions reserves the main slots so it seeds cleanly).
+const PROFILE_QUALIFYING_RR = {
+  tournamentName: 'E2E Composite Draws',
+  tournamentAttributes: { tournamentId: 'e2e-composite-draws' },
+  participantsProfile: { participantsCount: 80 },
+  eventProfiles: [
+    {
+      eventName: 'Singles',
+      drawProfiles: [
+        {
+          drawName: 'Championship',
+          drawType: 'SINGLE_ELIMINATION' as const,
+          drawSize: 16,
+          qualifyingPositions: 4,
+          qualifyingProfiles: [
+            { structureProfiles: [{ stageSequence: 1, drawType: 'ROUND_ROBIN', drawSize: 8, qualifyingPositions: 4 }] },
+          ],
+        },
+        { drawName: 'Plate', drawType: 'SINGLE_ELIMINATION' as const, drawSize: 16 },
+      ],
+    },
+  ],
+  completeAllMatchUps: true,
+};
+
+// One event, three draws: pure round-robin (no bracket), plain SE, and
+// round-robin-with-playoff (RR groups → elimination playoff).
+const PROFILE_MIXED_STRUCTURES = {
+  tournamentName: 'E2E Mixed Draws',
+  tournamentAttributes: { tournamentId: 'e2e-mixed-draws' },
+  participantsProfile: { participantsCount: 80 },
+  eventProfiles: [
+    {
+      eventName: 'Singles',
+      drawProfiles: [
+        { drawName: 'Round Robin Pool', drawType: 'ROUND_ROBIN' as const, drawSize: 8 },
+        { drawName: 'Knockout', drawType: 'SINGLE_ELIMINATION' as const, drawSize: 16 },
+        { drawName: 'Groups To Final', drawType: 'ROUND_ROBIN_WITH_PLAYOFF' as const, drawSize: 8 },
+      ],
+    },
+  ],
+  completeAllMatchUps: true,
+};
+
+async function eventIdOf(page: import('@playwright/test').Page): Promise<string> {
+  const eventId = await page.evaluate(() => {
+    const { tournamentRecord } = dev.factory.tournamentEngine.getTournament();
+    return tournamentRecord?.events?.[0]?.eventId as string | undefined;
+  });
+  expect(eventId).toBeTruthy();
+  return eventId as string;
+}
+
+async function pickSunburst(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator('button[aria-label="Card display options"]').click();
+  await page.locator('input[name="drawCardDisplay"]').first().waitFor({ state: 'visible', timeout: 5_000 });
+  await page.locator('input[name="drawCardDisplay"][value="sunburst"]').click();
+}
+
+test.describe('Journey 85 — Composite draw structures', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await resetEventsViewMode(page);
+    await resetDrawsViewState(page);
+  });
+
+  test('draws table Draw-type column surfaces a round-robin qualifying', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_QUALIFYING_RR);
+    await new TournamentPage(page).goto(tournamentId);
+    await ensureDrawsTableMode(page);
+    const eventId = await eventIdOf(page);
+    await page.goto(`/#/tournament/${tournamentId}/event/${eventId}/draws`);
+    await page.locator('.tabulator-row').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    const drawTypeOfRow = (drawName: string) =>
+      page
+        .locator('.tabulator-row', { hasText: drawName })
+        .locator('[tabulator-field="drawType"]')
+        .innerText();
+
+    // Regression: this row used to read just "SINGLE_ELIMINATION".
+    expect((await drawTypeOfRow('Championship')).trim()).toBe('Single Elimination (Round Robin Qualifying)');
+    // A plain SE draw is unchanged (now title-cased).
+    expect((await drawTypeOfRow('Plate')).trim()).toBe('Single Elimination');
+  });
+
+  test('sunburst renders elimination brackets but not pure round-robin draws', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_MIXED_STRUCTURES);
+    await new TournamentPage(page).goto(tournamentId);
+    await ensureDrawsGridMode(page);
+    const eventId = await eventIdOf(page);
+    await page.goto(`/#/tournament/${tournamentId}/event/${eventId}/draws`);
+    await page.locator(DRAW_CARD).first().waitFor({ state: 'visible', timeout: 10_000 });
+    await expect(page.locator(DRAW_CARD)).toHaveCount(3);
+
+    await pickSunburst(page);
+
+    // Elimination bracket (SE) and the RR-with-playoff (its PLAY_OFF bracket)
+    // render; the pure round-robin draw has no bracket → no viz. Pre-fix all
+    // three rendered (the RR structures force-fit into an SE bracket).
+    await expect(page.locator(VIZ_ZONE)).toHaveCount(2);
+
+    const cardByName = (name: string) => page.locator(DRAW_CARD).filter({ hasText: name });
+    await expect(cardByName('Round Robin Pool').locator(VIZ_ZONE)).toHaveCount(0);
+    await expect(cardByName('Knockout').locator(`${VIZ_ZONE} svg`)).toHaveCount(1);
+    await expect(cardByName('Groups To Final').locator(`${VIZ_ZONE} svg`)).toHaveCount(1);
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/describeDrawType.test.ts
+++ b/src/pages/tournament/tabs/eventsTab/describeDrawType.test.ts
@@ -1,0 +1,49 @@
+import { describeDrawType, formatDrawTypeLabel } from './describeDrawType';
+import { describe, expect, it } from 'vitest';
+
+// Structure shapes mirror the factory (verified): RR → WIN_RATIO, elimination → ROUND_OUTCOME.
+const rrMain = { stage: 'MAIN', finishingPosition: 'WIN_RATIO' };
+const rrQualifying = { stage: 'QUALIFYING', finishingPosition: 'WIN_RATIO' };
+const seMain = { stage: 'MAIN', finishingPosition: 'ROUND_OUTCOME' };
+const seQualifying = { stage: 'QUALIFYING', finishingPosition: 'ROUND_OUTCOME' };
+const playOff = { stage: 'PLAY_OFF', finishingPosition: 'ROUND_OUTCOME' };
+
+describe('formatDrawTypeLabel', () => {
+  it('title-cases a SNAKE_CASE draw type', () => {
+    expect(formatDrawTypeLabel('SINGLE_ELIMINATION')).toBe('Single Elimination');
+    expect(formatDrawTypeLabel('ROUND_ROBIN_WITH_PLAYOFF')).toBe('Round Robin With Playoff');
+  });
+  it('returns empty string for missing input', () => {
+    expect(formatDrawTypeLabel(undefined)).toBe('');
+  });
+});
+
+describe('describeDrawType', () => {
+  it('labels a plain single-elimination draw', () => {
+    expect(describeDrawType({ drawType: 'SINGLE_ELIMINATION', structures: [seMain] })).toBe('Single Elimination');
+  });
+
+  it('surfaces a round-robin qualifying under a single-elimination main', () => {
+    // The reported bug: this used to read just "SINGLE_ELIMINATION".
+    expect(describeDrawType({ drawType: 'SINGLE_ELIMINATION', structures: [rrQualifying, seMain] })).toBe(
+      'Single Elimination (Round Robin Qualifying)',
+    );
+  });
+
+  it('does not repeat the family for a same-type qualifying', () => {
+    expect(describeDrawType({ drawType: 'SINGLE_ELIMINATION', structures: [seQualifying, seMain] })).toBe(
+      'Single Elimination (Qualifying)',
+    );
+  });
+
+  it('leaves named composite types (RR with playoff) un-annotated', () => {
+    expect(describeDrawType({ drawType: 'ROUND_ROBIN_WITH_PLAYOFF', structures: [rrMain, playOff] })).toBe(
+      'Round Robin With Playoff',
+    );
+  });
+
+  it('handles missing drawType / structures', () => {
+    expect(describeDrawType({})).toBe('');
+    expect(describeDrawType({ drawType: 'ROUND_ROBIN' })).toBe('Round Robin');
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/describeDrawType.ts
+++ b/src/pages/tournament/tabs/eventsTab/describeDrawType.ts
@@ -1,0 +1,44 @@
+/**
+ * Human-readable draw-type label for the draws table.
+ *
+ * `drawDefinition.drawType` names only the MAIN structure. A qualifying stage —
+ * notably a round-robin qualifying feeding a single-elimination main — is
+ * invisible in that single value, so the "Draw type" column reads e.g.
+ * "SINGLE_ELIMINATION" for a draw that is really RR-qualifying → SE-main.
+ * `describeDrawType` title-cases the base type and appends the qualifying stage
+ * (naming its family when it differs from the main), so composite draws read
+ * accurately: "Single Elimination (Round Robin Qualifying)".
+ *
+ * Named composite types (ROUND_ROBIN_WITH_PLAYOFF, FIRST_MATCH_LOSER_CONSOLATION)
+ * already encode their composition in `drawType`, so they need no annotation.
+ */
+import { drawDefinitionConstants } from 'tods-competition-factory';
+
+const { QUALIFYING, WIN_RATIO, ROUND_ROBIN, ROUND_ROBIN_WITH_PLAYOFF } = drawDefinitionConstants;
+
+/** SNAKE_CASE draw-type constant → Title Case (e.g. SINGLE_ELIMINATION → "Single Elimination"). */
+export function formatDrawTypeLabel(drawType?: string): string {
+  if (!drawType) return '';
+  return drawType
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
+export function describeDrawType(drawDefinition: any): string {
+  const base = formatDrawTypeLabel(drawDefinition?.drawType);
+  const structures = drawDefinition?.structures ?? [];
+  const qualifying = structures.find((structure: any) => structure?.stage === QUALIFYING);
+  if (!qualifying) return base;
+
+  const qualifyingIsRoundRobin = qualifying.finishingPosition === WIN_RATIO;
+  const mainIsRoundRobin =
+    drawDefinition?.drawType === ROUND_ROBIN || drawDefinition?.drawType === ROUND_ROBIN_WITH_PLAYOFF;
+  // Only name the qualifying family when it differs from the main; otherwise a
+  // bare "(Qualifying)" avoids redundant "Single Elimination (Single Elimination Qualifying)".
+  const note =
+    qualifyingIsRoundRobin === mainIsRoundRobin
+      ? 'Qualifying'
+      : `${qualifyingIsRoundRobin ? 'Round Robin' : 'Single Elimination'} Qualifying`;
+  return `${base} (${note})`;
+}

--- a/src/pages/tournament/tabs/eventsTab/mapDrawDefinition.ts
+++ b/src/pages/tournament/tabs/eventsTab/mapDrawDefinition.ts
@@ -4,6 +4,7 @@
  */
 import { publishingGovernor, entryStatusConstants } from 'tods-competition-factory';
 import { tournamentEngine } from 'services/factory/engine';
+import { describeDrawType } from './describeDrawType';
 
 // constants
 const { WITHDRAWN } = entryStatusConstants;
@@ -38,6 +39,9 @@ export const mapDrawDefinition =
       published,
       drawName,
       drawType,
+      // Composite-aware display label — `drawType` alone hides an RR qualifying
+      // under a SINGLE_ELIMINATION main (see describeDrawType).
+      drawTypeLabel: describeDrawType(drawDefinition),
       eventId,
       drawId,
     };

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/progressionStructure.test.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/progressionStructure.test.ts
@@ -1,0 +1,38 @@
+import { pickProgressionStructure } from './progressionStructure';
+import { describe, expect, it } from 'vitest';
+
+// Enriched-structure shapes mirroring getEventData().drawsData[i].structures[j]
+// (verified against the factory: RR → finishingPosition WIN_RATIO, elimination → ROUND_OUTCOME).
+const rrMain = { stage: 'MAIN', finishingPosition: 'WIN_RATIO', structureType: 'CONTAINER' };
+const rrQualifying = { stage: 'QUALIFYING', finishingPosition: 'WIN_RATIO', structureType: 'CONTAINER' };
+const seMain = { stage: 'MAIN', finishingPosition: 'ROUND_OUTCOME' };
+const playOff = { stage: 'PLAY_OFF', finishingPosition: 'ROUND_OUTCOME' };
+const consolation = { stage: 'CONSOLATION', finishingPosition: 'ROUND_OUTCOME' };
+
+describe('pickProgressionStructure', () => {
+  it('returns the MAIN single-elimination structure for a plain SE draw', () => {
+    expect(pickProgressionStructure([seMain])).toBe(seMain);
+  });
+
+  it('picks the MAIN elimination structure over an RR qualifying structure', () => {
+    // Qualifying RR → Main SE: must render the MAIN bracket, not the RR qualifying.
+    expect(pickProgressionStructure([rrQualifying, seMain])).toBe(seMain);
+  });
+
+  it('picks the playoff bracket when MAIN is round-robin (RR + playoff)', () => {
+    expect(pickProgressionStructure([rrMain, playOff])).toBe(playOff);
+  });
+
+  it('returns undefined for a pure round-robin draw (no elimination bracket)', () => {
+    expect(pickProgressionStructure([rrMain])).toBeUndefined();
+  });
+
+  it('prefers MAIN over other elimination structures (e.g. consolation)', () => {
+    expect(pickProgressionStructure([seMain, consolation])).toBe(seMain);
+  });
+
+  it('returns undefined for empty / missing input', () => {
+    expect(pickProgressionStructure([])).toBeUndefined();
+    expect(pickProgressionStructure(undefined)).toBeUndefined();
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/progressionStructure.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/progressionStructure.ts
@@ -1,0 +1,30 @@
+/**
+ * Pick the structure the progression sunburst should render.
+ *
+ * The burst chart is a single-elimination bracket visualization: it assumes each
+ * round halves (`drawSize = 2 * round1Count`). Round-robin structures
+ * (`finishingPosition: WIN_RATIO`) have no bracket progression, so a composite
+ * draw must render its ELIMINATION structure — never the round-robin one:
+ *   - Qualifying round-robin → main single-elimination: render the MAIN bracket.
+ *   - Main round-robin → elimination playoff: render the PLAY_OFF bracket.
+ *   - Pure round-robin (no playoff): no bracket exists → render nothing.
+ *
+ * Feeding `structures[0]` (the old behavior) rendered the round-robin structure's
+ * non-halving rounds as if single-elimination, lumping in every RR matchUp
+ * unconnected.
+ *
+ * Operates on the enriched `getEventData().drawsData[i].structures` shape (each
+ * carries `finishingPosition` + `stage`). Returns the bracket structure — a
+ * MAIN-stage elimination structure when present, else the first elimination
+ * structure — or `undefined` when the draw has no elimination bracket.
+ */
+import { drawDefinitionConstants } from 'tods-competition-factory';
+
+const { ROUND_OUTCOME, MAIN } = drawDefinitionConstants;
+
+export function pickProgressionStructure(structures?: any[]): any | undefined {
+  if (!structures?.length) return undefined;
+  const elimination = structures.filter((structure: any) => structure?.finishingPosition === ROUND_OUTCOME);
+  if (!elimination.length) return undefined;
+  return elimination.find((structure: any) => structure.stage === MAIN) ?? elimination[0];
+}

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsGrid.ts
@@ -21,6 +21,7 @@ import { addDraw } from 'components/drawers/addDraw/addDraw';
 import { tournamentEngine } from 'services/factory/engine';
 
 import { buildDrawCardVisualization } from './buildDrawCardVisualization';
+import { pickProgressionStructure } from './progressionStructure';
 import { DrawCardDisplayMode } from './drawCardDisplayMode';
 import {
   GateReason,
@@ -117,9 +118,7 @@ function computeAvailability(eventId: string): VizDataAvailability {
   // Competitiveness is only populated when matchUps are fetched with
   // contextProfile.withCompetitiveness — raw drawDefinitions don't carry it.
   const competitiveMatchUps = fetchCompetitiveMatchUps(eventId);
-  const hasCompetitiveness = competitiveMatchUps.some(
-    (m: any) => m?.competitiveProfile?.competitiveness,
-  );
+  const hasCompetitiveness = competitiveMatchUps.some((m: any) => m?.competitiveProfile?.competitiveness);
   return { hasRatings: !!ratingScale, hasCompetitiveness };
 }
 
@@ -166,10 +165,7 @@ export function readDrawCardData(eventId: string): DrawCardData[] {
   const { scaleValues } = (tournamentEngine as any).getRatingsStats?.({ eventId }) || {};
   const utrAvg = scaleValues?.ratingsStats?.UTR?.avg;
   const wtnAvg = scaleValues?.ratingsStats?.WTN?.avg;
-  return [
-    ...buildGeneratedRows(resolved, eventId, utrAvg, wtnAvg),
-    ...buildUngeneratedRows(resolved, eventId),
-  ];
+  return [...buildGeneratedRows(resolved, eventId, utrAvg, wtnAvg), ...buildUngeneratedRows(resolved, eventId)];
 }
 
 function openDrawCard(data: DrawCardData): void {
@@ -222,7 +218,7 @@ function resolveCardVisualization(row: any, ctx: CardVizContext): HTMLElement | 
   if (!dd) return null;
 
   const enrichedStructure = isSunburstMode(resolved.mode)
-    ? enrichedDrawsData.find((d: any) => d.drawId === row.drawId)?.structures?.[0]
+    ? pickProgressionStructure(enrichedDrawsData.find((d: any) => d.drawId === row.drawId)?.structures)
     : undefined;
   const competitiveMatchUps = resolved.mode === 'competitiveness' ? competitiveByDraw.get(row.drawId) : undefined;
   const drawParticipantIds =
@@ -284,10 +280,9 @@ export function renderDrawsGrid({
 
   // Sunburst needs the enriched structures (with `roundMatchUps`) from
   // getEventData — drawDefinition.structures alone doesn't carry that field.
-  const enrichedDrawsData =
-    isSunburstMode(resolved.mode)
-      ? (tournamentEngine as any).getEventData({ eventId })?.eventData?.drawsData ?? []
-      : [];
+  const enrichedDrawsData = isSunburstMode(resolved.mode)
+    ? ((tournamentEngine as any).getEventData({ eventId })?.eventData?.drawsData ?? [])
+    : [];
 
   // Competitiveness needs matchUps with `contextProfile.withCompetitiveness`;
   // fetch once and bucket by drawId.
@@ -323,11 +318,7 @@ export function renderDrawsGrid({
       participantsById,
     });
     grid.appendChild(
-      buildDrawCard(
-        { ...row, visualization },
-        { showVisualization: showViz },
-        { onClick: openDrawCard },
-      ),
+      buildDrawCard({ ...row, visualization }, { showVisualization: showViz }, { onClick: openDrawCard }),
     );
   }
 

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsTable.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawsTable.ts
@@ -4,6 +4,7 @@
  * Includes ungenerated flights which are clickable to generate draws.
  * Returns the Tabulator instance for control bar integration.
  */
+import { formatDrawTypeLabel } from 'pages/tournament/tabs/eventsTab/describeDrawType';
 import { headerSortElement } from 'components/tables/common/sorters/headerSortElement';
 import { mapDrawDefinition } from 'pages/tournament/tabs/eventsTab/mapDrawDefinition';
 import { drawEntriesClick } from 'components/tables/eventsTable/drawEntriesClick';
@@ -40,7 +41,9 @@ export function renderDrawsTable({ eventId, target }: { eventId: string; target:
   });
 
   const { scaleValues } = (tournamentEngine as any).getRatingsStats?.({ eventId }) || {};
-  const generatedData = drawDefinitions.map((dd: any) => mapDrawDefinition(eventId)({ drawDefinition: dd, scaleValues }));
+  const generatedData = drawDefinitions.map((dd: any) =>
+    mapDrawDefinition(eventId)({ drawDefinition: dd, scaleValues }),
+  );
   const data = [...generatedData, ...ungeneratedFlights];
 
   if (!data.length) return;
@@ -86,7 +89,14 @@ export function renderDrawsTable({ eventId, target }: { eventId: string; target:
       width: 55,
     },
     { title: t('tables.draws.drawName'), field: DRAW_NAME, cellClick: drawDetail },
-    { title: t('tables.draws.drawType'), field: DRAW_TYPE, cellClick: drawDetail },
+    {
+      title: t('tables.draws.drawType'),
+      field: DRAW_TYPE,
+      // Composite-aware label (e.g. "Single Elimination (Round Robin Qualifying)");
+      // falls back to a title-cased raw drawType for rows without a precomputed label.
+      formatter: (cell: any) => cell.getData()?.drawTypeLabel ?? formatDrawTypeLabel(cell.getValue()),
+      cellClick: drawDetail,
+    },
     { title: t('tables.draws.flight'), field: 'flightNumber', width: 70, headerSort: false, hozAlign: CENTER },
     {
       title: '<i class="fa-solid fa-user-group" />',


### PR DESCRIPTION
## Problem
Two issues in the per-event draws views when a draw combines round-robin and single-elimination (RR qualifying → SE main, or RR main → elimination playoff):

1. **Progression sunburst rendered as if pure single-elimination.** `renderDrawsGrid` fed `structures[0]` to the burst chart, which assumes an SE bracket (each round halves). For composite draws `structures[0]` is often the **round-robin** structure — its non-halving rounds got force-fit into a bracket, lumping in every RR matchUp unconnected.
2. **"Draw type" column mislabeled composite draws.** `drawDefinition.drawType` names only the MAIN structure, so an RR **qualifying** feeding an SE main read as `SINGLE_ELIMINATION`, hiding the round-robin entirely.

Root cause confirmed against the factory — the clean discriminator is `finishingPosition`: `ROUND_OUTCOME` = elimination bracket, `WIN_RATIO` = round-robin.

## Fix (TMX-only — no courthive-components change, avoids the publish chain)
- **`pickProgressionStructure(structures)`** selects the elimination structure (a `MAIN`-stage `ROUND_OUTCOME` structure, else the first `ROUND_OUTCOME`), or `undefined` when none exists. Result: qualifying-RR→main-SE renders the MAIN bracket; RR+playoff renders the playoff bracket; **pure round-robin renders no sunburst** (no bracket exists). `fromFactoryDrawData` already renders a proper SE structure correctly — only the *selection* was wrong.
- **`describeDrawType(drawDefinition)`** title-cases the drawType and appends the qualifying stage when present: e.g. **"Single Elimination (Round Robin Qualifying)"**. Named composite types (ROUND_ROBIN_WITH_PLAYOFF, FMLC) already encode themselves and are left as-is.

## Verification
- `check-types` (src + e2e) clean; `eslint` + `prettier` clean on touched files.
- Unit: `progressionStructure.test.ts` + `describeDrawType.test.ts` — 13 tests (shapes verified empirically against the factory).
- e2e **journey 85**: (a) draws-table column reads "Single Elimination (Round Robin Qualifying)"; (b) sunburst renders the SE + RR-with-playoff brackets but **not** the pure round-robin draw (2 of 3 cards). **Both guards falsified** against the reverted fix (column → raw "SINGLE_ELIMINATION"; sunburst → 3 of 3).

## Follow-up (noted, not in this PR)
A defensive guard in courthive-components' `fromFactoryDrawData`/`burstChart` to reject a `WIN_RATIO` structure passed directly would harden the component itself — deferred because it needs a components publish + dep bump.