### PR TITLE
feat(venues): add a tournament venue from the canonical facility registry

### DIFF
--- a/e2e/journeys/92-venues-add-from-registry.spec.ts
+++ b/e2e/journeys/92-venues-add-from-registry.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { createMutationCollector } from '../helpers/mutation-collector';
+import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 92 — WS2: add a tournament venue from the canonical facility registry.
+ *
+ * Why this exists: the hand-entry Add Venue form mints a venueId and courtIds local to the
+ * tournament, so the same physical club entered twice becomes two unrelated venues. A registry
+ * venue arrives carrying its canonical `facilityId` and court ids, which is what makes "every
+ * tournament at this facility" a join instead of a name match.
+ *
+ * The AMS passthrough is stubbed at the network layer with `page.route`. The registry's own
+ * behaviour is covered in courthive-facilities, and AMS's passthrough in its controller spec —
+ * what is untested until here is TMX's half: that a chosen candidate becomes an `addVenue`
+ * carrying the registry's ids rather than freshly minted ones.
+ */
+
+const AMS = '**/facilities/**';
+
+const CANDIDATES = {
+  results: [
+    {
+      facilityId: 'fac-life',
+      name: 'Life Time Peachtree',
+      city: 'Atlanta',
+      countryCode: 'USA',
+      courtCount: 7,
+      matchedOn: 'name',
+    },
+    {
+      facilityId: 'fac-lake',
+      name: 'Lakeside Racquet Club',
+      city: 'Marietta',
+      countryCode: 'USA',
+      courtCount: 4,
+      matchedOn: 'alias',
+    },
+  ],
+};
+
+const VENUE = {
+  venueId: 'fac-life',
+  facilityId: 'fac-life',
+  venueName: 'Life Time Peachtree',
+  addresses: [{ city: 'Atlanta', countryCode: 'USA', latitude: 33.848, longitude: -84.3733 }],
+  courts: [
+    { courtId: 'court-a', courtName: 'Court 1', surfaceCategory: 'HARD', indoorOutdoor: 'OUTDOOR', courtOrder: 1 },
+    { courtId: 'court-b', courtName: 'Court 2', surfaceCategory: 'HARD', indoorOutdoor: 'INDOOR', courtOrder: 2 },
+  ],
+};
+
+/** Stub the AMS passthrough. Returns the recorded request URLs so a test can assert what was called. */
+async function stubRegistry(page: Page, opts: { venue?: any; venueStatus?: number } = {}) {
+  const calls: string[] = [];
+  await page.route(AMS, async (route) => {
+    const url = route.request().url();
+    calls.push(url);
+    if (url.includes('/facilities/search')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(CANDIDATES) });
+    }
+    if (url.includes('/venue')) {
+      const status = opts.venueStatus ?? 200;
+      if (status !== 200) return route.fulfill({ status, contentType: 'application/json', body: '{}' });
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(opts.venue ?? VENUE),
+      });
+    }
+    return route.continue();
+  });
+  return calls;
+}
+
+/**
+ * The registry button is gated on a signed-in session — a logged-out user has no token to search
+ * with, so offering it would only 401. The spec stubs the session the same way it stubs the
+ * network: `validateToken` decodes the JWT locally and checks `exp`, so an unsigned token with a
+ * future expiry is enough to exercise the UI without a CFS login (and without the 10/min login
+ * throttle that makes the CFS-gated journeys skip at suite scale).
+ */
+async function stubSignedInSession(page: Page) {
+  await page.evaluate(() => {
+    const b64 = (o: any) => btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const token = `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ exp, roles: [], provider: {} })}.`;
+    localStorage.setItem('tmxToken', token);
+  });
+}
+
+async function openRegistryPicker(page: Page) {
+  await page.locator('#addVenue').click();
+  const lookup = page.locator('#facilityRegistryLookup');
+  await expect(lookup).toBeVisible({ timeout: 5_000 });
+  await lookup.click();
+  await expect(page.getByPlaceholder('Search facilities by name')).toBeVisible({ timeout: 5_000 });
+}
+
+async function gotoVenues(page: Page) {
+  const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+  await stubSignedInSession(page);
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  await tournament.navigateToVenues();
+  return tournamentId;
+}
+
+test.describe('Journey 92 — add venue from the facility registry', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('a chosen candidate is added carrying the registry facilityId and court ids', async ({ page }) => {
+    await stubRegistry(page);
+    await gotoVenues(page);
+    const collector = createMutationCollector(page);
+
+    await openRegistryPicker(page);
+    await page.getByPlaceholder('Search facilities by name').fill('life');
+
+    const candidate = page.locator('[data-facility-id="fac-life"]');
+    await expect(candidate).toBeVisible({ timeout: 5_000 });
+    // The row explains itself — court count and why the registry surfaced it.
+    await expect(candidate).toContainText('7 courts');
+    await expect(candidate).toContainText('matched name');
+    await candidate.click();
+
+    // Preview renders the venue and its courts before anything is committed.
+    await expect(page.locator('#facilityPreview')).toContainText('Court 1', { timeout: 5_000 });
+
+    await page.getByRole('button', { name: 'Add to tournament' }).click();
+    const entry = await collector.waitForMethod('addVenue', 10_000);
+    const params: any = entry.methods.find((m) => m.method === 'addVenue')?.params;
+
+    // The point of WS2: canonical ids survive into the tournament record rather than being minted.
+    expect(params?.venue?.facilityId).toBe('fac-life');
+    expect(params?.venue?.venueId).toBe('fac-life');
+    expect(params?.venue?.courts?.map((c: any) => c.courtId)).toEqual(['court-a', 'court-b']);
+
+    // And the venue actually lands, courts included — one mutation, no companion addCourts.
+    await expect
+      .poll(() => page.evaluate(() => dev.getTournament().venues?.[0]?.courts?.length ?? 0), { timeout: 8_000 })
+      .toBe(2);
+    const venue: any = await page.evaluate(() => dev.getTournament().venues?.[0]);
+    expect(venue.facilityId).toBe('fac-life');
+
+    collector.detach();
+  });
+
+  test('a single result is still only a candidate — nothing auto-selects', async ({ page }) => {
+    await page.route(AMS, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ results: [CANDIDATES.results[0]] }),
+      }),
+    );
+    await gotoVenues(page);
+    const collector = createMutationCollector(page);
+
+    await openRegistryPicker(page);
+    await page.getByPlaceholder('Search facilities by name').fill('life');
+    await expect(page.locator('[data-facility-id="fac-life"]')).toBeVisible({ timeout: 5_000 });
+
+    // A sole hit must NOT resolve itself into a preview or a mutation.
+    await expect(page.locator('#facilityPreview')).toBeEmpty();
+    expect(collector.hasMethod('addVenue')).toBe(false);
+
+    collector.detach();
+  });
+
+  test('a query below the registry minimum never reaches the network', async ({ page }) => {
+    const calls = await stubRegistry(page);
+    await gotoVenues(page);
+
+    await openRegistryPicker(page);
+    await page.getByPlaceholder('Search facilities by name').fill('l');
+    await page.waitForTimeout(600);
+
+    // The registry 400s a one-character query; firing it anyway would show the user a server
+    // error for their first keystroke.
+    expect(calls.filter((u) => u.includes('/facilities/search'))).toEqual([]);
+    await expect(page.getByText('Type at least 2 characters to search')).toBeVisible();
+  });
+
+  test('a facility whose venue is missing reports it instead of failing silently', async ({ page }) => {
+    await stubRegistry(page, { venueStatus: 404 });
+    await gotoVenues(page);
+    const collector = createMutationCollector(page);
+
+    await openRegistryPicker(page);
+    await page.getByPlaceholder('Search facilities by name').fill('life');
+    await page.locator('[data-facility-id="fac-life"]').click();
+
+    await expect(page.getByText('That facility has no venue record')).toBeVisible({ timeout: 5_000 });
+    expect(collector.hasMethod('addVenue')).toBe(false);
+
+    collector.detach();
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2006,6 +2006,24 @@
         "postalCodeLabel": "Postal code",
         "countryCodeLabel": "Country",
         "countryCodePlaceholder": "Start typing a country name"
+      },
+      "registry": {
+        "title": "Add venue from registry",
+        "searchPlaceholder": "Search facilities by name",
+        "keepTyping": "Type at least 2 characters to search",
+        "candidateCount": "{{count}} matching facility",
+        "candidateCount_other": "{{count}} matching facilities",
+        "noMatches": "No matching facilities",
+        "searchFailed": "Facility search is unavailable",
+        "venueFailed": "Could not load that facility",
+        "venueMissing": "That facility has no venue record",
+        "courtCount": "{{count}} court",
+        "courtCount_other": "{{count}} courts",
+        "matchedOn": "matched {{field}}",
+        "selectFirst": "Choose a facility first",
+        "addVenue": "Add to tournament",
+        "added": "Venue added from the registry",
+        "searching": "Searching…"
       }
     },
     "events": {

--- a/src/pages/tournament/tabs/venuesTab/addVenue.ts
+++ b/src/pages/tournament/tabs/venuesTab/addVenue.ts
@@ -14,6 +14,8 @@ import { context } from 'services/context';
 import { t } from 'i18n';
 
 import { attachTimePicker, createTimeOrderValidator, toMilitaryTime } from './venueTimeHelpers';
+import { addVenueFromRegistry } from './addVenueFromRegistry';
+import { getLoginState } from 'services/authentication/loginState';
 import { ADD_COURTS, ADD_ONLINE_RESOURCE, ADD_VENUE } from 'constants/mutationConstants';
 import { RIGHT } from 'constants/tmxConstants';
 
@@ -117,20 +119,32 @@ const saveVenue = (callback?: (result: any) => void, engine?: string, selectedCo
 // External lookup
 // ---------------------------------------------------------------------------
 
-function hasFacilityService(): boolean {
-  const provider = context.provider;
-  return !!(provider?.facilityService && provider?.facilityLookup);
+/**
+ * The registry lookup is offered to any signed-in user rather than behind the old
+ * `provider.facilityService && provider.facilityLookup` gate.
+ *
+ * Those two provider fields gated a third-party lookup that was never built — the handler was a
+ * `console.log` and a TODO — so there is no existing behaviour to preserve, and keeping a gate for
+ * a capability that never shipped would only hide the one that now has. The registry itself is the
+ * authority on access: AMS authenticates the request, and courthive-facilities holds the service
+ * token. Signed out, there is no token to search with, so the button would only 401.
+ */
+function canSearchRegistry(): boolean {
+  return !!getLoginState();
 }
 
-function createExternalLookupButton(): HTMLButtonElement {
+function createExternalLookupButton(callback?: (result: any) => void): HTMLButtonElement {
   const button = document.createElement('button');
   button.className = 'button is-fullwidth is-outlined is-info';
   button.style.marginBottom = '1em';
+  button.id = 'facilityRegistryLookup';
+  button.type = 'button';
   button.textContent = t('pages.venues.addVenue.externalLookup');
   button.addEventListener('click', () => {
-    // TODO: hand over to facility lookup modal populated by 3rd party service
-    const { facilityLookup } = context.provider || {};
-    console.log('External facility lookup triggered', facilityLookup);
+    // Close the hand-entry drawer first: the picker is an alternative to filling this form in, and
+    // leaving a half-typed venue behind it invites adding the same club twice.
+    context.drawer?.close();
+    addVenueFromRegistry({ callback });
   });
   return button;
 }
@@ -202,8 +216,8 @@ export function addVenue(callback?: (result: any) => void, engine?: string): voi
   ];
 
   const content = (elem: HTMLElement) => {
-    if (hasFacilityService()) {
-      elem.appendChild(createExternalLookupButton());
+    if (canSearchRegistry()) {
+      elem.appendChild(createExternalLookupButton(callback));
     }
     const inputs = renderForm(
       elem,

--- a/src/pages/tournament/tabs/venuesTab/addVenueFromRegistry.ts
+++ b/src/pages/tournament/tabs/venuesTab/addVenueFromRegistry.ts
@@ -1,0 +1,247 @@
+/**
+ * Add a tournament venue by picking it out of the canonical facility registry.
+ *
+ * The alternative — the hand-typed Add Venue form — mints a venueId and courtIds local to this
+ * tournament, so the same physical club entered at two tournaments becomes two unrelated venues.
+ * A registry venue arrives carrying its canonical `facilityId` and court ids, which is what makes
+ * "every tournament at this facility" a join rather than a fuzzy name match, and what lets a court
+ * closure logged once reach every tournament there.
+ *
+ * Flow: search (candidates) → choose → preview the venue and its courts → add.
+ *
+ * Nothing here resolves. The registry returns candidates and a person picks one; a sole result is
+ * still only a candidate and is never auto-selected. See Mentat/planning/REGISTRY_SEARCH_PATTERN.md.
+ */
+import {
+  MIN_FACILITY_QUERY,
+  fetchRegistryVenue,
+  searchFacilities,
+  type FacilityCandidate,
+  type RegistryVenue,
+} from 'services/apis/facilitiesApi';
+import { mutationRequest } from 'services/mutation/mutationRequest';
+import { openModal } from 'components/modals/baseModal/baseModal';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { buildVenueLocator } from 'courthive-components';
+import { isFunction } from 'functions/typeOf';
+import { t } from 'i18n';
+
+import { ADD_VENUE } from 'constants/mutationConstants';
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+export function addVenueFromRegistry({ callback }: { callback?: (result: any) => void } = {}): void {
+  let timer: any;
+  let inFlight: AbortController | undefined;
+  let chosen: { candidate: FacilityCandidate; venue: RegistryVenue } | undefined;
+
+  const content = document.createElement('div');
+
+  const input = document.createElement('input');
+  input.className = 'input';
+  input.type = 'search';
+  input.placeholder = t('pages.venues.registry.searchPlaceholder');
+  input.setAttribute('aria-label', t('pages.venues.registry.searchPlaceholder'));
+  content.appendChild(input);
+
+  const status = document.createElement('div');
+  status.style.cssText = 'margin: .5em 0; color: var(--tmx-text-secondary); font-size: .85rem;';
+  status.setAttribute('role', 'status');
+  content.appendChild(status);
+
+  const results = document.createElement('div');
+  results.id = 'facilityResults';
+  results.style.cssText = 'max-height: 40vh; overflow-y: auto;';
+  content.appendChild(results);
+
+  const preview = document.createElement('div');
+  preview.id = 'facilityPreview';
+  content.appendChild(preview);
+
+  const setStatus = (message: string) => (status.textContent = message);
+
+  // --- search -------------------------------------------------------------
+
+  const renderCandidates = (candidates: FacilityCandidate[]) => {
+    results.replaceChildren();
+    for (const candidate of candidates) {
+      results.appendChild(candidateRow(candidate, () => choose(candidate)));
+    }
+  };
+
+  const runSearch = async (query: string) => {
+    // Abort the previous request rather than letting a slow early keystroke resolve after a
+    // faster later one and repaint stale candidates over the current query's results.
+    inFlight?.abort();
+    const controller = new AbortController();
+    inFlight = controller;
+
+    if (query.trim().length < MIN_FACILITY_QUERY) {
+      results.replaceChildren();
+      setStatus(t('pages.venues.registry.keepTyping'));
+      return;
+    }
+
+    setStatus(t('pages.venues.registry.searching'));
+    try {
+      const { results: candidates } = await searchFacilities(query, { signal: controller.signal });
+      if (controller.signal.aborted) return;
+      renderCandidates(candidates);
+      setStatus(
+        candidates.length
+          ? t('pages.venues.registry.candidateCount', { count: candidates.length })
+          : t('pages.venues.registry.noMatches'),
+      );
+    } catch (err: any) {
+      if (controller.signal.aborted || err?.name === 'AbortError') return;
+      results.replaceChildren();
+      setStatus(t('pages.venues.registry.searchFailed'));
+    }
+  };
+
+  input.addEventListener('input', () => {
+    preview.replaceChildren();
+    chosen = undefined;
+    clearTimeout(timer);
+    const query = input.value;
+    timer = setTimeout(() => runSearch(query), SEARCH_DEBOUNCE_MS);
+  });
+
+  // --- choose + preview ---------------------------------------------------
+
+  async function choose(candidate: FacilityCandidate) {
+    setStatus(t('common.loading'));
+    let venue: RegistryVenue | null;
+    try {
+      venue = await fetchRegistryVenue(candidate.facilityId);
+    } catch {
+      setStatus(t('pages.venues.registry.venueFailed'));
+      return;
+    }
+    if (!venue) {
+      // A candidate whose venue is gone is a registry inconsistency, not a user error — say so
+      // rather than silently doing nothing.
+      setStatus(t('pages.venues.registry.venueMissing'));
+      return;
+    }
+
+    chosen = { candidate, venue };
+    results.replaceChildren();
+    setStatus('');
+    preview.replaceChildren(buildPreview(venue));
+  }
+
+  // --- add ----------------------------------------------------------------
+
+  const addChosenVenue = () => {
+    if (!chosen) {
+      tmxToast({ message: t('pages.venues.registry.selectFirst'), intent: 'is-warning' });
+      return;
+    }
+    // The registry shapes this as a TODS Venue with its courts inline, and `addVenue` pushes it
+    // whole — so there is no companion addCourts call and no translation step to drift.
+    const methods = [{ method: ADD_VENUE, params: { venue: chosen.venue, returnDetails: true } }];
+    mutationRequest({
+      methods,
+      callback: (result: any) => {
+        if (result?.success) {
+          tmxToast({ message: t('pages.venues.registry.added'), intent: 'is-success' });
+          if (isFunction(callback) && callback) callback(result);
+        } else {
+          tmxToast({ intent: 'is-danger', message: result?.error?.message || t('common.error') });
+        }
+      },
+    });
+  };
+
+  openModal({
+    title: t('pages.venues.registry.title'),
+    content,
+    config: { maxWidth: 620, padding: '1' },
+    buttons: [
+      { label: t('common.cancel'), intent: 'none', close: true },
+      { label: t('pages.venues.registry.addVenue'), intent: 'is-info', onClick: addChosenVenue, close: true },
+    ],
+  });
+
+  setStatus(t('pages.venues.registry.keepTyping'));
+  setTimeout(() => input.focus(), 100);
+}
+
+/** One candidate row. `matchedOn` is shown so the list is explainable rather than magic. */
+function candidateRow(candidate: FacilityCandidate, onSelect: () => void): HTMLElement {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'facility-candidate';
+  row.dataset.facilityId = candidate.facilityId;
+  row.style.cssText = [
+    'display: flex',
+    'width: 100%',
+    'justify-content: space-between',
+    'align-items: center',
+    'gap: 1em',
+    'padding: .6em .8em',
+    'margin-bottom: .35em',
+    'text-align: left',
+    'cursor: pointer',
+    'border: 1px solid var(--tmx-border-primary)',
+    'border-radius: 6px',
+    'background: var(--tmx-bg-primary)',
+    'color: var(--tmx-text-primary)',
+  ].join(';');
+
+  const place = [candidate.city, candidate.state, candidate.countryCode].filter(Boolean).join(', ');
+  const left = document.createElement('div');
+  const name = document.createElement('div');
+  name.style.fontWeight = '600';
+  name.textContent = candidate.name;
+  left.appendChild(name);
+  if (place) {
+    const sub = document.createElement('div');
+    sub.style.cssText = 'font-size: .8rem; color: var(--tmx-text-secondary);';
+    sub.textContent = place;
+    left.appendChild(sub);
+  }
+
+  const right = document.createElement('div');
+  right.style.cssText = 'text-align: right; font-size: .8rem; color: var(--tmx-text-secondary); white-space: nowrap;';
+  const courts = document.createElement('div');
+  courts.textContent = t('pages.venues.registry.courtCount', { count: candidate.courtCount ?? 0 });
+  right.appendChild(courts);
+  if (candidate.matchedOn) {
+    const why = document.createElement('div');
+    why.style.fontStyle = 'italic';
+    why.textContent = t('pages.venues.registry.matchedOn', { field: candidate.matchedOn });
+    right.appendChild(why);
+  }
+
+  row.append(left, right);
+  row.addEventListener('click', onSelect);
+  return row;
+}
+
+/**
+ * What the user is about to add. `buildVenueLocator` degrades on its own when the facility has no
+ * coordinates (or when leaflet is absent), rendering the header and court list without a map, so
+ * there is no separate no-geo branch to keep in step here.
+ */
+function buildPreview(venue: RegistryVenue): HTMLElement {
+  const address: any = Array.isArray(venue.addresses) ? venue.addresses[0] : undefined;
+  const addressFormatted = [address?.city, address?.state, address?.countryCode].filter(Boolean).join(', ');
+
+  return buildVenueLocator({
+    venueId: venue.venueId,
+    venueName: venue.venueName,
+    ...(addressFormatted ? { addressFormatted } : {}),
+    latitude: address?.latitude,
+    longitude: address?.longitude,
+    courts: (venue.courts ?? []).map((court: any) => ({
+      courtId: court.courtId,
+      courtName: court.courtName,
+      indoorOutdoor: court.indoorOutdoor,
+      surfaceCategory: court.surfaceCategory,
+      floodlit: court.floodlit,
+      courtOrder: court.courtOrder,
+    })),
+  });
+}

--- a/src/services/apis/facilitiesApi.ts
+++ b/src/services/apis/facilitiesApi.ts
@@ -1,0 +1,101 @@
+/**
+ * Facility-registry reads for the Venues tab, proxied by courthive-ams.
+ *
+ * TMX does NOT call `courthive-facilities` directly — the registry is service-token guarded and
+ * that token must stay server-side. It also does not go through CFS: a proxied read there would
+ * couple scorekeeper acknowledgement latency to an unrelated service, so AMS owns this passthrough
+ * (decision 2026-08-11, recorded in courthive-ams `facilities.controller.ts`).
+ *
+ * Auth is the same admin JWT TMX already holds (`tmxToken`). AMS verifies only and dual-accepts
+ * CFS's ES256 tokens, so no new signing path is involved. Search is authenticated but not
+ * role-gated (2026-08-13): a facility is one public physical place and the endpoint returns
+ * candidates a human chooses, never a resolution verdict.
+ *
+ * Base URL: `VITE_AMS_URL` (build-time) → localhost-aware fallback (:3130 in dev,
+ * `<origin>/ams` in prod) — the same shape `declarationsApi` uses.
+ */
+import { getJwtTokenStorageKey } from 'config/localStorage';
+
+/** One search hit. `matchedOn` is why the registry surfaced it — shown so a picker is explainable. */
+export interface FacilityCandidate {
+  facilityId: string;
+  name: string;
+  city?: string;
+  state?: string;
+  countryCode?: string;
+  courtCount?: number;
+  matchedOn?: string;
+}
+
+export interface FacilitySearchResult {
+  results: FacilityCandidate[];
+  nextCursor?: string;
+}
+
+/** A TODS `Venue`, shaped by the registry so factory's `addVenue` accepts it untranslated. */
+export interface RegistryVenue {
+  venueId: string;
+  facilityId: string;
+  venueName: string;
+  courts: Array<{ courtId: string; courtName: string; [attr: string]: unknown }>;
+  [attr: string]: unknown;
+}
+
+export function getAmsBaseUrl(): string {
+  const fromVite = (import.meta as any)?.env?.VITE_AMS_URL;
+  if (fromVite) return String(fromVite).replace(/\/+$/, '');
+  const loc = globalThis.location;
+  const host = loc?.host ?? '';
+  const local = host.includes('localhost') || loc?.hostname === '127.0.0.1';
+  return local ? 'http://localhost:3130' : `${loc?.origin ?? ''}/ams`;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(getJwtTokenStorageKey());
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * The registry rejects a query shorter than 2 characters with a 400. Returning empty for those
+ * locally keeps a picker from firing a request per keystroke that can only fail, and keeps the
+ * user's first character from surfacing as a server error.
+ */
+export const MIN_FACILITY_QUERY = 2;
+
+export async function searchFacilities(
+  query: string,
+  options: { city?: string; limit?: number; signal?: AbortSignal } = {},
+): Promise<FacilitySearchResult> {
+  const q = query.trim();
+  if (q.length < MIN_FACILITY_QUERY) return { results: [] };
+
+  const params = new URLSearchParams({ q });
+  if (options.city) params.set('city', options.city);
+  if (options.limit) params.set('limit', String(options.limit));
+
+  const res = await fetch(`${getAmsBaseUrl()}/facilities/search?${params.toString()}`, {
+    headers: authHeaders(),
+    signal: options.signal,
+  });
+  if (!res.ok) throw new Error(`facility search failed (${res.status})`);
+  return (await res.json()) as FacilitySearchResult;
+}
+
+/**
+ * The venue payload for a facility the user has already chosen.
+ *
+ * Returns null for 404 — a facility the registry does not know is a normal outcome the caller
+ * reports, not an exception. Any other failure throws, because "the registry is down" and "there
+ * is no such facility" must not look the same to the caller.
+ */
+export async function fetchRegistryVenue(facilityId: string, signal?: AbortSignal): Promise<RegistryVenue | null> {
+  const res = await fetch(`${getAmsBaseUrl()}/facilities/${encodeURIComponent(facilityId)}/venue`, {
+    headers: authHeaders(),
+    signal,
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`facility venue fetch failed (${res.status})`);
+  return (await res.json()) as RegistryVenue;
+}


### PR DESCRIPTION
WS2 of planning/FACILITIES_VENUES_COURTS_MAPS_SCAFFOLD.md. Search the registry, pick a
facility, see its map and courts, add it — instead of retyping a club that is already
known.

Why it matters beyond saving typing: the hand-entry form mints a venueId and courtIds
local to this tournament, so the same physical club entered at two tournaments becomes two
unrelated venues. A registry venue arrives carrying its canonical facilityId and court
ids, which is what makes "every tournament at this facility" a SQL join rather than a
fuzzy name match, and what lets a court closure logged once reach every tournament there.

Route: TMX reads through courthive-ams, not CFS. A proxied read on the mutation server
would couple scorekeeper acknowledgement latency to an unrelated service (decision
2026-08-11). Transport needed nothing new — AMS dual-accepts CFS's ES256 tokens and
verifies only, so the admin JWT TMX already holds is valid there. The AMS side of this is
courthive-ams#118, which exposes GET /facilities/:facilityId/venue and opens search to any
authenticated user; a TMX tournament director carries no AMS role and would otherwise have
been 403'd by the console's gate.

facilitiesApi follows the declarationsApi shape (VITE_AMS_URL with a localhost-aware
fallback) rather than inventing a second config convention. Queries shorter than the
registry's 2-character minimum are answered locally: the registry 400s them, and firing a
request per keystroke that can only fail would surface the user's first character as a
server error. Searches abort the previous request so a slow early keystroke cannot resolve
after a faster later one and repaint stale candidates.

The picker replaces the External Lookup stub in the Add Venue drawer, whose handler was a
console.log behind a TODO. That stub was gated on provider.facilityService &&
provider.facilityLookup — two fields for a third-party lookup that was never built, so
there is no behaviour to preserve and keeping the gate would only hide the capability that
now exists. It is offered to any signed-in user instead: signed out there is no token to
search with, so the button would only 401.

Preview uses the shipped buildVenueLocator, which renders the venue on Leaflet with its
courts listed beside it and degrades to header-plus-list when a facility has no
coordinates — so there is no separate no-geo branch here to keep in step. Verified in both
themes; the map swaps to CARTO Dark Matter under dark.

The chosen venue is dispatched as a single addVenue through mutationRequest. factory's
addVenue pushes the venue whole, courts included, so there is no companion addCourts and
no translation step between the registry's TODS shape and the factory's.

Journey 92 covers the flow with the AMS passthrough stubbed at the network layer: canonical
ids survive into the record, a sole result is still only a candidate and never
auto-selects, a sub-minimum query never reaches the network, and a facility whose venue is
missing reports it rather than failing silently. The registry's own behaviour is covered in
courthive-facilities and AMS's passthrough in its controller spec; what was untested until
now is TMX's half.