### PR TITLE
feat(scheduling): gate Plan tab behind schedulePlan beta flag

### DIFF
--- a/e2e/helpers/dev-bridge.ts
+++ b/e2e/helpers/dev-bridge.ts
@@ -215,7 +215,7 @@ export async function loginAsProviderMember(page: Page, providerId: string): Pro
  */
 export async function seedFeatureFlagInitScript(
   page: Page,
-  flag: 'formatWizard' | 'assistant' | 'reports',
+  flag: 'formatWizard' | 'assistant' | 'reports' | 'schedulePlan',
 ): Promise<void> {
   await page.addInitScript((flagName: string) => {
     const KEY = 'tmx_settings';

--- a/e2e/journeys/90-plan-mode-scenarios.spec.ts
+++ b/e2e/journeys/90-plan-mode-scenarios.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { initDevBridge, resetState, waitForAppReady, seedFeatureFlagInitScript } from '../helpers/dev-bridge';
 import { seedTournament } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';
 
@@ -112,6 +112,11 @@ async function seedScenario(
 
 test.describe('Journey 90 — schedule scenarios (Plan mode)', () => {
   test.beforeEach(async ({ page }) => {
+    // Plan mode is behind the schedulePlan beta flag — seed it into
+    // localStorage BEFORE the first navigation so hydrate enables it on boot
+    // and the 'Plan' switcher segment renders. Re-applied on every navigation
+    // by addInitScript, so it survives the localStorage.clear() below too.
+    await seedFeatureFlagInitScript(page, 'schedulePlan');
     await page.goto('/');
     await waitForAppReady(page);
     await initDevBridge(page);

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -8,12 +8,14 @@
 export interface FeatureFlags {
   assistant: boolean;
   formatWizard: boolean;
+  schedulePlan: boolean;
   usePublishState: boolean;
 }
 
 const defaults: FeatureFlags = {
   assistant: false,
   formatWizard: false,
+  schedulePlan: false,
   usePublishState: false,
 };
 

--- a/src/pages/tournament/tabs/schedulingTab/schedulingHeader.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingHeader.ts
@@ -10,6 +10,7 @@
  */
 import { buildScheduleDateSelector } from 'components/schedule/scheduleDateSelector';
 import { ScheduleDate } from 'courthive-components';
+import { featureFlags } from 'config/featureFlags';
 
 import type { SchedulingMode } from './schedulingTab';
 
@@ -67,7 +68,10 @@ export function buildSchedulingHeader(params: SchedulingHeaderParams): Schedulin
   const switcher = document.createElement('div');
   switcher.style.cssText = 'display: flex; align-items: center; gap: 0;';
 
-  MODES.forEach((mode, index) => {
+  // Plan mode is an in-flight beta — hide its segment unless the flag is on.
+  const modes = featureFlags.get().schedulePlan ? MODES : MODES.filter((mode) => mode.key !== 'plan');
+
+  modes.forEach((mode, index) => {
     const btn = document.createElement('button');
     btn.style.cssText = segmentBtnStyle(mode.key === activeMode);
     btn.title = mode.label;
@@ -82,7 +86,7 @@ export function buildSchedulingHeader(params: SchedulingHeaderParams): Schedulin
     });
 
     if (index === 0) btn.style.borderRadius = '6px 0 0 6px';
-    else if (index === MODES.length - 1) btn.style.borderRadius = '0 6px 6px 0';
+    else if (index === modes.length - 1) btn.style.borderRadius = '0 6px 6px 0';
     else btn.style.borderRadius = '0';
 
     switcher.appendChild(btn);

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -34,6 +34,7 @@ import { onFacilityScheduleChanged, onSocketReconnect } from 'services/messaging
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { buildSchedulingHeader, SchedulingHeader } from './schedulingHeader';
 import { resolveScheduleDate } from '../scheduleUtils';
+import { featureFlags } from 'config/featureFlags';
 import { context } from 'services/context';
 import { t } from 'i18n';
 import {
@@ -199,7 +200,11 @@ function writeBoolFlag(key: string, value: boolean): void {
 }
 
 function isValidMode(value: string | undefined): value is SchedulingMode {
-  return !!value && (VALID_MODES as string[]).includes(value);
+  if (!value || !(VALID_MODES as string[]).includes(value)) return false;
+  // Plan mode is an in-flight beta — a direct/bookmarked `.../plan` URL falls
+  // back to the default mode unless the flag is on (mirrors the hidden segment).
+  if (value === 'plan' && !featureFlags.get().schedulePlan) return false;
+  return true;
 }
 
 export function renderSchedulingTab(params: RenderSchedulingTabParams = {}): void {

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -113,6 +113,7 @@ async function persistAll(
   featureFlags.set({
     assistant: displayInputs.assistant?.checked || false,
     formatWizard: displayInputs.formatWizard?.checked || false,
+    schedulePlan: displayInputs.schedulePlan?.checked || false,
   });
 
   let scoringApproach: PreferencesConfig['scoringApproach'];
@@ -162,7 +163,10 @@ async function persistAll(
   }
 }
 
-export async function renderSettingsGrid(container: HTMLElement, options?: { excludeTournament?: boolean }): Promise<void> {
+export async function renderSettingsGrid(
+  container: HTMLElement,
+  options?: { excludeTournament?: boolean },
+): Promise<void> {
   const currentSettings = loadSettings();
 
   // These are populated after renderForm calls; persist closure captures the refs.
@@ -402,6 +406,14 @@ export async function renderSettingsGrid(container: HTMLElement, options?: { exc
       onChange: persist,
       checkbox: true,
     },
+    {
+      label: 'Schedule Plan',
+      checked: featureFlags.get().schedulePlan || false,
+      field: 'schedulePlan',
+      id: 'schedulePlan',
+      onChange: persist,
+      checkbox: true,
+    },
   ]);
 
   if (deviceConfig.get().isElectron) {
@@ -562,9 +574,11 @@ export async function renderSettingsGrid(container: HTMLElement, options?: { exc
 
         const showServerError = (body: any) => {
           const messageKey =
-            body?.errorCode === 'ERR_TOURNAMENT_NOT_ENDED' ? 'toasts.tournamentNotEnded' :
-            body?.errorCode === 'ERR_DELETE_FORBIDDEN'     ? 'toasts.deleteForbidden'     :
-            undefined;
+            body?.errorCode === 'ERR_TOURNAMENT_NOT_ENDED'
+              ? 'toasts.tournamentNotEnded'
+              : body?.errorCode === 'ERR_DELETE_FORBIDDEN'
+                ? 'toasts.deleteForbidden'
+                : undefined;
           tmxToast({
             message: messageKey ? t(messageKey) : body?.error || t('toasts.cannotDeleteTournament'),
             intent: 'is-danger',

--- a/src/services/settings/settingsStorage.ts
+++ b/src/services/settings/settingsStorage.ts
@@ -19,6 +19,7 @@ export type TMXSettings = {
   smartComplements?: boolean;
   assistant?: boolean;
   formatWizard?: boolean;
+  schedulePlan?: boolean;
   /**
    * @deprecated — Reports tab has been promoted to production. The icon
    * is always visible; the flag is no longer read. Retained in the type
@@ -150,6 +151,7 @@ export function hydrateConfigFromStorage(): TMXSettings | null {
   const flagsPatch: Record<string, any> = {};
   if (settings.assistant !== undefined) flagsPatch.assistant = settings.assistant;
   if (settings.formatWizard !== undefined) flagsPatch.formatWizard = settings.formatWizard;
+  if (settings.schedulePlan !== undefined) flagsPatch.schedulePlan = settings.schedulePlan;
   if (Object.keys(flagsPatch).length) {
     featureFlags.set(flagsPatch);
   }
@@ -179,6 +181,7 @@ export function persistConfigToStorage(
     saveLocal: server.saveLocal,
     assistant: flags.assistant,
     formatWizard: flags.formatWizard,
+    schedulePlan: flags.schedulePlan,
     ...extras,
   });
 }


### PR DESCRIPTION
Gate the scheduling-workspace **Plan** mode behind a new `schedulePlan` Settings → Beta Features flag (default off), matching the existing `assistant`/`formatWizard` pattern.

## Changes
- `config/featureFlags.ts` — add `schedulePlan` flag (default false)
- `services/settings/settingsStorage.ts` — hydrate + persist the flag (type + load + save)
- `settingsTab/settingsGrid.ts` — 'Schedule Plan' checkbox in the Beta Features panel
- `schedulingTab/schedulingHeader.ts` — hide the Plan segment unless the flag is on
- `schedulingTab/schedulingTab.ts` — `isValidMode` rejects `plan` when the flag is off, so a direct/bookmarked `…/plan` URL falls back to Grid
- `e2e/journeys/90-plan-mode-scenarios.spec.ts` + `e2e/helpers/dev-bridge.ts` — seed the flag via `seedFeatureFlagInitScript` so Plan-mode journeys render under the new gate

## Verification
- Unit: 1016 passed
- check-types + lint + prettier: clean
- Full e2e (rebased on current main, incl. #1240): 312 passed / 11 skipped / 0 failed