### PR TITLE
feat(schedule): add DRYING court booking pill

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -879,6 +879,7 @@
     "otherBookings": "Other",
     "practice": "Practice",
     "maintenance": "Maintenance",
+    "drying": "Drying",
     "unscheduled": "Unscheduled",
     "noScheduledMatchUps": "No scheduled matchUps",
     "noScheduledMatchUpsMatch": "No scheduled matchUps match the search",

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -5,8 +5,8 @@
  * in the schedule2 CSS grid. Uses tippy.js directly with custom DOM for a modern
  * pill/icon layout rather than the legacy flat menu list.
  */
+import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
-import { matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { getScheduleDateRange } from 'pages/tournament/tabs/scheduleUtils';
@@ -512,7 +512,7 @@ function showEmptyCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
     });
   };
 
-  const blockCourt = (rowCount: number, bookingType: string = 'BLOCKED') => {
+  const blockCourt = (rowCount: number, bookingType: string = BookingTypeEnum.BLOCKED) => {
     mutationRequest({
       methods: [
         { method: 'addCourtGridBooking', params: { courtId, scheduledDate, courtOrder, rowCount, bookingType } },
@@ -546,21 +546,21 @@ function showEmptyCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
   const blockRow = document.createElement('div');
   blockRow.style.cssText = PILL_ROW_CSS;
   blockRow.appendChild(
-    makePill('1 row', () => blockCourt(1, 'BLOCKED'), {
+    makePill('1 row', () => blockCourt(1, BookingTypeEnum.BLOCKED), {
       icon: ICON_BAN,
       tint: TINT_DANGER,
       color: '#f43f5e',
     }),
   );
   blockRow.appendChild(
-    makePill('2 rows', () => blockCourt(2, 'BLOCKED'), {
+    makePill('2 rows', () => blockCourt(2, BookingTypeEnum.BLOCKED), {
       icon: ICON_BAN,
       tint: TINT_DANGER,
       color: '#f43f5e',
     }),
   );
   blockRow.appendChild(
-    makePill('3 rows', () => blockCourt(3, 'BLOCKED'), {
+    makePill('3 rows', () => blockCourt(3, BookingTypeEnum.BLOCKED), {
       icon: ICON_BAN,
       tint: TINT_DANGER,
       color: '#f43f5e',
@@ -573,17 +573,27 @@ function showEmptyCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
   const otherRow = document.createElement('div');
   otherRow.style.cssText = PILL_ROW_CSS;
   otherRow.appendChild(
-    makePill(t('schedule.practice'), () => blockCourt(1, 'PRACTICE'), {
+    makePill(t('schedule.practice'), () => blockCourt(1, BookingTypeEnum.PRACTICE), {
       icon: 'fa-dumbbell',
       tint: 'rgba(59, 130, 246, 0.15)',
       color: '#3b82f6',
     }),
   );
   otherRow.appendChild(
-    makePill(t('schedule.maintenance'), () => blockCourt(1, 'MAINTENANCE'), {
+    makePill(t('schedule.maintenance'), () => blockCourt(1, BookingTypeEnum.MAINTENANCE), {
       icon: 'fa-wrench',
       tint: 'rgba(245, 158, 11, 0.15)',
       color: '#f59e0b',
+    }),
+  );
+  // Teal, deliberately not the maintenance amber: drying is reactive weather loss,
+  // maintenance is planned. The colour matches the DRYING cell stripe in
+  // courthive-components (schedule-grid-cell.css).
+  otherRow.appendChild(
+    makePill(t('schedule.drying'), () => blockCourt(1, BookingTypeEnum.DRYING), {
+      icon: 'fa-droplet',
+      tint: 'rgba(20, 184, 166, 0.15)',
+      color: '#14b8a6',
     }),
   );
   pop.appendChild(otherRow);


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until factory 6.18.0 is published and the pin bumped

`BookingTypeEnum` does not exist in the currently pinned `tods-competition-factory@6.17.0`. Local dev works because `pnpm-workspace.yaml` overrides factory to `link:../factory`, but `deploy-pages.yml` **strips link overrides** and builds against the published pin — so merging this before the bump plants a release-time build failure.

Sequence: publish factory 6.18.0 → `bump-factory-consumers.sh 6.18.0` → merge this.

## What it does

DRYING shipped in factory (PR #4561) as its own booking type and BlockType, but had no way to be set from the UI. Adds a pill beside Practice and Maintenance — teal, droplet icon — matching the DRYING cell stripe added in courthive-components (`660a578`).

Also replaces the magic booking-type strings at this call site with `BookingTypeEnum` members. The point of making `bookingType` a real vocabulary is that consumers stop hand-writing the strings; this is the first consumer to do so.

New i18n key `schedule.drying` in `en.json` (the other six locales come through the sync-i18n workflow).

## Verification

Full TMX suite green: **1033 tests / 101 files**. Lint clean.

`check-types` reports 5 errors — **all pre-existing and unrelated**, verified by diffing the error set with my changes stashed vs applied (identical, zero introduced). See the PR discussion for what those are; they are a separate factory-consumer issue.

## Also needs

The courthive-components DRYING styling is on `main` but unpublished, so the teal cell only renders locally via the link override until components is published and TMX's pin bumped.