### PR TITLE
fix(participants): clear the country when the field is emptied and saved

### DIFF
--- a/e2e/journeys/91-participants-edit-participant.spec.ts
+++ b/e2e/journeys/91-participants-edit-participant.spec.ts
@@ -234,6 +234,37 @@ test.describe('Journey 91 — Edit Participant drawer', () => {
     collector.detach();
   });
 
+  test('emptying the country dispatches an explicit clear, without pressing Enter', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+    await seedRichParticipant(page);
+    await gotoParticipants(page, tournamentId);
+    const collector = createMutationCollector(page);
+
+    const drawer = await openEditDrawer(page, 0);
+    const country = drawer.getByPlaceholder('Country of origin');
+    await expect(country).toHaveValue(/France/);
+    // Clear and go straight to Save. The type-ahead's callback only fires on a
+    // selection (or Enter in an empty field), so this is the path that used to
+    // submit the stale code.
+    await country.fill('');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    const entry = await collector.waitForMethod('modifyParticipant', 10_000);
+    const params: any = entry.methods.find((m) => m.method === 'modifyParticipant')?.params;
+
+    // Asserted on what TMX DISPATCHES, deliberately — not on the stored record.
+    // '' is the engine's explicit clear, and honouring it landed in factory #4599,
+    // which is merged but unpublished. TMX resolves factory through link:../factory
+    // locally and the published pin in CI, so a persisted-record assertion would pass
+    // here and fail there. factory covers its own half in clearPersonFields.test.ts.
+    expect(params?.participant?.person?.nationalityCode).toBe('');
+    // The rest of the person must still ride along untouched.
+    expect(params?.participant?.person?.standardGivenName).toBe('Virginia');
+    expect(params?.participant?.person?.birthDate).toBe('1994-03-17');
+
+    collector.detach();
+  });
+
   test('a new participant left at Sex "Unknown" stores no sex, not the label', async ({ page }) => {
     const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
     await gotoParticipants(page, tournamentId);

--- a/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
@@ -43,6 +43,20 @@ export function editIndividualParticipant({
 
   const nationalityCodeValue = (value: string) => (values.nationalityCode = value);
 
+  // `values.nationalityCode` is only written by the type-ahead's selection callback, so an
+  // emptied field would otherwise still submit the previously stored code — clearing the
+  // country by deleting the text and pressing Save silently did nothing, while deleting it
+  // and pressing Enter worked (the type-ahead reports '' for an empty field on Enter).
+  // Reading the input back at save time makes both paths agree.
+  //
+  // '' is the engine's explicit "remove this value"; a participant being created has nothing
+  // to clear, so the add path sends undefined instead of an empty string.
+  const submittedNationalityCode = (): string | undefined => {
+    const displayed = inputs.nationalityCode?.value?.trim();
+    if (displayed) return values.nationalityCode;
+    return participant?.participantId ? '' : undefined;
+  };
+
   const validValues = ({ firstName, lastName, nickname }: any) => {
     const hasFullName = validators.nameValidator(2)(firstName || '') && validators.nameValidator(2)(lastName || '');
     const hasNickname = nickname && nickname.trim().length >= 2;
@@ -169,11 +183,10 @@ export function editIndividualParticipant({
   function saveParticipant(): void {
     if (participant?.participantId) {
       const person = {
-        // `values.nationalityCode` is the IOC code the type-ahead callback records.
-        // The input's own value is the human-readable label after a selection, and
-        // `modifyParticipant` silently skips a nationalityCode that fails
-        // `validNationalityCode()` — so reading the input discarded every country edit.
-        nationalityCode: values.nationalityCode,
+        // Never `inputs.nationalityCode.value` — after a selection that holds the
+        // human-readable label, and `modifyParticipant` silently skips a nationalityCode
+        // that fails `validNationalityCode()`, which discarded every country edit.
+        nationalityCode: submittedNationalityCode(),
         standardFamilyName: inputs.lastName.value,
         standardGivenName: inputs.firstName.value,
         birthDate: inputs.birthday.value,
@@ -213,7 +226,7 @@ export function editIndividualParticipant({
       participantType: INDIVIDUAL,
       participantId: tools.UUID(),
       person: {
-        nationalityCode: values.nationalityCode,
+        nationalityCode: submittedNationalityCode(),
         standardGivenName: firstName,
         standardFamilyName: lastName,
         sex,


### PR DESCRIPTION
Emptying the country in the Edit Participant drawer and clicking Save kept the
previously stored code. `saveParticipant` submitted `values.nationalityCode`, and
`values` is only written by the type-ahead's selection callback — so with nothing
selected it still held whatever was there when the drawer opened.

Emptying the field and pressing Enter did work, because `createTypeAhead` reports
'' for an empty field on Enter. Two paths to the same intent, and the common one
was the broken one.

The submitted code is now resolved from the input at save time: empty text means
clear, anything else means the code recorded at selection. '' is the engine's
explicit remove-this-value; a participant being created has nothing to clear, so
the add path sends undefined rather than an empty string.

birthDate needed no equivalent change — TMX already submits inputs.birthday.value,
which is '' when the field is emptied.

The engine side of this landed in competition-factory#4599, which taught
modifyParticipant to treat '' as a clear for both birthDate and nationalityCode.
Until that publishes, the dispatched '' is simply ignored by the pinned factory, so
this is forward-compatible rather than dependent on it.

The test asserts what TMX dispatches rather than what ends up in the record, for
exactly that reason: TMX resolves factory through link:../factory locally but the
published pin in CI, so a persisted-record assertion would pass here and fail there.
factory covers its own half in clearPersonFields.test.ts. Verified to fail against
the pre-fix behaviour, dispatching 'FRA' where '' is expected.