### PR TITLE
fix(deps): courthive-components 3.13.1 + pdf-factory 0.8.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.14",
+    "pdf-factory": "0.8.16",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.13.0",
+    "courthive-components": "3.13.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.4",


### PR DESCRIPTION
Fan-out of the components 3.13.1 + pdf-factory 0.8.16 publishes to TMX (manifest + lockfile). Routed via PR because main requires the `lint` check; the other consumers took it via direct push.