### PR TITLE
feat: stop futile-refresh loop on factory version mismatch

### DIFF
--- a/src/services/version/checkFactoryVersion.test.ts
+++ b/src/services/version/checkFactoryVersion.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { factoryVersion, fetchDeployedManifest, promptRefresh, tmxToast } = vi.hoisted(() => ({
+  factoryVersion: vi.fn(),
+  fetchDeployedManifest: vi.fn(),
+  promptRefresh: vi.fn(),
+  tmxToast: vi.fn(),
+}));
+
+vi.mock('tods-competition-factory', () => ({ version: factoryVersion }));
+vi.mock('services/version/deployedManifest', () => ({ fetchDeployedManifest }));
+vi.mock('services/version/refreshPrompt', () => ({ promptRefresh }));
+vi.mock('services/notifications/tmxToast', () => ({ tmxToast }));
+vi.mock('config/serverConfig', () => ({ serverConfig: { get: () => ({ socketPath: 'https://srv' }) } }));
+vi.mock('config/debugConfig', () => ({ debugConfig: { get: () => ({ socketLog: false }) } }));
+
+import { checkFactoryVersion, resetFactoryVersionCheck } from './checkFactoryVersion';
+
+function mockServerVersion(version: string | undefined, ok = true) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 503,
+    json: async () => ({ version }),
+  }) as any;
+}
+
+describe('checkFactoryVersion', () => {
+  beforeEach(() => {
+    resetFactoryVersionCheck();
+    factoryVersion.mockReturnValue('6.13.0');
+    fetchDeployedManifest.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing when client and server share major.minor (patch tolerated)', async () => {
+    factoryVersion.mockReturnValue('6.13.0');
+    mockServerVersion('6.13.5');
+
+    await checkFactoryVersion();
+
+    expect(fetchDeployedManifest).not.toHaveBeenCalled();
+    expect(promptRefresh).not.toHaveBeenCalled();
+    expect(tmxToast).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the server version cannot be fetched', async () => {
+    mockServerVersion(undefined, false);
+
+    await checkFactoryVersion();
+
+    expect(promptRefresh).not.toHaveBeenCalled();
+    expect(tmxToast).not.toHaveBeenCalled();
+  });
+
+  it('prompts a refresh when the deployed SPA bundles a factory aligned with the server', async () => {
+    factoryVersion.mockReturnValue('6.13.0'); // this tab
+    mockServerVersion('6.14.0'); // server upgraded
+    fetchDeployedManifest.mockResolvedValue({ version: '8.16.0', factoryVersion: '6.14.0' }); // aligned deploy exists
+
+    await checkFactoryVersion();
+
+    expect(promptRefresh).toHaveBeenCalledTimes(1);
+    expect(promptRefresh).toHaveBeenCalledWith(expect.stringContaining('6.14.0'));
+    expect(tmxToast).not.toHaveBeenCalled();
+  });
+
+  it('shows a passive notice (no refresh) when the latest deploy still mismatches — the futile-refresh case', async () => {
+    factoryVersion.mockReturnValue('6.13.0');
+    mockServerVersion('6.14.0');
+    fetchDeployedManifest.mockResolvedValue({ version: '8.15.0', factoryVersion: '6.13.0' }); // no aligned deploy
+
+    await checkFactoryVersion();
+
+    expect(promptRefresh).not.toHaveBeenCalled();
+    expect(tmxToast).toHaveBeenCalledTimes(1);
+    const arg = tmxToast.mock.calls[0][0];
+    expect(arg.intent).toBe('is-warning');
+    expect(arg.action).toBeUndefined(); // no Refresh CTA
+    expect(arg.message).toContain('6.14.0'); // server engine version, server-ahead wording
+  });
+
+  it('reports server-behind wording when the deployed app is ahead of the server engine', async () => {
+    factoryVersion.mockReturnValue('6.14.0'); // this tab
+    mockServerVersion('6.13.0'); // server behind
+    fetchDeployedManifest.mockResolvedValue({ version: '8.16.0', factoryVersion: '6.14.0' }); // latest deploy also ahead
+
+    await checkFactoryVersion();
+
+    expect(promptRefresh).not.toHaveBeenCalled();
+    expect(tmxToast).toHaveBeenCalledTimes(1);
+    expect(tmxToast.mock.calls[0][0].message).toContain('server is being updated');
+  });
+
+  it('falls back to prompting a refresh when the deployed factory version is unknown', async () => {
+    factoryVersion.mockReturnValue('6.13.0');
+    mockServerVersion('6.14.0');
+    fetchDeployedManifest.mockResolvedValue({ version: '8.15.0' }); // no factoryVersion field (older manifest)
+
+    await checkFactoryVersion();
+
+    expect(promptRefresh).toHaveBeenCalledTimes(1);
+    expect(tmxToast).not.toHaveBeenCalled();
+  });
+
+  it('dedupes the passive notice per server version', async () => {
+    factoryVersion.mockReturnValue('6.13.0');
+    mockServerVersion('6.14.0');
+    fetchDeployedManifest.mockResolvedValue({ version: '8.15.0', factoryVersion: '6.13.0' });
+
+    await checkFactoryVersion();
+    await checkFactoryVersion();
+
+    expect(tmxToast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/version/checkFactoryVersion.ts
+++ b/src/services/version/checkFactoryVersion.ts
@@ -1,53 +1,111 @@
 /**
- * Verify the bundled factory version matches the server's factory version
- * on the major.minor axis. Patch differences are tolerated.
+ * Verify the bundled factory version matches the server's factory version on
+ * the major.minor axis. Patch differences are tolerated.
  *
- * Re-runs on each fresh socket connection so a server upgrade mid-session
- * is caught after the next reconnect.
+ * On a major/minor mismatch, decide whether a refresh can actually resolve it
+ * by consulting the deployed `version.json` manifest (what a hard refresh would
+ * load):
+ *   - the latest-deployed SPA bundles a factory that aligns with the server
+ *     → a refresh helps: prompt to refresh.
+ *   - the latest-deployed SPA still bundles a mismatched factory
+ *     → a refresh is futile (it re-serves the same bundle): show a passive,
+ *       non-actionable notice instead of looping the user through reloads.
+ *   - the deployed factory version can't be read (older deploy / fetch failure)
+ *     → fall back to prompting a refresh rather than regressing the resolvable
+ *       case.
+ *
+ * Re-runs on each fresh socket connection so a server upgrade mid-session is
+ * caught after the next reconnect.
  */
 import { version as factoryVersion } from 'tods-competition-factory';
+import { fetchDeployedManifest } from 'services/version/deployedManifest';
+import { promptRefresh } from 'services/version/refreshPrompt';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { serverConfig } from 'config/serverConfig';
 import { debugConfig } from 'config/debugConfig';
 
 const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
 
-let lastWarnedServerVersion: string | undefined;
+let lastNoticedServerVersion: string | undefined;
 
-function parseMajorMinor(v: string | undefined): { major: number; minor: number } | null {
+interface MajorMinor {
+  major: number;
+  minor: number;
+}
+
+function parseMajorMinor(v: string | undefined): MajorMinor | null {
   if (!v) return null;
   const m = /^(\d+)\.(\d+)/.exec(v);
   if (!m) return null;
   return { major: Number(m[1]), minor: Number(m[2]) };
 }
 
-export async function checkFactoryVersion(): Promise<void> {
+function sameMajorMinor(a: MajorMinor, b: MajorMinor): boolean {
+  return a.major === b.major && a.minor === b.minor;
+}
+
+// -1 when a < b, 0 when equal, 1 when a > b (major.minor ordering).
+function compareMajorMinor(a: MajorMinor, b: MajorMinor): number {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  return 0;
+}
+
+async function fetchServerFactoryVersion(): Promise<string | undefined> {
   const base = serverConfig.get().socketPath || globalThis.location.origin;
   const url = `${base}/factory/version`;
-
-  let serverVersion: string | undefined;
   try {
     const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) {
       slog('[version] /factory/version returned', res.status);
-      return;
+      return undefined;
     }
     const body = await res.json();
-    serverVersion = body?.version;
+    return body?.version;
   } catch (err) {
     slog('[version] /factory/version fetch failed:', err);
-    return;
+    return undefined;
   }
+}
+
+export async function checkFactoryVersion(): Promise<void> {
+  const serverVersion = await fetchServerFactoryVersion();
 
   const client = parseMajorMinor(factoryVersion());
   const server = parseMajorMinor(serverVersion);
   if (!client || !server) return;
 
-  if (client.major === server.major && client.minor === server.minor) return;
-  if (lastWarnedServerVersion === serverVersion) return;
-  lastWarnedServerVersion = serverVersion;
+  // Aligned on major.minor (patch differences tolerated).
+  if (sameMajorMinor(client, server)) return;
 
-  const message = `Factory version mismatch — server ${serverVersion}, client ${factoryVersion()}. Please refresh.`;
+  // Mismatch. Would a refresh resolve it? Compare the server against the
+  // factory version the latest-deployed SPA bundles (what a refresh loads).
+  const { factoryVersion: deployedFactory } = await fetchDeployedManifest();
+  const deployed = parseMajorMinor(deployedFactory);
+
+  // Refresh helps only when the deployed SPA's factory aligns with the server.
+  // If the deployed factory version is unknown (older manifest without the
+  // field, or the manifest was unreachable), fall back to offering a refresh so
+  // we don't regress the common resolvable case.
+  const refreshResolves = !deployed || sameMajorMinor(deployed, server);
+
+  if (refreshResolves) {
+    promptRefresh(`A newer app version is available (competition engine ${serverVersion}). Refresh to update.`);
+    return;
+  }
+
+  // Refresh is futile: the latest-deployed app still bundles a mismatched
+  // engine. Show a passive, non-actionable notice (deduped per server version).
+  if (lastNoticedServerVersion === serverVersion) return;
+  lastNoticedServerVersion = serverVersion;
+
+  // server ahead of the deployed app → an updated app is still being prepared;
+  // server behind → the server is mid-upgrade. Either way the user can't fix it
+  // by refreshing, so no Refresh action is offered.
+  const serverAhead = compareMajorMinor(server, deployed) > 0;
+  const message = serverAhead
+    ? `This tournament is running a newer competition engine (${serverVersion}) than any available app build. An updated app is being prepared — some features may be unavailable until then.`
+    : `The server is being updated to match this app's competition engine (${factoryVersion()}). Some features may be unavailable until it completes.`;
   console.warn('[version]', message);
   tmxToast({
     intent: 'is-warning',
@@ -55,10 +113,9 @@ export async function checkFactoryVersion(): Promise<void> {
     dismissible: true,
     pauseOnHover: true,
     message,
-    action: { text: 'Refresh', onClick: () => globalThis.location.reload() },
   });
 }
 
 export function resetFactoryVersionCheck(): void {
-  lastWarnedServerVersion = undefined;
+  lastNoticedServerVersion = undefined;
 }

--- a/src/services/version/checkTmxVersion.ts
+++ b/src/services/version/checkTmxVersion.ts
@@ -3,55 +3,26 @@
  *
  * `dist/version.json` is emitted at build time by the Vite plugin in
  * `vite.config.ts`. We poll it on `visibilitychange→visible` and every
- * `POLL_INTERVAL_MS` while visible, comparing against the version baked
- * into this bundle. On mismatch, a sticky toast prompts the user to refresh.
+ * `POLL_INTERVAL_MS` while visible, comparing against the version baked into
+ * this bundle. On a newer deploy, `promptRefresh` shows a sticky toast — the
+ * same shared prompt the factory-mismatch check uses, so a scenario that trips
+ * both surfaces one refresh toast, not two.
  */
-import { tmxToast } from 'services/notifications/tmxToast';
+import { fetchDeployedManifest } from 'services/version/deployedManifest';
 import { version as bundledVersion } from 'config/version';
-import { debugConfig } from 'config/debugConfig';
-
-const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
+import { promptRefresh } from 'services/version/refreshPrompt';
 
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 
 let pollTimer: ReturnType<typeof setInterval> | undefined;
-let warned = false;
 let initialized = false;
 
-async function fetchDeployedVersion(): Promise<string | undefined> {
-  const url = `${import.meta.env.BASE_URL}version.json?t=${Date.now()}`;
-  try {
-    const res = await fetch(url, { cache: 'no-store' });
-    if (!res.ok) {
-      slog('[version] version.json returned', res.status);
-      return undefined;
-    }
-    const body = await res.json();
-    return typeof body?.version === 'string' ? body.version : undefined;
-  } catch (err) {
-    slog('[version] version.json fetch failed:', err);
-    return undefined;
-  }
-}
-
 async function check(): Promise<void> {
-  if (warned) return;
-  const deployed = await fetchDeployedVersion();
+  const { version: deployed } = await fetchDeployedManifest();
   if (!deployed || deployed === bundledVersion) return;
 
-  warned = true;
   stopPolling();
-
-  const message = `New TMX version available (${deployed}). Refresh to update.`;
-  console.warn('[version]', message, '— bundled:', bundledVersion);
-  tmxToast({
-    intent: 'is-info',
-    duration: 0,
-    dismissible: true,
-    pauseOnHover: true,
-    message,
-    action: { text: 'Refresh', onClick: () => globalThis.location.reload() },
-  });
+  promptRefresh(`New TMX version available (${deployed}). Refresh to update.`);
 }
 
 function startPolling(): void {
@@ -87,6 +58,5 @@ export function initTmxVersionCheck(): void {
 export function destroyTmxVersionCheck(): void {
   document.removeEventListener('visibilitychange', onVisibilityChange);
   stopPolling();
-  warned = false;
   initialized = false;
 }

--- a/src/services/version/deployedManifest.ts
+++ b/src/services/version/deployedManifest.ts
@@ -1,0 +1,36 @@
+/**
+ * Fetch TMX's build-emitted deploy manifest (`version.json`) — a description of
+ * the SPA a hard refresh would load: its SPA `version` and the `factoryVersion`
+ * it bundles. Emitted by the Vite plugin in `vite.config.ts`.
+ *
+ * Both fields may be absent when read from a deploy that predates the field
+ * (older `version.json` carried only `version` + `builtAt`); callers must treat
+ * `undefined` as "unknown", not "mismatched".
+ */
+import { debugConfig } from 'config/debugConfig';
+
+const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
+
+export interface DeployedManifest {
+  version?: string;
+  factoryVersion?: string;
+}
+
+export async function fetchDeployedManifest(): Promise<DeployedManifest> {
+  const url = `${import.meta.env.BASE_URL}version.json?t=${Date.now()}`;
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) {
+      slog('[version] version.json returned', res.status);
+      return {};
+    }
+    const body = await res.json();
+    return {
+      version: typeof body?.version === 'string' ? body.version : undefined,
+      factoryVersion: typeof body?.factoryVersion === 'string' ? body.factoryVersion : undefined,
+    };
+  } catch (err) {
+    slog('[version] version.json fetch failed:', err);
+    return {};
+  }
+}

--- a/src/services/version/refreshPrompt.test.ts
+++ b/src/services/version/refreshPrompt.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { tmxToast } = vi.hoisted(() => ({ tmxToast: vi.fn() }));
+vi.mock('services/notifications/tmxToast', () => ({ tmxToast }));
+
+import { promptRefresh, resetRefreshPrompt } from './refreshPrompt';
+
+describe('promptRefresh', () => {
+  beforeEach(() => {
+    resetRefreshPrompt();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows an actionable is-info refresh toast', () => {
+    promptRefresh('Refresh please');
+
+    expect(tmxToast).toHaveBeenCalledTimes(1);
+    const arg = tmxToast.mock.calls[0][0];
+    expect(arg.intent).toBe('is-info');
+    expect(arg.message).toBe('Refresh please');
+    expect(arg.action?.text).toBe('Refresh');
+    expect(typeof arg.action?.onClick).toBe('function');
+  });
+
+  it('shows the prompt only once until reset (dedupes across both version checks)', () => {
+    promptRefresh('first');
+    promptRefresh('second');
+
+    expect(tmxToast).toHaveBeenCalledTimes(1);
+    expect(tmxToast.mock.calls[0][0].message).toBe('first');
+
+    resetRefreshPrompt();
+    promptRefresh('third');
+    expect(tmxToast).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/version/refreshPrompt.ts
+++ b/src/services/version/refreshPrompt.ts
@@ -1,0 +1,31 @@
+/**
+ * A single "refresh to load a newer deploy" prompt, shared by the two version
+ * checks so a situation that trips both — the SPA-freshness check
+ * (`checkTmxVersion`) and the factory client/server mismatch check
+ * (`checkFactoryVersion`) — surfaces exactly one refresh toast instead of two.
+ *
+ * The prompt is only shown when a refresh will actually change what loads (a
+ * newer aligned deploy exists); callers must not use this for an unresolvable
+ * mismatch, where a reload is futile.
+ */
+import { tmxToast } from 'services/notifications/tmxToast';
+
+let prompted = false;
+
+export function promptRefresh(message: string): void {
+  if (prompted) return;
+  prompted = true;
+  console.warn('[version]', message);
+  tmxToast({
+    intent: 'is-info',
+    duration: 0,
+    dismissible: true,
+    pauseOnHover: true,
+    message,
+    action: { text: 'Refresh', onClick: () => globalThis.location.reload() },
+  });
+}
+
+export function resetRefreshPrompt(): void {
+  prompted = false;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
+import { version as factoryVersion } from 'tods-competition-factory';
 import EnvironmentPlugin from 'vite-plugin-environment';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
 import { version as pkgVersion } from './package.json';
 import path from 'path';
 
-// Emits `dist/version.json` at build time so a long-lived TMX tab can poll
-// for newer deployments. See `src/services/version/checkTmxVersion.ts`.
+// Emits `dist/version.json` at build time so a long-lived TMX tab can poll for
+// newer deployments (`src/services/version/checkTmxVersion.ts`) AND so the
+// factory-mismatch check can tell whether a refresh would actually resolve a
+// client/server engine mismatch (`src/services/version/checkFactoryVersion.ts`).
+// `factoryVersion` is the `tods-competition-factory` build bundles — the same
+// version its runtime `version()` returns — so a client can compare "what a
+// refresh would load" against the server's running engine.
 const emitVersionJson = (): Plugin => ({
   name: 'tmx-emit-version-json',
   apply: 'build',
@@ -12,7 +18,9 @@ const emitVersionJson = (): Plugin => ({
     this.emitFile({
       type: 'asset',
       fileName: 'version.json',
-      source: JSON.stringify({ version: pkgVersion, builtAt: new Date().toISOString() }) + '\n',
+      source:
+        JSON.stringify({ version: pkgVersion, factoryVersion: factoryVersion(), builtAt: new Date().toISOString() }) +
+        '\n',
     });
   },
 });


### PR DESCRIPTION
## Problem

`checkFactoryVersion` unconditionally told the user to **Refresh** on any major/minor client/server factory mismatch — even when no aligned TMX SPA was deployed. A reload then re-served the same bundle and the banner reappeared, looping the user through pointless refreshes. Patch differences were already tolerated (major.minor compare).

## Fix

`version.json` now records the **factory version the SPA bundles**, so the client can tell whether a refresh would actually resolve a mismatch by comparing the latest-deployed build's engine against the server's running engine.

| Situation | Behavior |
|---|---|
| Patch diff | silent (unchanged) |
| Minor/major mismatch, aligned deploy exists | **"Refresh to update"** — actionable |
| Minor/major mismatch, no aligned deploy | **passive notice, no Refresh CTA** (honest wording for app-lagging vs server-lagging) |
| Deployed factory version unknown (older manifest) | fall back to Refresh (no regression) |

## Changes

- `vite.config.ts` — emit `factoryVersion` in `version.json` (from factory `version()`, so the manifest always matches what the runtime reports)
- `deployedManifest.ts` (new) — shared `version.json` fetch → `{ version, factoryVersion }`
- `refreshPrompt.ts` (new) — shared, **deduped** refresh toast so the factory check and the SPA-freshness check never double-toast
- `checkFactoryVersion.ts` — resolvable / unresolvable / fallback branching
- `checkTmxVersion.ts` — now uses the shared manifest + prompt
- 9 new unit tests covering every branch (incl. the exact futile-refresh scenario)

## Design decisions (with @charlesallen)

- Signal source is **client-side via `version.json`** — no new CFS endpoint, no coupling of the server to the edge filesystem.
- Unresolvable mismatch → **passive banner, no Refresh CTA**.
- Patch differences stay **silent**.

## Verification

- New tests: 9 green. Full TMX suite: 1033/101 green. `check-types` + `lint` clean. Build confirmed emitting `factoryVersion` in `version.json`.