### PR TITLE
fix(deps): update tods-competition-factory to 6.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.21.0",
+    "tods-competition-factory": "6.22.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Ecosystem factory bump 6.21.0 → 6.22.0 (manifest + lockfile). Routed via PR because main requires the `lint` status check — the same bump landed on the other 9 consumers via direct push.