### PR TITLE
chore(vitest): exclude .claude worktrees from test discovery

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -77,7 +77,10 @@ const viteconfigFactory = ({ mode }: { mode: string }) => {
     },
     base: BASE_URL,
     test: {
-      exclude: ['e2e/**', 'node_modules/**'],
+      // '.claude/**' keeps a git worktree checked out under .claude/worktrees/ from being
+      // discovered as a second copy of the entire suite — Vitest's default `include` globs
+      // from the project root, and its default `exclude` does not cover .claude.
+      exclude: ['e2e/**', 'node_modules/**', '**/.claude/**'],
       // Quiet the suite: many error-path tests deliberately trigger a caught
       // error whose handler logs via console.error/warn (e.g. "[localCalendar]
       // failed to maintain entry"). Those are asserted on behaviorally, so the


### PR DESCRIPTION
## Problem

Test discovery globs from the project root with no exclusion for `.claude/`, so a git worktree checked out
under `.claude/worktrees/` is picked up as a **second copy of the entire suite**. Vitest's default `include`
is root-anchored, and its default `exclude` covers `node_modules` and `dist` but not `.claude`.

This is not hypothetical — the same gap broke `tods-competition-factory`, where a worktree turned
`pnpm test:server` into 18 suites where there should have been 9, and the duplicate copies resolved into two
instances of the same module (`TypeError: engineAsync.importMethods is not a function`). Fixed there in
CourtHive/competition-factory#4604 and, for the Jest services, across the ecosystem.

Sibling repos that were already safe — courthive-components, courthive-public, courthive-arena,
courthive-ingest, pdf-factory, provider-config — are safe because they anchor `include` at `src/**`. This repo
did not.

Verified by probe rather than by reading the config: a throwaway spec was written to
`.claude/worktrees/__probe__/`, `vitest list` was asked whether it appeared, and it did.

## Change

One entry added to `test.exclude` in `vite.config.ts`, with a comment recording why so it is not tidied away.

## Verification

`vitest list` with a probe spec present under `.claude/worktrees/`:

```
probe listed: 0     (was 1 before this change)
files listed: 105   (unchanged)
tests listed: 1033  (unchanged)
```

Unit discovery is unchanged and the Playwright suite is untouched — `e2e/playwright.config.ts` pins
`testDir: './journeys'` and was never exposed.
