### PR TITLE
chore(e2e): bring the Playwright suite under ESLint

### DIFF
--- a/e2e/global.d.ts
+++ b/e2e/global.d.ts
@@ -16,7 +16,6 @@ declare global {
   // to make the runtime injection point obvious). `var` is required
   // here — `let`/`const` inside `declare global` doesn't attach to
   // the globalThis index signature.
-  // eslint-disable-next-line no-var
   var dev: any;
 }
 

--- a/e2e/journeys/02-draw-form-new-main.spec.ts
+++ b/e2e/journeys/02-draw-form-new-main.spec.ts
@@ -29,18 +29,9 @@ const PROFILE_EVENT_NO_DRAW: MockProfile = {
   drawProfiles: [{ eventName: 'Singles', drawSize: 16, generate: false }],
 };
 
-/** Same but with qualifying entries to test qualifiers-count inference. */
-const PROFILE_WITH_QUALIFYING: MockProfile = {
-  tournamentName: 'E2E Draw Form Qualifying',
-  tournamentAttributes: { tournamentId: 'e2e-draw-form-qual' },
-  participantsProfile: { scaledParticipantsCount: 32 },
-  eventProfiles: [
-    {
-      eventName: 'Singles',
-      drawProfiles: [{ drawSize: 16, qualifyingProfiles: [{ drawSize: 8 }] }],
-    },
-  ],
-};
+/* Qualifiers-count inference used to be seeded from a local
+ * PROFILE_WITH_QUALIFYING here; that coverage now lives in
+ * 12-draw-form-qualifiers-inference.spec.ts, which owns its own fixture. */
 
 /* ─── Helpers ────────────────────────────────────────────────────────────── */
 

--- a/e2e/journeys/07-draw-form-populate-main.spec.ts
+++ b/e2e/journeys/07-draw-form-populate-main.spec.ts
@@ -12,7 +12,6 @@
  */
 import { test, expect } from '@playwright/test';
 import { ensureDrawsTableMode, initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
-import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament, MockProfile } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';
 import { DrawFormDrawer } from '../pages/DrawFormDrawer';
@@ -31,9 +30,7 @@ const PROFILE_QUALIFYING_FIRST: MockProfile = {
     {
       eventName: 'Singles',
       drawSize: 16,
-      qualifyingProfiles: [
-        { structureProfiles: [{ qualifyingPositions: 4, drawSize: 8 }] },
-      ],
+      qualifyingProfiles: [{ structureProfiles: [{ qualifyingPositions: 4, drawSize: 8 }] }],
     },
   ],
 };
@@ -124,12 +121,15 @@ test.describe('Journey 7 — POPULATE_MAIN and GENERATE_QUALIFYING flows', () =>
     // Check the entire page for "Qualifying" text — it appears in the
     // structure dropdown as the currently selected structure.
     const qualText = page.getByText('Qualifying', { exact: true });
-    const hasQualifying = await qualText.first().isVisible().catch(() => false);
+    const hasQualifying = await qualText
+      .first()
+      .isVisible()
+      .catch(() => false);
     expect(hasQualifying).toBe(true);
   });
 
   test('qualifying-first seed has both Main and Qualifying structures', async ({ page }) => {
-    const tournamentId = await seedTournament(page, PROFILE_QUALIFYING_FIRST);
+    await seedTournament(page, PROFILE_QUALIFYING_FIRST);
 
     // Verify directly via the factory engine
     const structures = await page.evaluate(() => {

--- a/e2e/journeys/09-draw-form-advanced.spec.ts
+++ b/e2e/journeys/09-draw-form-advanced.spec.ts
@@ -32,9 +32,7 @@ const PROFILE_12_MAIN_8_QUAL: MockProfile = {
     {
       eventName: 'Singles',
       drawSize: 16,
-      qualifyingProfiles: [
-        { structureProfiles: [{ qualifyingPositions: 4, drawSize: 8 }] },
-      ],
+      qualifyingProfiles: [{ structureProfiles: [{ qualifyingPositions: 4, drawSize: 8 }] }],
       generate: false,
     },
   ],
@@ -50,10 +48,7 @@ const PROFILE_8_ENTRIES: MockProfile = {
 
 /* ─── Helpers ────────────────────────────────────────────────────────────── */
 
-async function seedAndOpenDrawForm(
-  page: any,
-  profile: MockProfile = PROFILE_16_ENTRIES,
-): Promise<DrawFormDrawer> {
+async function seedAndOpenDrawForm(page: any, profile: MockProfile = PROFILE_16_ENTRIES): Promise<DrawFormDrawer> {
   const tournamentId = await seedTournament(page, profile);
   const tournamentPage = new TournamentPage(page);
   await tournamentPage.goto(tournamentId);
@@ -183,14 +178,11 @@ test.describe('Journey 9 — Draw form advanced scenarios', () => {
         const label = field?.querySelector('.label');
         const text = label?.textContent || '';
         if (text === 'Qualifiers') {
-          const setter = Object.getOwnPropertyDescriptor(
-            HTMLInputElement.prototype, 'value',
-          )?.set;
+          const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
           setter?.call(inp, '8');
           inp.dispatchEvent(new Event('input', { bubbles: true }));
 
           // Read back: check if Automated is now disabled
-          const creationField = wrapper.querySelector('.field:has(.label)');
           const allSelects = wrapper.querySelectorAll('select');
           for (const sel of allSelects) {
             for (const opt of sel.options) {
@@ -199,7 +191,12 @@ test.describe('Journey 9 — Draw form advanced scenarios', () => {
               }
             }
           }
-          return { found: true, automatedDisabled: false, value: (inp as HTMLInputElement).value, note: 'no Automated option found' };
+          return {
+            found: true,
+            automatedDisabled: false,
+            value: (inp as HTMLInputElement).value,
+            note: 'no Automated option found',
+          };
         }
       }
       return { found: false, reason: 'qualifiers input not found' };
@@ -266,9 +263,10 @@ test.describe('Journey 9 — Draw form advanced scenarios', () => {
     await drawer.toggleCheckbox('qualifyingFirst');
 
     // Verify RR_WITH_PLAYOFF is NOT available in qualifying mode
-    const values = await drawer.fieldSelect('Draw Type').locator('option').evaluateAll(
-      (opts: HTMLOptionElement[]) => opts.map((o) => o.value).filter((v) => v && !v.startsWith('─')),
-    );
+    const values = await drawer
+      .fieldSelect('Draw Type')
+      .locator('option')
+      .evaluateAll((opts: HTMLOptionElement[]) => opts.map((o) => o.value).filter((v) => v && !v.startsWith('─')));
     expect(values).not.toContain('ROUND_ROBIN_WITH_PLAYOFF');
     expect(values).toContain('SINGLE_ELIMINATION');
     expect(values).toContain('ROUND_ROBIN');

--- a/e2e/journeys/16-draw-form-topology-templates.spec.ts
+++ b/e2e/journeys/16-draw-form-topology-templates.spec.ts
@@ -54,12 +54,15 @@ test.describe('Journey 16 — Topology templates', () => {
     const { drawer, collector } = await seedAndOpenDrawForm(page);
 
     // Get all draw type option labels
-    const options = await drawer.fieldSelect('Draw Type').locator('option').evaluateAll(
-      (opts: HTMLOptionElement[]) => opts.map((o) => ({
-        label: o.textContent?.trim() || '',
-        value: o.value,
-      })),
-    );
+    const options = await drawer
+      .fieldSelect('Draw Type')
+      .locator('option')
+      .evaluateAll((opts: HTMLOptionElement[]) =>
+        opts.map((o) => ({
+          label: o.textContent?.trim() || '',
+          value: o.value,
+        })),
+      );
 
     // Filter for topology template options (value starts with TOPOLOGY_TEMPLATE:)
     const templateOptions = options.filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:'));
@@ -100,11 +103,6 @@ test.describe('Journey 16 — Topology templates', () => {
       const event = tournament.events?.[0];
       if (!event) return false;
 
-      // Import the built-in templates from courthive-components
-      const templates = dev.factory.topologyToDrawOptions
-        ? true // topologyToDrawOptions exists
-        : false;
-
       // Create a minimal valid topology: single SE node
       const template = {
         name: 'E2E Test Template',
@@ -143,12 +141,14 @@ test.describe('Journey 16 — Topology templates', () => {
     await drawer.waitForOpen();
 
     // Get template options
-    const templateOptions = await drawer.fieldSelect('Draw Type').locator('option').evaluateAll(
-      (opts: HTMLOptionElement[]) =>
+    const templateOptions = await drawer
+      .fieldSelect('Draw Type')
+      .locator('option')
+      .evaluateAll((opts: HTMLOptionElement[]) =>
         opts
           .filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:'))
           .map((o) => ({ label: o.textContent?.trim() || '', value: o.value })),
-    );
+      );
 
     console.log(`Templates after seeding: ${templateOptions.length}`);
     for (const t of templateOptions) {
@@ -181,7 +181,8 @@ test.describe('Journey 16 — Topology templates', () => {
 
     // The drawer should close (template bypasses form submission)
     // Wait for either the drawer to close or a mutation to appear
-    const mutationReceived = await collector.waitForMethod('addDrawDefinition', 15_000)
+    const mutationReceived = await collector
+      .waitForMethod('addDrawDefinition', 15_000)
       .then(() => true)
       .catch(() => false);
 
@@ -215,14 +216,16 @@ test.describe('Journey 16 — Topology templates', () => {
       dev.factory.tournamentEngine.addTournamentExtension({
         extension: {
           name: 'topologyTemplates',
-          value: [{
-            name: 'E2E Structure Test',
-            state: {
-              drawName: 'Structure Test',
-              nodes: [{ id: 'main', stage: 'MAIN', structureType: 'SINGLE_ELIMINATION', drawSize: 16 }],
-              edges: [],
+          value: [
+            {
+              name: 'E2E Structure Test',
+              state: {
+                drawName: 'Structure Test',
+                nodes: [{ id: 'main', stage: 'MAIN', structureType: 'SINGLE_ELIMINATION', drawSize: 16 }],
+                edges: [],
+              },
             },
-          }],
+          ],
         },
       });
     });
@@ -242,11 +245,13 @@ test.describe('Journey 16 — Topology templates', () => {
     // Verify the generated structure
     const structures = await page.evaluate(() => {
       const draw = dev.getTournament().events?.[0]?.drawDefinitions?.[0];
-      return draw?.structures?.map((s: any) => ({
-        stage: s.stage,
-        name: s.structureName,
-        positions: s.positionAssignments?.length || 0,
-      })) || [];
+      return (
+        draw?.structures?.map((s: any) => ({
+          stage: s.stage,
+          name: s.structureName,
+          positions: s.positionAssignments?.length || 0,
+        })) || []
+      );
     });
 
     console.log('Generated structures:', JSON.stringify(structures));
@@ -261,19 +266,19 @@ test.describe('Journey 16 — Topology templates', () => {
     const { drawer, collector } = await seedAndOpenDrawForm(page);
 
     // Get template count in main mode
-    const mainTemplates = await drawer.fieldSelect('Draw Type').locator('option').evaluateAll(
-      (opts: HTMLOptionElement[]) =>
-        opts.filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:')).length,
-    );
+    const mainTemplates = await drawer
+      .fieldSelect('Draw Type')
+      .locator('option')
+      .evaluateAll((opts: HTMLOptionElement[]) => opts.filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:')).length);
 
     // Toggle to qualifying-first mode
     await drawer.toggleCheckbox('qualifyingFirst');
 
     // Get template count in qualifying mode
-    const qualTemplates = await drawer.fieldSelect('Draw Type').locator('option').evaluateAll(
-      (opts: HTMLOptionElement[]) =>
-        opts.filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:')).length,
-    );
+    const qualTemplates = await drawer
+      .fieldSelect('Draw Type')
+      .locator('option')
+      .evaluateAll((opts: HTMLOptionElement[]) => opts.filter((o) => o.value.startsWith('TOPOLOGY_TEMPLATE:')).length);
 
     console.log(`Templates: main=${mainTemplates}, qualifying=${qualTemplates}`);
 

--- a/e2e/journeys/20-unified-entries-seeding-doubles.spec.ts
+++ b/e2e/journeys/20-unified-entries-seeding-doubles.spec.ts
@@ -9,7 +9,6 @@
  */
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
-import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament, MockProfile } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';
 import { S } from '../helpers/selectors';
@@ -39,7 +38,10 @@ async function navigateToEntries(page: any, profile: MockProfile): Promise<strin
   await tournamentPage.navigateToEvents();
   await tournamentPage.eventsTable.locator('.tabulator-row').first().click();
   await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
-  const entriesVisible = await page.locator(S.ENTRIES_VIEW).isVisible().catch(() => false);
+  const entriesVisible = await page
+    .locator(S.ENTRIES_VIEW)
+    .isVisible()
+    .catch(() => false);
   if (!entriesVisible) {
     await page.locator('#eventTabsBar').getByText('Entries').click();
   }

--- a/e2e/journeys/44-add-remove-draw-entries.spec.ts
+++ b/e2e/journeys/44-add-remove-draw-entries.spec.ts
@@ -118,7 +118,6 @@ test.describe('Journey 44 — Add to draw / Remove from draw on selection', () =
     // Pick a participant that is on the draw but NOT placed.
     const removable = await page.evaluate(
       ({ eventId, drawId }: { eventId: string; drawId: string }) => {
-        const engine = (dev as any).factory.tournamentEngine;
         const tr = (dev as any).getTournament();
         const event = tr.events.find((e: any) => e.eventId === eventId);
         const dd = event.drawDefinitions.find((d: any) => d.drawId === drawId);

--- a/e2e/journeys/57-matchups-calledat-column.spec.ts
+++ b/e2e/journeys/57-matchups-calledat-column.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { TournamentPage } from '../pages/TournamentPage';
-import { S } from '../helpers/selectors';
 
 /**
  * Journey 57 — MatchUps page "Called" (calledAt) column, hidden by default

--- a/e2e/journeys/67-seeded-draw-structure.spec.ts
+++ b/e2e/journeys/67-seeded-draw-structure.spec.ts
@@ -42,9 +42,6 @@ async function probeStructure(page: import('@playwright/test').Page): Promise<St
     const positionAssignments: any[] = main?.positionAssignments ?? [];
     const seedAssignments: any[] = main?.seedAssignments ?? [];
 
-    const posByDrawPosition = new Map<number, any>();
-    for (const pa of positionAssignments) posByDrawPosition.set(pa.drawPosition, pa);
-
     const seedParticipant = (seedNumber: number): string | undefined =>
       seedAssignments.find((s: any) => s.seedNumber === seedNumber)?.participantId;
 
@@ -66,7 +63,9 @@ async function probeStructure(page: import('@playwright/test').Page): Promise<St
     ).length;
 
     const seed1MatchUp = round1Main.find((m: any) =>
-      (m.sides ?? []).some((side: any) => side?.participantId === seed1Id || side?.participant?.participantId === seed1Id),
+      (m.sides ?? []).some(
+        (side: any) => side?.participantId === seed1Id || side?.participant?.participantId === seed1Id,
+      ),
     );
 
     return {
@@ -99,7 +98,13 @@ test.describe('Journey 67 — seeded-draw structure', () => {
       // participantsCount < drawSize forces BYEs (the whole point of this test);
       // scaledParticipantsCount only sizes the pool, not the draw entries.
       drawProfiles: [
-        { eventName: 'Singles', drawSize: DRAW_SIZE, participantsCount: PLAYER_COUNT, seedsCount: SEEDS, drawType: 'SINGLE_ELIMINATION' },
+        {
+          eventName: 'Singles',
+          drawSize: DRAW_SIZE,
+          participantsCount: PLAYER_COUNT,
+          seedsCount: SEEDS,
+          drawType: 'SINGLE_ELIMINATION',
+        },
       ],
     });
 

--- a/e2e/journeys/72-registrations-nav-visibility.spec.ts
+++ b/e2e/journeys/72-registrations-nav-visibility.spec.ts
@@ -23,7 +23,7 @@ let seeded = false;
 async function seedTournamentWithReg(page: Page, withRegistration: boolean): Promise<string> {
   return page.evaluate(async (withReg) => {
     await dev.tmx2db.initDB();
-    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+    dev.factory.mocksEngine.generateTournamentRecord({
       nonRandom: 1,
       setState: true,
       tournamentName: 'E2E Registrations',

--- a/e2e/pages/DrawFormDrawer.ts
+++ b/e2e/pages/DrawFormDrawer.ts
@@ -2,6 +2,27 @@ import { Locator, Page, expect } from '@playwright/test';
 import { S } from '../helpers/selectors';
 
 /**
+ * Browser-side: click a checkbox and resolve once its change handler has run and
+ * one animation frame has passed, so the handler's synchronous DOM mutations are
+ * flushed before the caller continues.
+ *
+ * Declared at module scope, not inline in `page.evaluate`, so its nested callbacks
+ * stay within the ecosystem's function-nesting limit (sonarjs/no-nested-functions,
+ * threshold 4). Playwright serialises it, so it must not close over anything.
+ */
+function clickAndAwaitChange(checkboxId: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const input = document.getElementById(checkboxId) as HTMLInputElement;
+    if (!input) {
+      resolve();
+      return;
+    }
+    input.addEventListener('change', () => requestAnimationFrame(() => resolve()), { once: true });
+    input.click();
+  });
+}
+
+/**
  * Page object for the draw configuration drawer (addDraw).
  *
  * The drawer is rendered inside #tmxDrawer by courthive-components' renderForm.
@@ -116,35 +137,10 @@ export class DrawFormDrawer {
    *
    *  For qualifyingFirst, the change handler (qualifyingFirstChange)
    *  re-renders draw type options, toggles field visibility, and
-   *  re-derives draw size. We wait for the draw type select's options
-   *  to change as a signal that the handler completed. */
+   *  re-derives draw size. We wait for the change event to fire and one
+   *  animation frame to pass as the signal that the handler completed. */
   async toggleCheckbox(id: string): Promise<void> {
-    // Capture the draw type option count before toggle
-    const optionCountBefore = await this.fieldSelect('Draw Type')
-      .locator('option')
-      .count()
-      .catch(() => 0);
-
-    // Click the checkbox and wait for the change event handler to
-    // complete its DOM mutations. We use a Promise that resolves
-    // when the handler finishes by watching for a known DOM change.
-    await this.page.evaluate((checkboxId) => {
-      return new Promise<void>((resolve) => {
-        const input = document.getElementById(checkboxId) as HTMLInputElement;
-        if (!input) { resolve(); return; }
-
-        // Listen for the NEXT change event on the input — when the
-        // handler is done, the DOM has been mutated.
-        const handler = () => {
-          input.removeEventListener('change', handler);
-          // Use requestAnimationFrame to let any synchronous DOM
-          // mutations from the handler flush before resolving
-          requestAnimationFrame(() => resolve());
-        };
-        input.addEventListener('change', handler);
-        input.click();
-      });
-    }, id);
+    await this.page.evaluate(clickAndAwaitChange, id);
   }
 
   /** Click the Generate button. It lives in the drawer footer which

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,7 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
-        project: ['tsconfig.json', 'electron/tsconfig.json'],
+        project: ['tsconfig.json', 'electron/tsconfig.json', 'e2e/tsconfig.json'],
       },
       globals: {
         ...globals.browser,
@@ -36,6 +36,9 @@ export default [
         ...globals.es2021,
         ...globals.jest,
         NodeJS: 'readonly',
+        // Injected by TMX at runtime and declared in e2e/global.d.ts; ESLint's no-undef
+        // cannot see ambient TypeScript declarations.
+        dev: 'readonly',
       },
     },
     plugins: {
@@ -86,6 +89,16 @@ export default [
       'import/no-named-as-default': 'off',
       'import/no-named-as-default-member': 'off',
       'import/no-unresolved': 'off',
+    },
+  },
+  {
+    // Playwright journeys and their page objects. Test files carry the ecosystem's
+    // standard test overrides: repeated selector/label literals are the clearest way
+    // to write an assertion, and empty functions are common as no-op callbacks.
+    files: ['e2e/**/*.ts'],
+    rules: {
+      'sonarjs/no-duplicate-string': 'off',
+      '@typescript-eslint/no-empty-function': 'off',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs:publish": "pnpm build && git checkout docs && rm -rf docs/* && cp -r dist/* docs && git add docs && git commit -m 'docs: update' && git push && git checkout main",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
-    "lint": "eslint src --cache --max-warnings 0",
+    "lint": "eslint src e2e --cache --max-warnings 0",
     "lint:fix": "eslint src --fix --cache",
     "lint:staged": "TZ=UTC lint-staged",
     "pre-commit": "lint-staged",


### PR DESCRIPTION
`pnpm lint` was `eslint src`, and e2e sat outside the parser project entirely —
linting a journey spec failed with "file was not found in any of the provided
project(s)". Specs were type-checked (tsc -p e2e/tsconfig.json) but never linted,
so 90 spec files had been drifting unchecked.

Three config changes make the suite lintable:

- add e2e/tsconfig.json to parserOptions.project
- declare `dev` as a global. It is real, injected by TMX at runtime and declared
  in e2e/global.d.ts, but no-undef cannot see ambient TypeScript declarations —
  without this it accounted for 426 of 518 findings
- give e2e the ecosystem's standard test-file overrides, no-duplicate-string and
  no-empty-function. Repeated selector and label literals are the clearest way to
  write an assertion; that rule accounted for another 80

That leaves 13 real findings, all fixed here:

DrawFormDrawer.toggleCheckbox nested five functions deep, one past the
sonarjs/no-nested-functions threshold. Its browser-side body is now the
module-scope helper clickAndAwaitChange — module-level helpers do not count
toward a caller's nesting depth, and Playwright serialises it unchanged. The same
commit drops optionCountBefore, which the method captured and never read after it
switched from polling option counts to awaiting the change event, and corrects the
JSDoc that still described the old strategy.

The rest is dead code across nine specs: unused imports, assignments whose values
are never read, a Map built and never queried in journey 67, and a
PROFILE_WITH_QUALIFYING fixture in journey 02 left behind when qualifiers-count
inference moved to journey 12. Journey 07 keeps its seedTournament call and only
drops the unused binding — the call seeds state the test depends on.

The now-unnecessary no-var disable in global.d.ts goes too; no-var is not enabled,
so the directive itself was reported once e2e came into scope.

Verified the coverage actually catches something rather than trusting a green run:
a planted spec with an unused variable fails `pnpm lint` (exit 1) and passes once
removed (exit 0). All 66 tests across the touched specs pass, including the four
that exercise the refactored toggleCheckbox.