### PR TITLE
chore(deps): factory 6.22.1 + provider-config 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "yargs": "18.1.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "0.12.0",
+    "@courthive/provider-config": "0.13.0",
     "@courthive/scoring-visualizations": "^0.2.9",
     "@eslint/js": "^10.0.1",
     "animate.css": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.22.0",
+    "tods-competition-factory": "6.22.1",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Ecosystem dependency cascade (published 2026-08-13):
- tods-competition-factory 6.22.0 → 6.22.1 (fix: resolve alpha-3/IOC codes before building a country flag)
- @courthive/provider-config 0.12.0 → 0.13.0

Routed via PR because TMX main requires the `lint` status check (direct cascade push is rejected). check-types + e2e tsconfig pass locally.