### PR TITLE
fix(modals): dispose the Leaflet map when the location picker closes

### DIFF
--- a/src/components/modals/getLatLong.ts
+++ b/src/components/modals/getLatLong.ts
@@ -113,15 +113,27 @@ export function getLatLong({ coords, callback }: { coords?: Coords; callback?: (
     if (evt.key === 'Enter') processLink();
   };
 
-  openModal({ title: t('modals.getLatLong.title'), content: html, buttons });
+  // Assigned just below, after the modal DOM exists; the modal may close before or after.
+  let disposeMap: (() => void) | undefined;
+
+  openModal({
+    title: t('modals.getLatLong.title'),
+    content: html,
+    buttons,
+    onClose: () => {
+      disposeMap?.();
+      disposeMap = undefined;
+    },
+  });
 
   const container = idObj(ids);
-  let { map, marker } = locationMap({
+  let { map, marker, dispose } = locationMap({
     successElement: container.map.element,
     mapElementId: container.map.id,
     coords,
     zoom,
   });
+  disposeMap = dispose;
   if (container.link.element) {
     (container.link.element as HTMLInputElement).value = '';
     container.link.element.focus();
@@ -173,7 +185,7 @@ function locationMap({
   mapElementId: string;
   coords: Coords;
   zoom: number;
-}): { map: any; marker: any } {
+}): { map: any; marker: any; dispose: () => void } {
   const nav = getNavigator();
   if (!nav?.onLine) return {} as any;
 
@@ -195,9 +207,18 @@ function locationMap({
     marker = L.marker([+coords.latitude, +coords.longitude]).addTo(map);
   }
 
-  setTimeout(function () {
+  // The map is created inside a modal that has just opened, so its container has no size yet.
+  // Cancel this on dispose: invalidateSize() on a removed map throws.
+  const sizeTimer = setTimeout(function () {
     map.invalidateSize();
   }, 300);
 
-  return { map, marker };
+  // Leaflet keeps window/document listeners and in-flight tile requests until remove() is called.
+  // Without this every open of the picker leaked a whole map.
+  const dispose = () => {
+    clearTimeout(sizeTimer);
+    map.remove();
+  };
+
+  return { map, marker, dispose };
 }


### PR DESCRIPTION
`getLatLong` created a Leaflet map with `L.map()` and never called `remove()`, so every open of the location picker leaked the map along with the window/document listeners and in-flight tile requests Leaflet holds until disposal. The modal already supported an `onClose` hook — it just wasn't used.

`locationMap` now returns a `dispose()` that the modal runs on close. It also clears the pending 300ms `invalidateSize` timer: that timer exists because the map is created inside a modal whose container has no size yet, and firing it after `remove()` throws.

Found while auditing teardown for the new `venue-locator` component in courthive-components, which disposes for the same reason.

Verified on the current main (components 3.13.0 / factory 6.21.0): `check-types`, `lint` and 1033 unit tests pass.