### PR TITLE
test(e2e): unique provider abbreviations so CFS-gated journeys are idempotent

### DIFF
--- a/e2e/helpers/role-fixtures.ts
+++ b/e2e/helpers/role-fixtures.ts
@@ -152,3 +152,20 @@ export async function cleanupProvisioner(
 export function uniqueSuffix(): string {
   return `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 }
+
+/**
+ * A short, unique provider abbreviation for a single e2e run.
+ *
+ * `ensureProvider` keys on `organisationAbbreviation`, so a FIXED abbreviation
+ * makes the seed non-idempotent: a repeat local run finds the prior run's
+ * provider (with its stale name) instead of creating a fresh one, and any spec
+ * that selects the provider by its freshly-suffixed name times out. A unique
+ * abbreviation per run sidesteps that entirely. The `E2E` prefix keeps these in
+ * scope of CFS's cleanup-test-data.mjs (which matches abbreviation LIKE 'E2E%').
+ * Kept short (~8 chars) so it renders cleanly in the provider badge.
+ */
+export function uniqueAbbr(tag = ''): string {
+  const t = Date.now().toString(36).slice(-4);
+  const r = Math.floor(Math.random() * 46_656).toString(36); // up to 3 base-36 chars
+  return `E2E${tag}${t}${r}`.toUpperCase();
+}

--- a/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
+++ b/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
@@ -4,6 +4,7 @@ import {
   SERVER,
   ROLE_PASSWORD,
   uniqueSuffix,
+  uniqueAbbr,
   removeUser,
   ensureProvider,
   createProvisioner,
@@ -61,7 +62,7 @@ test.describe('Journey 36 — provider switcher + admin gating (real login)', ()
     token = await signInSuperAdmin(request);
     if (!token) return; // seed admin unavailable → tests skip below
 
-    providerId = await ensureProvider(request, token, 'TMXROLE', PROVIDER_NAME);
+    providerId = await ensureProvider(request, token, uniqueAbbr('R'), PROVIDER_NAME);
     await createLoginableUser(request, token, {
       email: PROVIDER_ADMIN_EMAIL,
       roles: ['client'],

--- a/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
+++ b/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
@@ -4,6 +4,7 @@ import {
   SERVER,
   ensureProvider,
   uniqueSuffix,
+  uniqueAbbr,
   signInSuperAdmin,
   SUPERADMIN_EMAIL,
   SUPERADMIN_PASSWORD,
@@ -38,8 +39,8 @@ import {
  * SERVER.
  */
 const suffix = uniqueSuffix();
-const PROVIDER_A_ABBR = 'TMXSWA';
-const PROVIDER_B_ABBR = 'TMXSWB';
+const PROVIDER_A_ABBR = uniqueAbbr('A');
+const PROVIDER_B_ABBR = uniqueAbbr('B');
 const PROVIDER_A_NAME = `E2E Switch Alpha ${suffix}`;
 const PROVIDER_B_NAME = `E2E Switch Beta ${suffix}`;
 const PATCH_LAST_SELECTED = '/auth/me/last-selected-provider';

--- a/e2e/journeys/71-publishing-login-gating.spec.ts
+++ b/e2e/journeys/71-publishing-login-gating.spec.ts
@@ -5,6 +5,7 @@ import {
   SERVER,
   ensureProvider,
   uniqueSuffix,
+  uniqueAbbr,
   signInSuperAdmin,
   SUPERADMIN_EMAIL,
   SUPERADMIN_PASSWORD,
@@ -30,7 +31,7 @@ import { AuthFlow } from '../pages/AuthFlow';
 const PART_TOGGLE =
   'xpath=//h3[contains(., "Participants")]/following-sibling::div[contains(@class,"pub-toggle-row")]//label[contains(@class,"pub-toggle")]/input';
 
-const PROVIDER_ABBR = 'TMXPUB';
+const PROVIDER_ABBR = uniqueAbbr('P');
 const PROVIDER_NAME = `E2E Publish ${uniqueSuffix()}`;
 
 let seeded = false;

--- a/e2e/journeys/73-chat-indicator-gating.spec.ts
+++ b/e2e/journeys/73-chat-indicator-gating.spec.ts
@@ -5,6 +5,7 @@ import {
   SERVER,
   ensureProvider,
   uniqueSuffix,
+  uniqueAbbr,
   signInSuperAdmin,
   SUPERADMIN_EMAIL,
   SUPERADMIN_PASSWORD,
@@ -24,7 +25,7 @@ import { AuthFlow } from '../pages/AuthFlow';
  */
 
 const CHAT = '#chatIndicator';
-const PROVIDER_ABBR = 'TMXCHT';
+const PROVIDER_ABBR = uniqueAbbr('C');
 const PROVIDER_NAME = `E2E Chat ${uniqueSuffix()}`;
 
 let seeded = false;


### PR DESCRIPTION
`role-fixtures.ensureProvider` keys on `organisationAbbreviation`, so the fixed abbreviations (TMXCHT/TMXPUB/TMXSWA/TMXSWB/TMXROLE) made the seed non-idempotent: a repeat local run finds the prior run's provider (with its stale name) instead of creating a fresh one, and the specs that select the provider by its freshly-suffixed name (36/58/71/73) time out. CI passed only because it starts with a clean DB.

Adds `uniqueAbbr()` to role-fixtures — a short, unique, `E2E`-prefixed abbreviation per run. No reuse across runs, and in scope of CFS `cleanup-test-data.mjs` (which matches abbreviation `LIKE 'E2E%'`; the old `TMX*` ones were missed).

**Verified** against a local CFS (with the new `DISABLE_HTTP_THROTTLE=true`): journeys 36/58/71/73 pass **twice back-to-back with no cleanup between runs** (8/8 each) — previously the second run failed on stale providers.