### PR TITLE
fix(e2e): seed the local calendar day, not the UTC one

### DIFF
--- a/e2e/helpers/dates.ts
+++ b/e2e/helpers/dates.ts
@@ -1,0 +1,38 @@
+/**
+ * Calendar-day helpers for seeding e2e fixtures.
+ *
+ * Why this exists: `new Date().toISOString().slice(0, 10)` is the **UTC** calendar day, and TMX's
+ * scheduling surfaces render and filter by the **local** one. The two disagree for part of every
+ * day — after ~20:00 in a UTC−4 zone, or before ~10:00 UTC in a far-eastern one — and in that
+ * window a spec seeds a schedule onto a day the grid is not showing. The grid renders perfectly
+ * and reports "Scheduled 0", so the spec times out waiting for a cell that was never going to
+ * appear, and the failure looks like a broken drag-and-drop rather than a calendar bug.
+ *
+ * That cost an hour of bisecting on 2026-08-13 (stash, checkout, dev-server restart, sibling-build
+ * check) before the clock turned out to be the variable. Seed days through here instead.
+ *
+ * See Mentat/planning/E2E_SCHEDULE2_UTC_LOCAL_DAY_MISMATCH.md.
+ */
+
+/** Format a Date as `YYYY-MM-DD` in the **local** zone — never via toISOString(). */
+export function toLocalCalendarDay(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Today's calendar day as TMX sees it. Use for any seeded `startDate`, `endDate` or
+ * `scheduledDate` that a spec later expects to find rendered.
+ */
+export function todayLocal(): string {
+  return toLocalCalendarDay(new Date());
+}
+
+/** `todayLocal()` shifted by whole days — negative for the past. */
+export function daysFromTodayLocal(offset: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + offset);
+  return toLocalCalendarDay(date);
+}

--- a/e2e/journeys/24-unified-entries-refresh-bugs.spec.ts
+++ b/e2e/journeys/24-unified-entries-refresh-bugs.spec.ts
@@ -13,6 +13,7 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 import { S } from '../helpers/selectors';
 
@@ -24,11 +25,12 @@ import { S } from '../helpers/selectors';
  * rating columns should appear once entries are added.
  */
 async function seedTournamentWithRatedParticipants(page: any): Promise<string> {
-  return page.evaluate(() => {
+  // `todayLocal()` is computed HERE, in node, and passed in — it is a spec helper and does not
+  // exist inside the browser context page.evaluate runs in.
+  return page.evaluate((startDate: string) => {
     const { mocksEngine, tournamentEngine } = dev.factory;
 
     // Create a bare tournament
-    const startDate = new Date().toISOString().slice(0, 10);
     tournamentEngine.newTournamentRecord({
       tournamentName: 'E2E Ratings Refresh',
       tournamentId: 'e2e-ratings-refresh',
@@ -55,7 +57,7 @@ async function seedTournamentWithRatedParticipants(page: any): Promise<string> {
     const tournament = tournamentEngine.getTournament().tournamentRecord;
     dev.load(tournament);
     return tournament.tournamentId as string;
-  });
+  }, todayLocal());
 }
 
 async function navigateToEntries(page: any, tournamentId: string): Promise<void> {
@@ -68,7 +70,10 @@ async function navigateToEntries(page: any, tournamentId: string): Promise<void>
   await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
 
   // Ensure we're on the Entries tab
-  const entriesVisible = await page.locator(S.ENTRIES_VIEW).isVisible().catch(() => false);
+  const entriesVisible = await page
+    .locator(S.ENTRIES_VIEW)
+    .isVisible()
+    .catch(() => false);
   if (!entriesVisible) {
     await page.locator('#eventTabsBar').getByText('Entries').click();
   }
@@ -222,7 +227,9 @@ test.describe('Journey 24 — Ratings columns, grouping chips, and entry removal
   });
 
   test('24.4 — "Remove from event" button appears for selected entries without draw positions', async ({ page }) => {
-    page.on('console', (msg) => { if (msg.text().includes('CONTROLBAR')) console.log('  [browser]', msg.text()); });
+    page.on('console', (msg) => {
+      if (msg.text().includes('CONTROLBAR')) console.log('  [browser]', msg.text());
+    });
     const tournamentId = await seedTournamentWithRatedParticipants(page);
     await navigateToEntries(page, tournamentId);
 

--- a/e2e/journeys/29-schedule2-active-strip.spec.ts
+++ b/e2e/journeys/29-schedule2-active-strip.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament } from '../helpers/seed';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -23,7 +24,7 @@ const CELL_SELECTOR = '.spl-active-strip-cell';
 const SPACER_LABEL_SELECTOR = '.spl-active-strip-spacer-label';
 const STATE_PILL_SELECTOR = '.spl-active-strip-state-pill';
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const PROFILE_STRIP = {
   tournamentName: 'E2E Active Strip',
@@ -255,18 +256,21 @@ test.describe('Journey 29 — Schedule2 active courts strip', () => {
     // Going through the engine surface (rather than a Playwright drag-drop)
     // keeps this test focused on the data contract: a deliberate drop must
     // stamp `calledAt`, and a generic court assignment (no strip) must not.
-    await page.evaluate(({ matchUpId, drawId, courtId, venueId }) => {
-      dev.factory.tournamentEngine.addMatchUpScheduleItems({
-        matchUpId,
-        drawId,
-        schedule: { scheduledDate: new Date().toISOString().slice(0, 10), courtId, courtOrder: 1, venueId },
-      });
-      dev.factory.tournamentEngine.setMatchUpCalledAt({
-        matchUpId,
-        drawId,
-        calledAt: new Date().toISOString(),
-      });
-    }, setup);
+    await page.evaluate(
+      ({ matchUpId, drawId, courtId, venueId, scheduledDate }) => {
+        dev.factory.tournamentEngine.addMatchUpScheduleItems({
+          matchUpId,
+          drawId,
+          schedule: { scheduledDate, courtId, courtOrder: 1, venueId },
+        });
+        dev.factory.tournamentEngine.setMatchUpCalledAt({
+          matchUpId,
+          drawId,
+          calledAt: new Date().toISOString(),
+        });
+      },
+      { ...setup, scheduledDate: SCHEDULE_DATE },
+    );
 
     // Assert: matchUp.schedule.calledAt is an ISO string >= beforeIso.
     const calledAt = await page.evaluate(({ matchUpId }) => {

--- a/e2e/journeys/38-schedule2-scheduled-panel.spec.ts
+++ b/e2e/journeys/38-schedule2-scheduled-panel.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -27,7 +28,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * `[data-sidebar-panel="scheduled"]`.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const SCHEDULED_PANEL = '[data-sidebar-panel="scheduled"]';
 const SCHEDULED_TAB = 'button[data-sidebar-tab="scheduled"]';
@@ -53,10 +54,7 @@ interface ScheduledSeed {
  * seed helper's fire-and-forget `dev.load` (same gotcha Journey 29's
  * `seedAndScheduleFirstMatchUp` documents).
  */
-async function seedScheduledMatchUps(
-  page: import('@playwright/test').Page,
-  count: number,
-): Promise<ScheduledSeed> {
+async function seedScheduledMatchUps(page: import('@playwright/test').Page, count: number): Promise<ScheduledSeed> {
   return page.evaluate(
     async ({ date, count }) => {
       try {

--- a/e2e/journeys/39-schedule2-round-emphasis.spec.ts
+++ b/e2e/journeys/39-schedule2-round-emphasis.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -25,7 +26,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * courthive-components catalog widget itself.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 const TITLE_SELECTOR = '.spl-matchup-card .sp-card-title, .spl-matchup-card [class^="spl-card-title"]';
 const UNSCHEDULED_TAB = 'button[data-sidebar-tab="unscheduled"]';
 const CURRENT_TITLE = '.spl-card-title--round-current';

--- a/e2e/journeys/41-schedule2-add-venue-refresh.spec.ts
+++ b/e2e/journeys/41-schedule2-add-venue-refresh.spec.ts
@@ -1,5 +1,6 @@
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, MockProfile } from '../helpers/seed';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 import { test, expect } from '@playwright/test';
 
@@ -19,7 +20,7 @@ import { test, expect } from '@playwright/test';
  * and asserts the grid grew a "Court 1" header after submit.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const PROFILE_NO_VENUES: MockProfile = {
   tournamentName: 'E2E Add Venue Refresh',

--- a/e2e/journeys/47-schedule2-completed-orphans.spec.ts
+++ b/e2e/journeys/47-schedule2-completed-orphans.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -29,7 +30,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  *     already excluded BYEs; the date selector now matches.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const SCHEDULED_PANEL = '[data-sidebar-panel="scheduled"]';
 const SCHEDULED_TAB = 'button[data-sidebar-tab="scheduled"]';
@@ -56,9 +57,7 @@ interface OrphanSeed {
  * resulting state is the exact shape Battle-of-Boca was in after the
  * upstream sync wiped court coordinates while preserving date/time.
  */
-async function seedOrphansWithCompletedMix(
-  page: import('@playwright/test').Page,
-): Promise<OrphanSeed> {
+async function seedOrphansWithCompletedMix(page: import('@playwright/test').Page): Promise<OrphanSeed> {
   return page.evaluate(
     async ({ date }) => {
       try {
@@ -148,9 +147,7 @@ async function seedNoOrphans(page: import('@playwright/test').Page): Promise<{ t
             endDate: date,
           },
           participantsProfile: { scaledParticipantsCount: 16 },
-          drawProfiles: [
-            { eventName: 'Singles', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' },
-          ],
+          drawProfiles: [{ eventName: 'Singles', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' }],
           venueProfiles: [{ courtsCount: 2, venueName: 'Empty Venue' }],
         });
         await dev.tmx2db.addTournament(tournamentRecord);

--- a/e2e/journeys/48-schedule2-score-entry-refresh.spec.ts
+++ b/e2e/journeys/48-schedule2-score-entry-refresh.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -23,7 +24,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * entered score — failing if the cache is served stale.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 const SCORE_STRING = '6-2 6-3';
 
 interface ScoreSeed {
@@ -53,9 +54,7 @@ async function seedCourtScheduledMatchUp(page: import('@playwright/test').Page):
             startDate: date,
             endDate: date,
           },
-          drawProfiles: [
-            { eventName: 'Singles', drawSize: 4, drawType: 'SINGLE_ELIMINATION' },
-          ],
+          drawProfiles: [{ eventName: 'Singles', drawSize: 4, drawType: 'SINGLE_ELIMINATION' }],
           venueProfiles: [{ courtsCount: 2, venueName: 'Score Venue' }],
         });
 
@@ -173,8 +172,8 @@ test.describe('Journey 48 — Schedule2 score entry refreshes the grid cell', ()
 
     // The grid cell must now show the entered score. Before the cache fix
     // this stayed empty because refreshGridView read the stale matchUp cache.
-    await expect(page.locator(`[data-matchup-id="${seed.matchUpId}"]`).first().locator('.spl-grid-cell__score')).toHaveText(
-      SCORE_STRING,
-    );
+    await expect(
+      page.locator(`[data-matchup-id="${seed.matchUpId}"]`).first().locator('.spl-grid-cell__score'),
+    ).toHaveText(SCORE_STRING);
   });
 });

--- a/e2e/journeys/49-schedule2-grid-swap.spec.ts
+++ b/e2e/journeys/49-schedule2-grid-swap.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -21,7 +22,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * journey covers the live DOM → handler → engine path.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP_SELECTOR = '.spl-active-strip';
 const STRIP_CELL = '.spl-active-strip-cell';
 

--- a/e2e/journeys/50-schedule2-court-time-order.spec.ts
+++ b/e2e/journeys/50-schedule2-court-time-order.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -18,7 +19,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * The pure detector has dedicated unit coverage in courtTimeOrderIssues.test.ts.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP_SELECTOR = '.spl-active-strip';
 const ISSUES_BUTTON = 'button:has(i.fa-triangle-exclamation)';
 

--- a/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
+++ b/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -20,7 +21,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * specifically about the Now-strip path preserving the planned time.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP_SELECTOR = '.spl-active-strip';
 const STRIP_CELL = '.spl-active-strip-cell';
 

--- a/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
+++ b/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 import { S } from '../helpers/selectors';
 
@@ -17,7 +18,7 @@ import { S } from '../helpers/selectors';
  * (added by highlightMatchUp, removed after 4s).
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP_SELECTOR = '.spl-active-strip';
 
 /** Seed a tournament and place its first playable matchUp on court0/order1 in a

--- a/e2e/journeys/59-schedule2-date-badge-recompute.spec.ts
+++ b/e2e/journeys/59-schedule2-date-badge-recompute.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -23,7 +24,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * asserting the chip goes 1 → 2 → 1.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 interface BadgeSeed {
   tournamentId: string;
@@ -107,23 +108,20 @@ async function scheduleThroughMutationRequest(
   page: import('@playwright/test').Page,
   params: { matchUpId: string; drawId: string; schedule: Record<string, any> },
 ): Promise<void> {
-  await page.evaluate(
-    async ({ matchUpId, drawId, schedule }) => {
-      await new Promise<void>((resolve) => {
-        dev.mutationRequest({
-          methods: [
-            { method: 'addMatchUpScheduleItems', params: { matchUpId, drawId, schedule, removePriorValues: true } },
-          ],
-          callback: () => {
-            // Mirror the drop callback: refresh the active surface (wired to refreshGridView).
-            dev.tournamentContext.refreshActiveTable?.();
-            resolve();
-          },
-        });
+  await page.evaluate(async ({ matchUpId, drawId, schedule }) => {
+    await new Promise<void>((resolve) => {
+      dev.mutationRequest({
+        methods: [
+          { method: 'addMatchUpScheduleItems', params: { matchUpId, drawId, schedule, removePriorValues: true } },
+        ],
+        callback: () => {
+          // Mirror the drop callback: refresh the active surface (wired to refreshGridView).
+          dev.tournamentContext.refreshActiveTable?.();
+          resolve();
+        },
       });
-    },
-    params,
-  );
+    });
+  }, params);
 }
 
 test.describe('Journey 59 — Schedule2 date badge recomputes on schedule / unschedule', () => {

--- a/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
+++ b/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -18,7 +19,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * stay stable across the grid's post-drop re-render.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP = '.spl-active-strip';
 const SAVE = '.sp-btn--success';
 const DISCARD = '.sp-btn--danger';

--- a/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
+++ b/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, loginAsProviderMember, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -22,7 +23,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * pass for the wrong reason.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP = '.spl-active-strip';
 const PROVIDER_ID = 'e2e-provider-1';
 

--- a/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
+++ b/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -14,7 +15,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * matchUpIds carried by the dispatched mutation + the resulting schedule state.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP = '.spl-active-strip';
 const CLEAR_BTN = 'button:has(i.fa-eraser)';
 

--- a/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
+++ b/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -19,7 +20,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * it exercises the no-teardown path the observer specifically covers.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const BADGE = 'button:has(i.fa-calendar-days) span';
 
 /** Seed a tournament with a 2-court venue and `scheduledCount` R1 matchUps placed on today. */

--- a/e2e/journeys/77-schedule-resolve-conflicts.spec.ts
+++ b/e2e/journeys/77-schedule-resolve-conflicts.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -24,7 +25,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * proColumnResolve test.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const STRIP_SELECTOR = '.spl-active-strip';
 const RESOLVE_BUTTON = 'button:has(i.fa-arrows-down-to-line)';
 const CONFLICT_TYPES = ['participantConflict', 'potentialParticipantConflict'];

--- a/e2e/journeys/78-schedule-footer-publish-toggle.spec.ts
+++ b/e2e/journeys/78-schedule-footer-publish-toggle.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -29,7 +30,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * introduced — Playwright is this ecosystem's single DOM test layer.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const PUBLISH_PILL = 'button.spl-publish-pill';
 const PUBLISH_PILL_ON = 'button.spl-publish-pill.spl-publish-pill--on';

--- a/e2e/journeys/80-schedule-apply-times-attached-policy.spec.ts
+++ b/e2e/journeys/80-schedule-apply-times-attached-policy.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -19,7 +20,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * DOM test layer.
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const PROFILE_MODE = 'button[title="Profile"]';
 const APPLY_TIMES_BTN = 'button[title^="Apply Times —"]';

--- a/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
+++ b/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady, seedSuperAdminTokenInitScript } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -15,7 +16,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * the stubbed peer occupies court-order 2 — which must show as a reserved, non-draggable cell.
  */
 
-const DATE = new Date().toISOString().slice(0, 10);
+const DATE = todayLocal();
 const ID = 'e2e-reserved-primary';
 const PEER = 'e2e-reserved-peer';
 
@@ -41,7 +42,13 @@ async function seedPrimary(page: Page): Promise<{ courtId: string; venueId: stri
       dev.factory.tournamentEngine.addMatchUpScheduleItems({
         matchUpId: mu.matchUpId,
         drawId: mu.drawId,
-        schedule: { scheduledDate: date, scheduledTime: '10:00', venueId: court.venueId, courtId: court.courtId, courtOrder: 1 },
+        schedule: {
+          scheduledDate: date,
+          scheduledTime: '10:00',
+          venueId: court.venueId,
+          courtId: court.courtId,
+          courtOrder: 1,
+        },
       });
       const rec = dev.factory.tournamentEngine.getTournament().tournamentRecord;
       rec.linkedTournamentIds = [id, peer]; // links drive which peers the projection is requested for
@@ -128,7 +135,15 @@ test.describe('Journey 86 — shared-facility reserved cells', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           scheduleCells: [
-            { tournamentId: PEER, access: 'view', courtId, venueId, courtOrder: peerOrder, scheduledDate: DATE, scheduledTime: peerTime },
+            {
+              tournamentId: PEER,
+              access: 'view',
+              courtId,
+              venueId,
+              courtOrder: peerOrder,
+              scheduledDate: DATE,
+              scheduledTime: peerTime,
+            },
           ],
         }),
       });

--- a/e2e/journeys/90-plan-mode-scenarios.spec.ts
+++ b/e2e/journeys/90-plan-mode-scenarios.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady, seedFeatureFlagInitScript } from '../helpers/dev-bridge';
 import { seedTournament } from '../helpers/seed';
+import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';
 
 /**
@@ -19,7 +20,7 @@ import { TournamentPage } from '../pages/TournamentPage';
  * local-only (no provider seeded).
  */
 
-const SCHEDULE_DATE = new Date().toISOString().slice(0, 10);
+const SCHEDULE_DATE = todayLocal();
 
 const PROFILE_PLAN = {
   tournamentName: 'E2E Plan Mode',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,6 +99,19 @@ export default [
     rules: {
       'sonarjs/no-duplicate-string': 'off',
       '@typescript-eslint/no-empty-function': 'off',
+      // `toISOString().slice(0, 10)` is the UTC calendar day; TMX's scheduling surfaces render
+      // and filter by the LOCAL one. A spec seeding the UTC day silently targets a day the grid
+      // is not showing whenever the two differ, and the resulting timeout looks like a broken
+      // drag-and-drop rather than a calendar bug. 21 specs had this before it was caught.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.property.name='slice'][callee.object.callee.property.name='toISOString']",
+          message:
+            'Seed calendar days with todayLocal() from e2e/helpers/dates — toISOString() is UTC, but TMX renders the local day. See Mentat/planning/E2E_SCHEDULE2_UTC_LOCAL_DAY_MISMATCH.md',
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
21 specs derived their tournament day from `new Date().toISOString().slice(0, 10)`, which
is the UTC calendar day. TMX's scheduling surfaces render and filter by the LOCAL day. The
two disagree for part of every day — after ~20:00 in a UTC-4 zone, or before ~10:00 UTC in
a far-eastern one — and in that window a spec seeds a schedule onto a day the grid is not
showing.

The failure is badly disguised. The grid renders correctly and reports "Scheduled 0", so
every affected spec times out waiting for a
`[data-court-id][data-court-order][data-matchup-id]` cell that was never going to appear,
and it reads as broken drag-and-drop rather than a calendar bug. Journeys 29, 38, 47, 48
and 49 were observed failing this way; the grep found the same pattern in 21 specs, so the
rest had simply never been run in the window.

`todayLocal()` in e2e/helpers/dates.ts replaces every one. It formats from getFullYear /
getMonth / getDate rather than round-tripping through UTC. `daysFromTodayLocal()` is there
for the same reason the next spec will need it.

A no-restricted-syntax rule now rejects `toISOString().slice(...)` anywhere under e2e/ with
a message pointing at the helper. Without it this comes straight back — the pattern is the
obvious thing to type and passes review because it looks timezone-neutral.

Two of the 21 call sites were inside `page.evaluate` callbacks, which run in the browser
where a node-side spec helper does not exist. Those now compute the day in node and pass
it through as an argument. Worth noting that `tsc` accepted the broken version: it cannot
see that page.evaluate runs in another realm, so only executing the specs catches it.

Reproduction is deterministic rather than a wait for the clock: pick a timezone whose
local day differs from UTC at the current hour — `Pacific/Kiritimati` (UTC+14) when the
UTC hour is >= 10, `Pacific/Honolulu` (UTC-10) when it is < 10. Verified journey 49 at
9 failed before and 9 passed after under an identical `TZ=Pacific/Kiritimati`, and the
full suite at 332 passed / 1 skipped / 0 failed in that same window, in TZ=UTC, and in the
machine's own zone.

Chosen over pinning TZ=UTC for playwright (as package.json does for vitest): pinning buys
determinism by no longer exercising the local-day behaviour that broke, and TMX's grid is
explicitly local-day.

Analysis in Mentat/planning/E2E_SCHEDULE2_UTC_LOCAL_DAY_MISMATCH.md.