### PR TITLE
fix(scheduling): gate schedule auto-call to tournament provider members

### DIFF
--- a/e2e/helpers/dev-bridge.ts
+++ b/e2e/helpers/dev-bridge.ts
@@ -168,6 +168,46 @@ export async function seedSuperAdminTokenInitScript(page: Page): Promise<void> {
 }
 
 /**
+ * Seed a NON-super-admin JWT whose `providerAssociations` tie the user to a
+ * specific provider, so provider-member-gated behaviour fires in e2e. The
+ * schedule "Now" strip auto-call (isTournamentProviderMember → runAutoCallPass)
+ * only stamps calledAt for a user associated with the loaded tournament's
+ * provider, so any journey asserting auto-call must (a) seed the tournament with
+ * `parentOrganisation.organisationId === providerId` and (b) inject this token.
+ *
+ * Evaluate-based (not addInitScript): `getLoginState()` re-reads localStorage on
+ * every call, and the gate runs at strip-mount — after boot — so the token only
+ * needs to be present in localStorage by then. Call AFTER any beforeEach
+ * `localStorage.clear()` and before navigating to the scheduling view; the token
+ * persists across the in-SPA hash routes that follow. addInitScript would not
+ * work here: `tournament.goto('/#/...')` is a same-document hash change that
+ * doesn't reload, so an init script wouldn't re-fire, and the boot-set token
+ * would already be wiped by the clear. Roles deliberately exclude 'superadmin' —
+ * the gate must pass on genuine provider membership, not the super-admin escape.
+ */
+export async function loginAsProviderMember(page: Page, providerId: string): Promise<void> {
+  await page.evaluate((pid: string) => {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+    const payload = btoa(
+      JSON.stringify({
+        roles: ['client'],
+        sub: 'e2e-provider-member',
+        providerAssociations: [
+          {
+            providerId: pid,
+            providerRole: 'DIRECTOR',
+            organisationName: 'E2E Provider',
+            organisationAbbreviation: 'E2EP',
+          },
+        ],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    );
+    localStorage.setItem('tmxToken', `${header}.${payload}.fake-signature`);
+  }, providerId);
+}
+
+/**
  * Enable a beta feature flag in localStorage before the app boots.
  * Format Wizard, for example, is hidden from the UI until the user
  * opts in via Settings; e2e tests need the flag pre-seeded so the

--- a/e2e/journeys/29-schedule2-active-strip.spec.ts
+++ b/e2e/journeys/29-schedule2-active-strip.spec.ts
@@ -97,6 +97,15 @@ async function seedAndScheduleFirstMatchUp(
         drawId: target.drawId,
         schedule: { scheduledDate: date, courtId: targetCourt.courtId, courtOrder: 1, venueId: targetCourt.venueId },
       });
+      // Stamp calledAt so the scheduled match surfaces on the Now strip as NEXT.
+      // Previously implicit via mount-time auto-call, which is now provider-member-
+      // gated (this journey runs unauthenticated); making the precondition explicit
+      // keeps this test focused on strip rendering, not the auto-call mechanism.
+      dev.factory.tournamentEngine.setMatchUpCalledAt({
+        matchUpId: target.matchUpId,
+        drawId: target.drawId,
+        calledAt: new Date().toISOString(),
+      });
 
       // One persist call — no race.
       const mutated = dev.factory.tournamentEngine.getTournament().tournamentRecord;

--- a/e2e/journeys/49-schedule2-grid-swap.spec.ts
+++ b/e2e/journeys/49-schedule2-grid-swap.spec.ts
@@ -97,6 +97,16 @@ async function seedScheduled(
             ...(a.scheduledTime ? { scheduledTime: a.scheduledTime } : {}),
           },
         });
+        // Stamp calledAt so the match surfaces on the Now strip as NEXT (an
+        // "occupied" court). Previously this happened implicitly via mount-time
+        // auto-call; auto-call is now provider-member-gated (this journey runs
+        // unauthenticated), so the strip-occupancy precondition is made explicit
+        // here — it's the state under test, not the mechanism that produced it.
+        dev.factory.tournamentEngine.setMatchUpCalledAt({
+          matchUpId: mu.matchUpId,
+          drawId: mu.drawId,
+          calledAt: new Date().toISOString(),
+        });
         matchUpIds.push(mu.matchUpId);
       });
 

--- a/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
+++ b/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { initDevBridge, loginAsProviderMember, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { TournamentPage } from '../pages/TournamentPage';
 
@@ -12,15 +12,34 @@ import { TournamentPage } from '../pages/TournamentPage';
  * the strip refresh (gridView.ts:2241, today-gated), so the decision is
  * observable at mount via the mutation collector. A regression here silently
  * calls matches to court at the wrong time — a participant-notification hazard.
+ *
+ * Auto-call is provider-member-gated (isTournamentProviderMember): it only fires
+ * for a user associated with the tournament's provider, so this journey seeds
+ * `parentOrganisation` on the record (synced into engine state so the load-time
+ * short-circuit doesn't serve a parent-less in-memory copy) and logs in as a
+ * provider member via `loginAsProviderMember`. Without that, the auth gate — not
+ * the due-gate under test — would suppress the call and the second case would
+ * pass for the wrong reason.
  */
 
 const DATE = new Date().toISOString().slice(0, 10);
 const STRIP = '.spl-active-strip';
+const PROVIDER_ID = 'e2e-provider-1';
+
+/** Server-first would emit to a socket that never acks in the client-only e2e run;
+ *  keep the auto-call mutation local so it applies + logs deterministically. Set
+ *  after the full-page goto (fresh module state) and before the scheduling strip
+ *  mounts — navigateToScheduling is an in-SPA hash route, so this persists. */
+async function forceLocalExecution(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    dev.env.serverFirst = false;
+  });
+}
 
 /** Seed a single-court venue and schedule one pending R1 matchUp on today with the given time. */
 async function seedOnePlaced(page: Page, scheduledTime?: string): Promise<{ tournamentId: string; matchUpId: string }> {
   return page.evaluate(
-    async ({ date, scheduledTime }) => {
+    async ({ date, scheduledTime, providerId }) => {
       await dev.tmx2db.initDB();
       const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
         nonRandom: 1,
@@ -52,10 +71,21 @@ async function seedOnePlaced(page: Page, scheduledTime?: string): Promise<{ tour
       });
 
       const rec = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+      // Provider-scope the tournament so isTournamentProviderMember can match it
+      // against the seeded provider-member JWT (auto-call gate). Sync it into
+      // engine state too: `setState:true` already loaded a parent-less record, and
+      // loadTournament short-circuits when the engine already holds this id — so
+      // without this re-setState, goto would serve the parent-less in-memory copy.
+      rec.parentOrganisation = {
+        organisationId: providerId,
+        organisationName: 'E2E Provider',
+        organisationAbbreviation: 'E2EP',
+      };
+      dev.factory.tournamentEngine.setState(rec);
       await dev.tmx2db.addTournament(rec);
       return { tournamentId: tournamentRecord.tournamentId as string, matchUpId: match.matchUpId as string };
     },
-    { date: DATE, scheduledTime },
+    { date: DATE, scheduledTime, providerId: PROVIDER_ID },
   );
 }
 
@@ -75,6 +105,8 @@ test.describe('Journey 61 — now-strip auto-call due-gating', () => {
 
     const tournament = new TournamentPage(page);
     await tournament.goto(seed.tournamentId);
+    await loginAsProviderMember(page, PROVIDER_ID);
+    await forceLocalExecution(page);
     await tournament.navigateToScheduling();
     await page.waitForSelector(STRIP, { timeout: 10_000 });
 
@@ -92,6 +124,8 @@ test.describe('Journey 61 — now-strip auto-call due-gating', () => {
 
     const tournament = new TournamentPage(page);
     await tournament.goto('e2e-auto-call');
+    await loginAsProviderMember(page, PROVIDER_ID);
+    await forceLocalExecution(page);
     await tournament.navigateToScheduling();
     await page.waitForSelector(STRIP, { timeout: 10_000 });
 

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -86,6 +86,8 @@ import {
   getCachedTournamentInfo,
   getCachedAllMatchUps,
 } from './schedule2DataCache';
+import { isTournamentProviderMember } from 'services/authentication/isTournamentProviderMember';
+import { getLoginState } from 'services/authentication/loginState';
 import { computeAutoCalls } from './autoCallDueMatches';
 import {
   createSchedulePage,
@@ -2437,6 +2439,12 @@ function refreshActiveStrip(date: string): void {
  */
 function runAutoCallPass(columns: ActiveStripPanelData['grid']['columns']): void {
   if (!currentRefresh) return;
+  // Auto-call is a running-desk action, not a viewer side effect: only users
+  // associated with this tournament's provider trigger it. A super-admin (or any
+  // cross-provider viewer) merely observing must not stamp calledAt. Deferred:
+  // a per-provider on/off toggle (default ON for provider staff) + calling roles.
+  const { tournamentRecord } = tournamentEngine.getTournament() || {};
+  if (!isTournamentProviderMember({ loginState: getLoginState(), tournamentRecord })) return;
   const now = new Date();
   const nowHHMM = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
   const calls = computeAutoCalls(columns as any, nowHHMM);

--- a/src/services/authentication/isTournamentProviderMember.test.ts
+++ b/src/services/authentication/isTournamentProviderMember.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTournamentProviderMember } from './isTournamentProviderMember';
+
+const TOURNAMENT = { parentOrganisation: { organisationId: 'prov-1' } };
+
+describe('isTournamentProviderMember', () => {
+  it('false when no login state', () => {
+    expect(isTournamentProviderMember({ tournamentRecord: TOURNAMENT, loginState: null })).toBe(false);
+  });
+
+  it('false when tournament has no parentOrganisation.organisationId', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: {},
+        loginState: { providerAssociations: [{ providerId: 'prov-1', providerRole: 'DIRECTOR' }] },
+      }),
+    ).toBe(false);
+  });
+
+  it('false for a super-admin who is NOT associated with the tournament provider', () => {
+    // The load-bearing case: an observing super-admin must not auto-call.
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: { roles: ['superadmin'] },
+      }),
+    ).toBe(false);
+  });
+
+  it('true for any association at the tournament provider (DIRECTOR is desk staff)', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: {
+          roles: ['client'],
+          providerAssociations: [{ providerId: 'prov-1', providerRole: 'DIRECTOR' }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('true for PROVIDER_ADMIN at the tournament provider', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: {
+          roles: ['client'],
+          providerAssociations: [{ providerId: 'prov-1', providerRole: 'PROVIDER_ADMIN' }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('true for a provisioner managing the tournament provider', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: { roles: ['client'], provisionerProviders: [{ providerId: 'prov-1' }] },
+      }),
+    ).toBe(true);
+  });
+
+  it('false when the only association is at a different provider', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: {
+          roles: ['client'],
+          providerAssociations: [{ providerId: 'prov-other', providerRole: 'PROVIDER_ADMIN' }],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('true when a super-admin also has an association at the tournament provider', () => {
+    expect(
+      isTournamentProviderMember({
+        tournamentRecord: TOURNAMENT,
+        loginState: {
+          roles: ['superadmin'],
+          providerAssociations: [{ providerId: 'prov-1', providerRole: 'DIRECTOR' }],
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/services/authentication/isTournamentProviderMember.ts
+++ b/src/services/authentication/isTournamentProviderMember.ts
@@ -1,0 +1,41 @@
+/**
+ * "Is the current user a member of *this tournament's* provider?"
+ *
+ * Deliberate inverse of `isActiveProviderAdmin` / `canManageRegistrations`:
+ * there is **no super-admin shortcut**. A super-admin merely observing another
+ * provider's tournament must NOT be treated as provider staff — this predicate
+ * gates side effects that only the running desk should trigger (auto-call being
+ * the first: `runAutoCallPass` fires `setMatchUpCalledAt` on load + every
+ * ticker, and a viewing super-admin was stamping `calledAt` on tournaments they
+ * were only observing).
+ *
+ * Membership (any one, matched against the tournament's own provider):
+ *   1. PROVISIONER managing the tournament's provider (`provisionerProviders`)
+ *   2. any provider association at the tournament's provider (`providerAssociations`)
+ *
+ * Role is intentionally NOT narrowed to PROVIDER_ADMIN — any association with
+ * the running provider is desk staff for this purpose. When dedicated "calling"
+ * roles land, tighten the association check here.
+ *
+ * Loose `any` inputs mirror `canManageRegistrations`: both LoginState and
+ * Tournament carry many fields we don't need and are read defensively.
+ */
+export interface IsTournamentProviderMemberInput {
+  tournamentRecord?: any;
+  loginState?: any;
+}
+
+export function isTournamentProviderMember(input: IsTournamentProviderMemberInput): boolean {
+  const login = input.loginState;
+  if (!login) return false;
+
+  const providerId = input.tournamentRecord?.parentOrganisation?.organisationId;
+  if (!providerId) return false;
+
+  // Provisioner-managed provider counts as membership (matches CFS
+  // `provisionerProviderIds` in checkTournamentAccess).
+  if (login.provisionerProviders?.some((p) => p.providerId === providerId)) return true;
+
+  // Any direct association with the tournament's provider.
+  return !!login.providerAssociations?.some((a) => a.providerId === providerId);
+}


### PR DESCRIPTION
## Problem

`runAutoCallPass` in the schedule2 "Now" strip fired `setMatchUpCalledAt` for **anyone** viewing today's schedule — so a super-admin merely observing another provider's tournament was stamping `calledAt` on load and on the 30s ticker (observed: `rooby@courthive.com` auto-calling on BOBOCA with no manual action). Auto-call is a running-desk action, not a viewer side effect, and the server can't distinguish an auto-call from a manual call — so the gate must be client-side.

## Change

- New pure predicate `isTournamentProviderMember` — provisioner or any association at the **tournament's own** provider, with **no** super-admin shortcut (deliberate inverse of `isActiveProviderAdmin` / `canManageRegistrations`).
- `runAutoCallPass` bails unless the current user is a member of the loaded tournament's provider. The other three `SET_MATCHUP_CALLED_AT` sites are user-initiated (unschedule-clear ×2, drag-to-court drop) and unchanged.
- Default stays **ON** for provider staff; a per-provider on/off toggle and dedicated "calling" roles are deferred follow-ups.

## Tests

- New unit test for the predicate (8 cases), including the load-bearing "observing super-admin → false" and "super-admin who is also associated → true".
- e2e journeys 29 / 49 / 61 updated for the gate: journey 61 seeds `parentOrganisation` + logs in as a provider member so both cases exercise the due-gate (not the auth-gate); journeys 29/49 make the strip-occupancy precondition explicit (stamp `calledAt`) since they test rendering/drag-drop, not the gate. New helper `loginAsProviderMember`.

Verified: `pnpm check-types`, `pnpm lint`, unit suite (1024), and journeys 29/49/61 (17) all green.
