### PR TITLE
feat(scheduling): shared-facility reserved cells (coordination view + live refresh)

### DIFF
--- a/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
+++ b/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
@@ -74,13 +74,14 @@ test.describe('Journey 86 — shared-facility reserved cells', () => {
           scheduleCells: [
             {
               tournamentId: PEER,
+              access: 'view', // coordination-view: a peer the viewer can't author → reserved
               matchUpId: 'peer-mu',
               courtId,
               venueId,
               courtOrder: 2,
               scheduledDate: DATE,
               scheduledTime: '14:00',
-              labels: ['Should Not Render'],
+              labels: ['Should Not Render'], // opaque cell kind must never surface participant labels
             },
           ],
         }),

--- a/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
+++ b/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady, seedSuperAdminTokenInitScript } from '../helpers/dev-bridge';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 86 — Shared-facility RESERVED cells.
+ *
+ * A court slot taken by another facility-sharing tournament the viewer can't author renders as a
+ * read-only "reserved" cell — fed by a slim schedule projection, NOT by loading peer records. The
+ * grid injects reserved cells into empty slots (`mergeReservedCellsIntoRows`) and courthive-components
+ * renders the `isReserved` kind.
+ *
+ * The projection endpoint is stubbed here (the server-side coordination-view/access work that makes
+ * it return other-tournament cells is separate). The primary owns court-order 1 on the shared court;
+ * the stubbed peer occupies court-order 2 — which must show as a reserved, non-draggable cell.
+ */
+
+const DATE = new Date().toISOString().slice(0, 10);
+const ID = 'e2e-reserved-primary';
+const PEER = 'e2e-reserved-peer';
+
+async function seedPrimary(page: Page): Promise<{ courtId: string; venueId: string; aMatchUpId: string }> {
+  return page.evaluate(
+    async ({ date, id, peer }) => {
+      await dev.tmx2db.initDB();
+      dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'E2E Reserved Primary',
+        tournamentAttributes: { tournamentId: id, startDate: date, endDate: date },
+        participantsProfile: { scaledParticipantsCount: 16 },
+        drawProfiles: [{ eventName: 'Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+        venueProfiles: [{ courtsCount: 2, venueName: 'Shared Venue' }],
+      });
+      const court = dev.factory.tournamentEngine.getVenuesAndCourts().venues[0].courts[0];
+      const mu = (dev.factory.competitionEngine.allTournamentMatchUps({}).matchUps || []).filter(
+        (m: any) =>
+          m.matchUpStatus !== 'BYE' &&
+          (m.sides || []).filter((s: any) => s.participantId || s.participant?.participantId).length === 2,
+      )[0];
+      dev.factory.tournamentEngine.addMatchUpScheduleItems({
+        matchUpId: mu.matchUpId,
+        drawId: mu.drawId,
+        schedule: { scheduledDate: date, scheduledTime: '10:00', venueId: court.venueId, courtId: court.courtId, courtOrder: 1 },
+      });
+      const rec = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+      rec.linkedTournamentIds = [id, peer]; // links drive which peers the projection is requested for
+      dev.factory.tournamentEngine.setState(rec); // put the linked record back on the engine (goto may reuse it)
+      await dev.tmx2db.addTournament(rec);
+      return { courtId: court.courtId, venueId: court.venueId, aMatchUpId: mu.matchUpId as string };
+    },
+    { date: DATE, id: ID, peer: PEER },
+  );
+}
+
+test.describe('Journey 86 — shared-facility reserved cells', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSuperAdminTokenInitScript(page);
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('a peer’s court occupancy renders as a read-only reserved cell on the shared court', async ({ page }) => {
+    const { courtId, venueId, aMatchUpId } = await seedPrimary(page);
+
+    // Stub the schedule projection: the peer occupies court-order 2 on the shared court at 14:00.
+    await page.route('**/factory/schedule-projection', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scheduleCells: [
+            {
+              tournamentId: PEER,
+              matchUpId: 'peer-mu',
+              courtId,
+              venueId,
+              courtOrder: 2,
+              scheduledDate: DATE,
+              scheduledTime: '14:00',
+              labels: ['Should Not Render'],
+            },
+          ],
+        }),
+      });
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(ID);
+    await page.waitForFunction(
+      (id) => dev.factory.competitionEngine.getTournamentInfo()?.tournamentInfo?.tournamentId === id,
+      ID,
+      { timeout: 15_000 },
+    );
+    await page.evaluate((hash) => (globalThis.location.hash = hash), `#/tournament/${ID}/scheduling/${DATE}/grid`);
+
+    // Own matchUp renders normally at court-order 1.
+    await page.waitForSelector(`[data-court-id="${courtId}"][data-court-order="1"][data-matchup-id="${aMatchUpId}"]`, {
+      state: 'visible',
+      timeout: 15_000,
+    });
+
+    // The peer's slot renders as a reserved cell at court-order 2 (fetched async, then the grid refreshes).
+    const reserved = page.locator(`[data-court-id="${courtId}"][data-court-order="2"] .spl-cell--reserved`);
+    await reserved.waitFor({ state: 'visible', timeout: 15_000 });
+    await expect(reserved).toContainText('Reserved');
+    await expect(reserved).toContainText('14:00');
+    // Opaque + read-only: no participant labels, and the wrapper carries no matchUpId (so no drag).
+    await expect(reserved).not.toContainText('Should Not Render');
+    const wrapper = page.locator(`[data-court-id="${courtId}"][data-court-order="2"]`).first();
+    expect(await wrapper.getAttribute('data-matchup-id')).toBeNull();
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -107,6 +107,8 @@ import {
   SET_MATCHUP_STATUS,
 } from 'constants/mutationConstants';
 import { COMPETITION_ENGINE, MINIMUM_SCHEDULE_COLUMNS, REPORTS_TAB, TOURNAMENT } from 'constants/tmxConstants';
+import { mergeReservedCellsIntoRows } from 'services/facilitySchedule/facilityScheduleHelpers';
+import { getReservedCellsForDate } from 'services/facilitySchedule/reservedCells';
 import { hiddenCourtIds, syncVisibilityDate } from './visibilityState';
 import { addVenue } from 'pages/tournament/tabs/venuesTab/addVenue';
 
@@ -1549,7 +1551,14 @@ function buildRowCourtCells(params: {
     const venueId = cellData?.schedule?.venueId ?? courtInfo?.venueId ?? '';
     const courtOrder = cellData?.schedule?.courtOrder ?? ri + 1;
 
-    const cellContent = buildScheduleGridCell(mapMatchUpToCellData(cellData || {}), DEFAULT_SCHEDULE_CELL_CONFIG);
+    // Reserved cells (another facility-sharing tournament's occupancy) are opaque + read-only: build
+    // them directly (bypass the matchUp mapper) and carry no matchUpId, so no drag source is attached.
+    const cellContent = cellData?.isReserved
+      ? buildScheduleGridCell(
+          { matchUpId: '', isReserved: true, reservation: cellData.reservation, schedule: cellData.schedule },
+          DEFAULT_SCHEDULE_CELL_CONFIG,
+        )
+      : buildScheduleGridCell(mapMatchUpToCellData(cellData || {}), DEFAULT_SCHEDULE_CELL_CONFIG);
 
     const cell = document.createElement('div');
     cell.style.cssText = 'min-height: 60px; font-size: 0.6875rem;';
@@ -1985,6 +1994,12 @@ function buildInteractiveGrid(selectedDate: string, callbacks: GridCallbacks): I
     const rows: any[] = scheduleResult.rows || [];
     const allCourtsData: any[] = scheduleResult.courtsData || [];
     const courtPrefix: string = scheduleResult.courtPrefix || 'C|';
+
+    // Overlay read-only reserved cells (other facility-sharing tournaments' court occupancy) into the
+    // empty slots of the owned grid. Data is a slim projection cached by reservedCells — no records
+    // are loaded. Runs before conflict annotation so a reserved slot participates in nothing else.
+    const primaryTournamentId = getCachedTournamentInfo()?.tournamentInfo?.tournamentId ?? '';
+    mergeReservedCellsIntoRows(rows, getReservedCellsForDate(date, primaryTournamentId), allCourtsData, courtPrefix);
 
     // Run proConflicts and annotate cell data with issue styling info
     if (allCourtsData.length) annotateConflicts(rows, allCourtsData, courtPrefix);

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -23,7 +23,8 @@ import { renderProfileView, destroyProfileView } from '../scheduleViews/profileV
 import { openClearScheduleMenu } from '../scheduleViews/clearScheduleActions';
 import { buildGridHeaderActions } from '../scheduleViews/gridHeaderActions';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
-import { competitionEngine } from 'services/factory/engine';
+import { loadReservedCells, clearReservedCells } from 'services/facilitySchedule/reservedCells';
+import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { buildSchedulingHeader, SchedulingHeader } from './schedulingHeader';
 import { resolveScheduleDate } from '../scheduleUtils';
 import { context } from 'services/context';
@@ -90,6 +91,21 @@ let queueUnsubscribe: (() => void) | null = null;
 let currentHeader: SchedulingHeader | null = null;
 let currentMode: SchedulingMode | null = null;
 let availabilityInstance: AvailabilityGridInstance | null = null;
+// Tournament id whose shared-facility reserved cells (other tournaments' court occupancy) are cached,
+// so we fetch them once per tab session rather than on every date change.
+let reservedLoadedFor: string | null = null;
+
+/**
+ * Fetch the loaded tournament's shared-facility reserved cells (a slim projection of other
+ * facility-sharing tournaments' court occupancy) and, once cached, refresh the grid so they render
+ * as read-only reserved cells. No records are loaded; best-effort — a no-op when there are none.
+ */
+async function loadReservedCellsForGrid(tournamentId: string): Promise<void> {
+  const primary = tournamentEngine.q.tournament();
+  if (primary?.tournamentId !== tournamentId) return; // tab changed underneath us
+  const count = await loadReservedCells(primary);
+  if (count > 0 && reservedLoadedFor === tournamentId) refreshGridView();
+}
 
 function readBoolFlag(key: string, fallback: boolean): boolean {
   try {
@@ -172,6 +188,14 @@ export function renderSchedulingTab(params: RenderSchedulingTabParams = {}): voi
   queueUnsubscribe?.();
   queueUnsubscribe = subscribeQueue(refreshActionBar);
   refreshActionBar();
+
+  // Shared-facility overlay: in grid mode, fetch other tournaments' court occupancy once per tab
+  // session so it renders as read-only reserved cells. Gated on tournamentId so a date change within
+  // the tab doesn't re-fetch.
+  if (resolvedMode === 'grid' && tournamentId && reservedLoadedFor !== tournamentId) {
+    reservedLoadedFor = tournamentId;
+    void loadReservedCellsForGrid(tournamentId);
+  }
 }
 
 export function destroySchedulingTab(): void {
@@ -179,6 +203,10 @@ export function destroySchedulingTab(): void {
   currentHeader = null;
   queueUnsubscribe?.();
   queueUnsubscribe = null;
+  // Drop cached shared-facility reserved cells so the next mount (possibly a different tournament)
+  // starts clean.
+  clearReservedCells();
+  reservedLoadedFor = null;
   destroyCurrentMode();
   // Drop every cached factory result so the next mount (possibly a different
   // tournament, or after external mutations that bypassed onMutationApplied)

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -23,7 +23,8 @@ import { renderProfileView, destroyProfileView } from '../scheduleViews/profileV
 import { openClearScheduleMenu } from '../scheduleViews/clearScheduleActions';
 import { buildGridHeaderActions } from '../scheduleViews/gridHeaderActions';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
-import { loadReservedCells, clearReservedCells } from 'services/facilitySchedule/reservedCells';
+import { loadReservedCells, reloadReservedCells, clearReservedCells } from 'services/facilitySchedule/reservedCells';
+import { peerLinkedIds } from 'services/facilitySchedule/facilityScheduleHelpers';
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { buildSchedulingHeader, SchedulingHeader } from './schedulingHeader';
 import { resolveScheduleDate } from '../scheduleUtils';
@@ -94,17 +95,56 @@ let availabilityInstance: AvailabilityGridInstance | null = null;
 // Tournament id whose shared-facility reserved cells (other tournaments' court occupancy) are cached,
 // so we fetch them once per tab session rather than on every date change.
 let reservedLoadedFor: string | null = null;
+// Live-refresh handles for the reserved-cell overlay. Peer reschedules are not broadcast to us (the
+// peer tournament isn't loaded), so we keep the projection reasonably fresh by polling + on focus.
+let reservedRefreshTimer: ReturnType<typeof setInterval> | null = null;
+let reservedFocusHandler: (() => void) | null = null;
+const RESERVED_REFRESH_MS = 60_000;
 
 /**
  * Fetch the loaded tournament's shared-facility reserved cells (a slim projection of other
  * facility-sharing tournaments' court occupancy) and, once cached, refresh the grid so they render
  * as read-only reserved cells. No records are loaded; best-effort — a no-op when there are none.
+ * When the tournament has linked peers, also starts a lightweight live refresh.
  */
 async function loadReservedCellsForGrid(tournamentId: string): Promise<void> {
   const primary = tournamentEngine.q.tournament();
   if (primary?.tournamentId !== tournamentId) return; // tab changed underneath us
   const count = await loadReservedCells(primary);
-  if (count > 0 && reservedLoadedFor === tournamentId) refreshGridView();
+  if (reservedLoadedFor !== tournamentId) return; // tab moved on during the fetch
+  if (count > 0) refreshGridView();
+  if (peerLinkedIds(primary).length) startReservedCellsLiveRefresh(tournamentId);
+}
+
+/**
+ * Keep reserved cells reasonably fresh without a server broadcast: re-fetch on a modest interval and
+ * whenever the tab regains focus, re-rendering the grid only when the projection actually changed.
+ */
+function startReservedCellsLiveRefresh(tournamentId: string): void {
+  stopReservedCellsLiveRefresh();
+  const tick = async () => {
+    const primary = tournamentEngine.q.tournament();
+    if (primary?.tournamentId !== tournamentId || reservedLoadedFor !== tournamentId) return;
+    if (await reloadReservedCells(primary)) refreshGridView();
+  };
+  reservedRefreshTimer = setInterval(() => void tick(), RESERVED_REFRESH_MS);
+  reservedFocusHandler = () => {
+    if (document.visibilityState === 'visible') void tick();
+  };
+  globalThis.addEventListener('focus', reservedFocusHandler);
+  document.addEventListener('visibilitychange', reservedFocusHandler);
+}
+
+function stopReservedCellsLiveRefresh(): void {
+  if (reservedRefreshTimer) {
+    clearInterval(reservedRefreshTimer);
+    reservedRefreshTimer = null;
+  }
+  if (reservedFocusHandler) {
+    globalThis.removeEventListener('focus', reservedFocusHandler);
+    document.removeEventListener('visibilitychange', reservedFocusHandler);
+    reservedFocusHandler = null;
+  }
 }
 
 function readBoolFlag(key: string, fallback: boolean): boolean {
@@ -203,8 +243,9 @@ export function destroySchedulingTab(): void {
   currentHeader = null;
   queueUnsubscribe?.();
   queueUnsubscribe = null;
-  // Drop cached shared-facility reserved cells so the next mount (possibly a different tournament)
-  // starts clean.
+  // Stop the reserved-cell live refresh + drop the cache so the next mount (possibly a different
+  // tournament) starts clean.
+  stopReservedCellsLiveRefresh();
   clearReservedCells();
   reservedLoadedFor = null;
   destroyCurrentMode();

--- a/src/services/apis/servicesApi.ts
+++ b/src/services/apis/servicesApi.ts
@@ -22,15 +22,21 @@ export async function requestTournamentUpdatedAt({ tournamentId, silent }: { tou
  * requested tournaments the caller is authorized to view, optionally filtered to venueIds. Used to
  * overlay linked peers' court claims without loading their full records. */
 export async function fetchScheduleProjection({
+  tournamentId,
   tournamentIds,
   venueIds,
   silent,
 }: {
-  tournamentIds: string[];
+  tournamentId?: string;
+  tournamentIds?: string[];
   venueIds?: string[];
   silent?: boolean;
 }) {
-  return await baseApi.post('/factory/schedule-projection', { tournamentIds, venueIds }, silent ? { silenceErrors: true } : undefined);
+  return await baseApi.post(
+    '/factory/schedule-projection',
+    { tournamentId, tournamentIds, venueIds },
+    silent ? { silenceErrors: true } : undefined,
+  );
 }
 
 export async function addProvider({ provider }: { provider: any }) {

--- a/src/services/facilitySchedule/facilityScheduleHelpers.test.ts
+++ b/src/services/facilitySchedule/facilityScheduleHelpers.test.ts
@@ -1,4 +1,11 @@
-import { peerLinkedIds, primaryVenueIds, peerOccupancyForDate, conflictsForDate, cellLabel } from './facilityScheduleHelpers';
+import {
+  peerLinkedIds,
+  primaryVenueIds,
+  peerOccupancyForDate,
+  conflictsForDate,
+  cellLabel,
+  mergeReservedCellsIntoRows,
+} from './facilityScheduleHelpers';
 import { describe, it, expect } from 'vitest';
 
 const DATE = '2025-01-01';
@@ -63,5 +70,55 @@ describe('facilityScheduleHelpers', () => {
   it('cellLabel composes time, round and players with fallbacks', () => {
     expect(cellLabel({ scheduledTime: '09:00', roundName: 'R16', labels: ['A', 'B'] })).toEqual('09:00 R16 A v B');
     expect(cellLabel({ labels: [] , matchUpId: 'm9' })).toEqual('m9');
+  });
+});
+
+describe('mergeReservedCellsIntoRows', () => {
+  const courtsData = [{ courtId: 'c0' }, { courtId: 'c1' }];
+
+  it('places a reserved cell in the empty slot at its court column + courtOrder row', () => {
+    const rows: any[] = [{ rowId: 'r0' }, { rowId: 'r1' }];
+    mergeReservedCellsIntoRows(
+      rows,
+      [{ courtId: 'c1', courtOrder: 2, venueId: 'v1', scheduledTime: '14:00' }],
+      courtsData,
+      'C|',
+    );
+    expect(rows[1]['C|1']).toMatchObject({
+      isReserved: true,
+      reservation: { scheduledTime: '14:00' },
+      schedule: { courtId: 'c1', courtOrder: 2, venueId: 'v1' },
+    });
+  });
+
+  it('never overwrites an owned matchUp (SAME_COURT_ORDER clash keeps the owned cell)', () => {
+    const rows: any[] = [{ 'C|0': { matchUpId: 'own' } }];
+    mergeReservedCellsIntoRows(rows, [{ courtId: 'c0', courtOrder: 1 }], [{ courtId: 'c0' }], 'C|');
+    expect(rows[0]['C|0']).toEqual({ matchUpId: 'own' });
+  });
+
+  it('replaces an empty placeholder slot (no matchUpId) — the grid pre-populates empty cells', () => {
+    const rows: any[] = [{ 'C|0': { matchUpId: '', schedule: {} } }];
+    mergeReservedCellsIntoRows(rows, [{ courtId: 'c0', courtOrder: 1, scheduledTime: '09:00' }], [{ courtId: 'c0' }], 'C|');
+    expect(rows[0]['C|0']).toMatchObject({ isReserved: true, reservation: { scheduledTime: '09:00' } });
+  });
+
+  it('skips a court not present in this grid', () => {
+    const rows: any[] = [{}];
+    mergeReservedCellsIntoRows(rows, [{ courtId: 'not-here', courtOrder: 1 }], [{ courtId: 'c0' }], 'C|');
+    expect(rows[0]).toEqual({});
+  });
+
+  it('skips a courtOrder beyond the rendered rows', () => {
+    const rows: any[] = [{}];
+    mergeReservedCellsIntoRows(rows, [{ courtId: 'c0', courtOrder: 5 }], [{ courtId: 'c0' }], 'C|');
+    expect(rows[0]).toEqual({});
+  });
+
+  it('is a no-op with empty rows or empty cells', () => {
+    expect(() => mergeReservedCellsIntoRows([], [{ courtId: 'c0', courtOrder: 1 }], [{ courtId: 'c0' }], 'C|')).not.toThrow();
+    const rows: any[] = [{}];
+    mergeReservedCellsIntoRows(rows, [], [{ courtId: 'c0' }], 'C|');
+    expect(rows[0]).toEqual({});
   });
 });

--- a/src/services/facilitySchedule/facilityScheduleHelpers.ts
+++ b/src/services/facilitySchedule/facilityScheduleHelpers.ts
@@ -46,3 +46,41 @@ export function cellLabel(cell: any): string {
   const players = Array.isArray(cell?.labels) && cell.labels.length ? cell.labels.join(' v ') : '';
   return `${time}${round}${players}`.trim() || cell?.matchUpId || '';
 }
+
+/**
+ * Inject read-only reserved cells (other tournaments' court occupancy, from a schedule projection)
+ * into the grid's `rows` model IN PLACE. A reserved cell lands in the empty slot at its court column
+ * (`courtId` → index in `courtsData`, keyed `${courtPrefix}${index}`) and its `courtOrder` row
+ * (`rows[courtOrder - 1]`). Occupied slots (the viewer's own matchUp) are never overwritten — a
+ * SAME_COURT_ORDER clash keeps the owned matchUp and drops the reserved marker. Cells for courts not
+ * in this grid, or whose `courtOrder` exceeds the rendered rows, are skipped. Opaque by design: only
+ * the scheduled time is surfaced, never participants/round.
+ *
+ * `courtsData` must be the FULL (pre-visibility-filter) court list, since row keys use those indices.
+ */
+export function mergeReservedCellsIntoRows(
+  rows: any[],
+  reservedCells: any[],
+  courtsData: any[],
+  courtPrefix: string,
+): void {
+  if (!reservedCells?.length || !rows?.length) return;
+  const courtIndexById = new Map<string, number>();
+  for (let i = 0; i < courtsData.length; i++) courtIndexById.set(courtsData[i].courtId, i);
+
+  for (const cell of reservedCells) {
+    const courtIndex = courtIndexById.get(cell?.courtId);
+    if (courtIndex === undefined) continue;
+    const ri = (cell?.courtOrder ?? 0) - 1;
+    if (ri < 0 || ri >= rows.length || !rows[ri]) continue;
+    const key = `${courtPrefix}${courtIndex}`;
+    // Skip only a slot holding an OWNED matchUp — the grid pre-populates empty slots with placeholder
+    // cell objects (no matchUpId), which must be replaceable by a reserved marker.
+    if (rows[ri][key]?.matchUpId) continue;
+    rows[ri][key] = {
+      isReserved: true,
+      reservation: { scheduledTime: cell?.scheduledTime },
+      schedule: { courtId: cell.courtId, courtOrder: cell.courtOrder, venueId: cell?.venueId },
+    };
+  }
+}

--- a/src/services/facilitySchedule/reservedCells.test.ts
+++ b/src/services/facilitySchedule/reservedCells.test.ts
@@ -1,7 +1,8 @@
 /**
- * reservedCells — fetch + cache of other facility-sharing tournaments' court occupancy (a slim
- * schedule projection). No tournamentRecords are loaded; a projection cell for another tournament is
- * a reserved slot from the viewer's perspective.
+ * reservedCells — coordination-view fetch + cache of other facility-sharing tournaments' court
+ * occupancy. The request sends the loaded (authored) tournament as the context; the server returns
+ * its linked peers' projections tagged access:'author'|'view'. Only `view` peers are reserved slots
+ * (a different director/provider); `author` peers render normally. No tournamentRecords are loaded.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,6 +20,7 @@ const primaryRecord = (peerIds: string[]) => ({
   linkedTournamentIds: [PRIMARY, ...peerIds],
   venues: [{ venueId: 'v1' }],
 });
+const viewCell = (over: any) => ({ tournamentId: 'peer', access: 'view', courtId: 'c1', ...over });
 const proj = (cells: any[]) => ({ data: { scheduleCells: cells } });
 
 beforeEach(() => {
@@ -28,11 +30,11 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe('loadReservedCells', () => {
-  it('caches other-tournament cells and exposes them per date', async () => {
+  it('requests the coordination view for the context tournament and caches view cells per date', async () => {
     fetchScheduleProjectionMock.mockResolvedValue(
       proj([
-        { tournamentId: 'peer', courtId: 'c1', courtOrder: 2, scheduledDate: DATE, scheduledTime: '14:00' },
-        { tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE_2 },
+        viewCell({ courtOrder: 2, scheduledDate: DATE, scheduledTime: '14:00' }),
+        viewCell({ courtOrder: 1, scheduledDate: DATE_2 }),
       ]),
     );
 
@@ -40,7 +42,7 @@ describe('loadReservedCells', () => {
 
     expect(count).toBe(2);
     expect(fetchScheduleProjectionMock).toHaveBeenCalledWith(
-      expect.objectContaining({ tournamentIds: ['peer'], venueIds: ['v1'] }),
+      expect.objectContaining({ tournamentId: PRIMARY, venueIds: ['v1'] }),
     );
     expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.courtOrder)).toEqual([2]);
     expect(getReservedCellsForDate(DATE_2, PRIMARY)).toHaveLength(1);
@@ -48,18 +50,18 @@ describe('loadReservedCells', () => {
     expect(hasReservedCells(PRIMARY)).toBe(true);
   });
 
-  it('excludes the primary tournament’s own cells (only other tournaments are reserved)', async () => {
+  it('keeps only view-access cells — author peers render normally, not as reserved', async () => {
     fetchScheduleProjectionMock.mockResolvedValue(
       proj([
-        { tournamentId: PRIMARY, courtId: 'c1', courtOrder: 1, scheduledDate: DATE },
-        { tournamentId: 'peer', courtId: 'c1', courtOrder: 2, scheduledDate: DATE },
+        { tournamentId: 'own-linked', access: 'author', courtId: 'c1', courtOrder: 1, scheduledDate: DATE },
+        viewCell({ courtOrder: 2, scheduledDate: DATE }),
       ]),
     );
 
-    const count = await loadReservedCells(primaryRecord(['peer']));
+    const count = await loadReservedCells(primaryRecord(['peer', 'own-linked']));
 
     expect(count).toBe(1);
-    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.tournamentId)).toEqual(['peer']);
+    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.access)).toEqual(['view']);
   });
 
   it('does not fetch and caches an empty set when there are no linked peers', async () => {
@@ -79,18 +81,14 @@ describe('loadReservedCells', () => {
 
 describe('getReservedCellsForDate / clearReservedCells', () => {
   it('returns nothing for a different tournament than the one cached', async () => {
-    fetchScheduleProjectionMock.mockResolvedValue(
-      proj([{ tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE }]),
-    );
+    fetchScheduleProjectionMock.mockResolvedValue(proj([viewCell({ courtOrder: 1, scheduledDate: DATE })]));
     await loadReservedCells(primaryRecord(['peer']));
     expect(getReservedCellsForDate(DATE, 'other-tournament')).toEqual([]);
     expect(hasReservedCells('other-tournament')).toBe(false);
   });
 
   it('clearReservedCells empties the cache', async () => {
-    fetchScheduleProjectionMock.mockResolvedValue(
-      proj([{ tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE }]),
-    );
+    fetchScheduleProjectionMock.mockResolvedValue(proj([viewCell({ courtOrder: 1, scheduledDate: DATE })]));
     await loadReservedCells(primaryRecord(['peer']));
     clearReservedCells();
     expect(getReservedCellsForDate(DATE, PRIMARY)).toEqual([]);

--- a/src/services/facilitySchedule/reservedCells.test.ts
+++ b/src/services/facilitySchedule/reservedCells.test.ts
@@ -1,0 +1,99 @@
+/**
+ * reservedCells — fetch + cache of other facility-sharing tournaments' court occupancy (a slim
+ * schedule projection). No tournamentRecords are loaded; a projection cell for another tournament is
+ * a reserved slot from the viewer's perspective.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchScheduleProjectionMock } = vi.hoisted(() => ({ fetchScheduleProjectionMock: vi.fn() }));
+
+vi.mock('services/apis/servicesApi', () => ({ fetchScheduleProjection: fetchScheduleProjectionMock }));
+
+import { loadReservedCells, getReservedCellsForDate, hasReservedCells, clearReservedCells } from './reservedCells';
+
+const PRIMARY = 'primary';
+const DATE = '2026-07-20';
+const DATE_2 = '2026-07-21';
+const primaryRecord = (peerIds: string[]) => ({
+  tournamentId: PRIMARY,
+  linkedTournamentIds: [PRIMARY, ...peerIds],
+  venues: [{ venueId: 'v1' }],
+});
+const proj = (cells: any[]) => ({ data: { scheduleCells: cells } });
+
+beforeEach(() => {
+  fetchScheduleProjectionMock.mockReset();
+  clearReservedCells();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('loadReservedCells', () => {
+  it('caches other-tournament cells and exposes them per date', async () => {
+    fetchScheduleProjectionMock.mockResolvedValue(
+      proj([
+        { tournamentId: 'peer', courtId: 'c1', courtOrder: 2, scheduledDate: DATE, scheduledTime: '14:00' },
+        { tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE_2 },
+      ]),
+    );
+
+    const count = await loadReservedCells(primaryRecord(['peer']));
+
+    expect(count).toBe(2);
+    expect(fetchScheduleProjectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tournamentIds: ['peer'], venueIds: ['v1'] }),
+    );
+    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.courtOrder)).toEqual([2]);
+    expect(getReservedCellsForDate(DATE_2, PRIMARY)).toHaveLength(1);
+    expect(getReservedCellsForDate('2099-01-01', PRIMARY)).toEqual([]);
+    expect(hasReservedCells(PRIMARY)).toBe(true);
+  });
+
+  it('excludes the primary tournament’s own cells (only other tournaments are reserved)', async () => {
+    fetchScheduleProjectionMock.mockResolvedValue(
+      proj([
+        { tournamentId: PRIMARY, courtId: 'c1', courtOrder: 1, scheduledDate: DATE },
+        { tournamentId: 'peer', courtId: 'c1', courtOrder: 2, scheduledDate: DATE },
+      ]),
+    );
+
+    const count = await loadReservedCells(primaryRecord(['peer']));
+
+    expect(count).toBe(1);
+    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.tournamentId)).toEqual(['peer']);
+  });
+
+  it('does not fetch and caches an empty set when there are no linked peers', async () => {
+    const count = await loadReservedCells(primaryRecord([]));
+    expect(count).toBe(0);
+    expect(fetchScheduleProjectionMock).not.toHaveBeenCalled();
+    expect(getReservedCellsForDate(DATE, PRIMARY)).toEqual([]);
+  });
+
+  it('degrades to an empty cache on a failed projection', async () => {
+    fetchScheduleProjectionMock.mockRejectedValue(new Error('403'));
+    const count = await loadReservedCells(primaryRecord(['peer']));
+    expect(count).toBe(0);
+    expect(getReservedCellsForDate(DATE, PRIMARY)).toEqual([]);
+  });
+});
+
+describe('getReservedCellsForDate / clearReservedCells', () => {
+  it('returns nothing for a different tournament than the one cached', async () => {
+    fetchScheduleProjectionMock.mockResolvedValue(
+      proj([{ tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE }]),
+    );
+    await loadReservedCells(primaryRecord(['peer']));
+    expect(getReservedCellsForDate(DATE, 'other-tournament')).toEqual([]);
+    expect(hasReservedCells('other-tournament')).toBe(false);
+  });
+
+  it('clearReservedCells empties the cache', async () => {
+    fetchScheduleProjectionMock.mockResolvedValue(
+      proj([{ tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE }]),
+    );
+    await loadReservedCells(primaryRecord(['peer']));
+    clearReservedCells();
+    expect(getReservedCellsForDate(DATE, PRIMARY)).toEqual([]);
+    expect(hasReservedCells(PRIMARY)).toBe(false);
+  });
+});

--- a/src/services/facilitySchedule/reservedCells.test.ts
+++ b/src/services/facilitySchedule/reservedCells.test.ts
@@ -10,7 +10,13 @@ const { fetchScheduleProjectionMock } = vi.hoisted(() => ({ fetchScheduleProject
 
 vi.mock('services/apis/servicesApi', () => ({ fetchScheduleProjection: fetchScheduleProjectionMock }));
 
-import { loadReservedCells, getReservedCellsForDate, hasReservedCells, clearReservedCells } from './reservedCells';
+import {
+  loadReservedCells,
+  reloadReservedCells,
+  getReservedCellsForDate,
+  hasReservedCells,
+  clearReservedCells,
+} from './reservedCells';
 
 const PRIMARY = 'primary';
 const DATE = '2026-07-20';
@@ -93,5 +99,21 @@ describe('getReservedCellsForDate / clearReservedCells', () => {
     clearReservedCells();
     expect(getReservedCellsForDate(DATE, PRIMARY)).toEqual([]);
     expect(hasReservedCells(PRIMARY)).toBe(false);
+  });
+});
+
+describe('reloadReservedCells (live-refresh change detection)', () => {
+  it('reports no change when the projection is identical', async () => {
+    fetchScheduleProjectionMock.mockResolvedValue(proj([viewCell({ courtOrder: 1, scheduledDate: DATE })]));
+    await loadReservedCells(primaryRecord(['peer']));
+    expect(await reloadReservedCells(primaryRecord(['peer']))).toBe(false);
+  });
+
+  it('reports a change when a peer reschedules (cells differ)', async () => {
+    fetchScheduleProjectionMock.mockResolvedValueOnce(proj([viewCell({ courtOrder: 1, scheduledDate: DATE })]));
+    await loadReservedCells(primaryRecord(['peer']));
+    fetchScheduleProjectionMock.mockResolvedValueOnce(proj([viewCell({ courtOrder: 3, scheduledDate: DATE })]));
+    expect(await reloadReservedCells(primaryRecord(['peer']))).toBe(true);
+    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.courtOrder)).toEqual([3]);
   });
 });

--- a/src/services/facilitySchedule/reservedCells.ts
+++ b/src/services/facilitySchedule/reservedCells.ts
@@ -10,10 +10,10 @@ import { fetchScheduleProjection } from 'services/apis/servicesApi';
  * and caches those cells for the loaded tournament; `gridView` reads them per-date and injects them
  * into empty grid slots.
  *
- * NOTE: which cells are actually reserved (vs the viewer's own, which render normally) ultimately
- * depends on the server's per-tournament `access` flag (view vs author) — the CFS coordination-view
- * work. Until that lands, the projection only returns tournaments the viewer can already see, so this
- * surfaces nothing in production; it is exercised via a stubbed projection in e2e.
+ * The request is the coordination view: it sends the loaded (authored) tournament as the context, and
+ * the server returns projections of its server-verified linked peers tagged `access:'author'|'view'`.
+ * Only `view` peers (a different director/provider sharing the facility) are reserved cells — an
+ * `author` peer is the viewer's own linked tournament and renders normally, not as a reserved slot.
  */
 
 let cache: { tournamentId: string; cells: any[] } | null = null;
@@ -27,20 +27,20 @@ export async function loadReservedCells(primaryRecord: any): Promise<number> {
   const primaryId = primaryRecord?.tournamentId;
   if (!primaryId) return 0;
 
-  const peerIds = peerLinkedIds(primaryRecord);
-  if (!peerIds.length) {
+  // No linked peers → nothing to coordinate around; skip the server round-trip.
+  if (!peerLinkedIds(primaryRecord).length) {
     cache = { tournamentId: primaryId, cells: [] };
     return 0;
   }
 
   try {
     const result: any = await fetchScheduleProjection({
-      tournamentIds: peerIds,
+      tournamentId: primaryId, // coordination context — the server expands to this tournament's links
       venueIds: primaryVenueIds(primaryRecord),
       silent: true,
     });
-    // A projection cell for another tournament = a reserved slot from the viewer's perspective.
-    const cells = (result?.data?.scheduleCells ?? []).filter((cell: any) => cell?.tournamentId !== primaryId);
+    // Only `view` peers are reserved slots; `author` peers are the viewer's own and render normally.
+    const cells = (result?.data?.scheduleCells ?? []).filter((cell: any) => cell?.access === 'view');
     cache = { tournamentId: primaryId, cells };
     return cells.length;
   } catch {

--- a/src/services/facilitySchedule/reservedCells.ts
+++ b/src/services/facilitySchedule/reservedCells.ts
@@ -49,6 +49,18 @@ export async function loadReservedCells(primaryRecord: any): Promise<number> {
   }
 }
 
+/**
+ * Re-fetch reserved cells and report whether they changed since the cached set. Used by the grid's
+ * lightweight live refresh — a peer director's reschedule is NOT broadcast to this client (the peer
+ * isn't loaded), so we poll/refresh-on-focus and only re-render the grid when something actually
+ * moved.
+ */
+export async function reloadReservedCells(primaryRecord: any): Promise<boolean> {
+  const before = JSON.stringify(cache?.cells ?? []);
+  await loadReservedCells(primaryRecord);
+  return JSON.stringify(cache?.cells ?? []) !== before;
+}
+
 /** Reserved cells for a given date, scoped to the loaded tournament. Empty when none are cached. */
 export function getReservedCellsForDate(scheduledDate: string, primaryId: string): any[] {
   if (!cache || cache.tournamentId !== primaryId) return [];

--- a/src/services/facilitySchedule/reservedCells.ts
+++ b/src/services/facilitySchedule/reservedCells.ts
@@ -1,0 +1,66 @@
+import { peerLinkedIds, primaryVenueIds } from './facilityScheduleHelpers';
+import { fetchScheduleProjection } from 'services/apis/servicesApi';
+
+/**
+ * Shared-facility reserved cells.
+ *
+ * A court slot taken by ANOTHER facility-sharing tournament the viewer can't author is shown in the
+ * grid as a read-only "reserved" cell (see courthive-components `isReserved`). The data is a slim
+ * `ScheduleCell[]` from the schedule projection — NOT loaded tournamentRecords. This module fetches
+ * and caches those cells for the loaded tournament; `gridView` reads them per-date and injects them
+ * into empty grid slots.
+ *
+ * NOTE: which cells are actually reserved (vs the viewer's own, which render normally) ultimately
+ * depends on the server's per-tournament `access` flag (view vs author) — the CFS coordination-view
+ * work. Until that lands, the projection only returns tournaments the viewer can already see, so this
+ * surfaces nothing in production; it is exercised via a stubbed projection in e2e.
+ */
+
+let cache: { tournamentId: string; cells: any[] } | null = null;
+
+/**
+ * Fetch the reserved cells (other-tournament court occupancy) for the primary's linked facility
+ * peers and cache them. Best-effort: a failed/absent projection caches an empty set rather than
+ * throwing. Returns the number of reserved cells loaded.
+ */
+export async function loadReservedCells(primaryRecord: any): Promise<number> {
+  const primaryId = primaryRecord?.tournamentId;
+  if (!primaryId) return 0;
+
+  const peerIds = peerLinkedIds(primaryRecord);
+  if (!peerIds.length) {
+    cache = { tournamentId: primaryId, cells: [] };
+    return 0;
+  }
+
+  try {
+    const result: any = await fetchScheduleProjection({
+      tournamentIds: peerIds,
+      venueIds: primaryVenueIds(primaryRecord),
+      silent: true,
+    });
+    // A projection cell for another tournament = a reserved slot from the viewer's perspective.
+    const cells = (result?.data?.scheduleCells ?? []).filter((cell: any) => cell?.tournamentId !== primaryId);
+    cache = { tournamentId: primaryId, cells };
+    return cells.length;
+  } catch {
+    cache = { tournamentId: primaryId, cells: [] };
+    return 0;
+  }
+}
+
+/** Reserved cells for a given date, scoped to the loaded tournament. Empty when none are cached. */
+export function getReservedCellsForDate(scheduledDate: string, primaryId: string): any[] {
+  if (!cache || cache.tournamentId !== primaryId) return [];
+  return cache.cells.filter((cell) => cell?.scheduledDate === scheduledDate);
+}
+
+/** True when reserved cells are cached for this tournament (drives the load-once guard). */
+export function hasReservedCells(primaryId: string): boolean {
+  return cache?.tournamentId === primaryId;
+}
+
+/** Drop the cache — called on scheduling teardown / tournament switch. */
+export function clearReservedCells(): void {
+  cache = null;
+}


### PR DESCRIPTION
## What
Renders another facility-sharing tournament's court occupancy as **read-only reserved cells** in the schedule grid — fed by a slim projection, **no peer records loaded, no overlay**.

- `reservedCells` service: fetches the **coordination-view** projection (sends the loaded/authored tournament as context; keeps only `access:'view'` cells — `author` peers are the viewer's own and render normally), caches per tournament
- `mergeReservedCellsIntoRows` (pure): injects reserved cells into empty grid slots (`courtId`→column, `courtOrder`→row); **never** overwrites an owned matchUp (the grid pre-populates empty slots with placeholder cells, so the guard keys on `.matchUpId`)
- `gridView`: reserved cells bypass the matchUp mapper + attach no drag source
- `schedulingTab`: fetch once per grid session; **lightweight live refresh** (60s poll + refresh-on-focus, re-render only on change) since peer reschedules aren't broadcast to us; torn down on teardown
- `fetchScheduleProjection` gains the context `tournamentId` form

## Tests
- `reservedCells` + `mergeReservedCellsIntoRows` unit suites (incl. change-detection); **975 unit tests, lint 0, tsc 0**
- **e2e journey 86**: stubbed projection → reserved cell renders opaque + read-only on the shared court (own matchUp normal at order 1, reserved at order 2)

## Ecosystem — merge order
1. **courthive-components #482** (the `isReserved` cell kind) → publish + bump
2. **CFS #828** (coordination-view endpoint) + this PR together — this client sends the context `tournamentId` the CFS PR expects.

Same provider + same director is unchanged (renders normally as ordinary matchUps).