### PR TITLE
feat(participants): inline competitive fingerprint on the participant card

### DIFF
--- a/e2e/journeys/93-participant-competitive-fingerprint.spec.ts
+++ b/e2e/journeys/93-participant-competitive-fingerprint.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * The participant profile modal's inline competitive fingerprint (§6.2 of
+ * Mentat/planning/COMPETITIVE_FINGERPRINT.md).
+ *
+ * This lives in e2e rather than vitest because the block is DOM, and TMX's
+ * vitest runs in node with no DOM. It also guards the one thing the unit tests
+ * structurally CANNOT: that the engine call hydrates ratings onto the matchUp
+ * side participants. `withScaleValues` nested inside `contextProfile` returns
+ * `ratings: {}`, the exposure axis silently finds nothing to band, and the bar
+ * quietly disappears — no error anywhere. The unit tests hand `fingerprintData`
+ * its matchUps, so only a real render catches that regression.
+ */
+import { initDevBridge, waitForAppReady } from '../helpers/dev-bridge';
+import { TournamentPage } from '../pages/TournamentPage';
+import { seedTournament } from '../helpers/seed';
+import { test, expect } from '@playwright/test';
+import { S } from '../helpers/selectors';
+
+const FINGERPRINT = '.tmx-fp';
+const SEGMENTS = `${FINGERPRINT} .chc-sb__seg`;
+
+test.describe('participant competitive fingerprint', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+  });
+
+  test('bands the participant against WTN-rated opponents', async ({ page }) => {
+    // Round robin so one participant plays several opponents; WTN so the signed
+    // exposure axis has a scale the factory can orient.
+    const tournamentId = await seedTournament(page, {
+      drawProfiles: [
+        { drawSize: 8, drawType: 'ROUND_ROBIN', category: { ratingType: 'WTN' }, completionGoal: 28 } as any,
+      ],
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToParticipants();
+
+    const rows = page.locator(`${S.TOURNAMENT_PARTICIPANTS} .tabulator-row`);
+    await expect(rows.first()).toBeVisible({ timeout: 20_000 });
+    await rows
+      .first()
+      .getByText(/[A-Za-z]+ [A-Za-z]+/)
+      .first()
+      .click();
+
+    const fingerprint = page.locator(FINGERPRINT);
+    await expect(fingerprint).toBeVisible({ timeout: 10_000 });
+
+    // Five segments, because the default policy declares five bands — the bar
+    // reads its vocabulary from policy, not from a hardcoded list.
+    await expect(page.locator(SEGMENTS)).toHaveCount(5);
+
+    const report = await fingerprint.evaluate((el) => {
+      const segs = [...el.querySelectorAll('.chc-sb__seg')] as HTMLElement[];
+      return {
+        text: el.textContent ?? '',
+        keys: segs.map((s) => s.dataset.key),
+        counts: segs.map((s) => Number(s.textContent || 0)),
+        // Every fill must resolve — an unset custom property would render
+        // transparent and the bar would look empty rather than broken.
+        backgrounds: segs.map((s) => getComputedStyle(s).backgroundColor),
+      };
+    });
+
+    expect(report.keys).toEqual(['STRETCH', 'UP', 'EVEN', 'DOWN', 'ANCHOR']);
+    expect(report.backgrounds.every((bg) => bg && bg !== 'rgba(0, 0, 0, 0)')).toEqual(true);
+
+    // The exposure axis actually resolved: at least one opponent was rated, and
+    // the counts add up to the rated total stated in the coverage line.
+    const rated = Number(/(\d+) rated on WTN/.exec(report.text)?.[1] ?? 0);
+    expect(rated).toBeGreaterThan(0);
+    expect(report.counts.reduce((a, b) => a + b, 0)).toEqual(rated);
+
+    // Coverage names the scale, so the bar is never a shape without provenance.
+    expect(report.text).toContain('WTN');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.22.1",
+    "tods-competition-factory": "6.23.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }

--- a/src/components/modals/participant-fingerprint.css
+++ b/src/components/modals/participant-fingerprint.css
@@ -1,0 +1,121 @@
+/* Inline competitive fingerprint (participant profile modal).
+ *
+ * The five band colours are a DIVERGING ramp — cool pole = played down, neutral
+ * grey = even, warm pole = played up — deliberately not good/bad hues, because
+ * the axis's whole claim is that a healthy diet contains up, even AND down.
+ *
+ * Derived with the dataviz palette validator rather than by eye. Both modes are
+ * SELECTED (each stepped for its own surface), not an automatic flip:
+ *
+ *   light (surface #fcfcfb)  worst adjacent CVD ΔE 18.4, normal-vision 18.4
+ *                            contrast: all ≥ 3:1 except --tmx-fp-down at 2.91,
+ *                            which is relieved by the count label rendered
+ *                            inside every segment plus the legend below it.
+ *   dark  (surface #1a1a19)  worst adjacent CVD ΔE 18.3, normal-vision 19.2
+ *                            contrast: all five ≥ 3:1.
+ *
+ * Two validator FAILs are by design and must not be "fixed": the chroma floor
+ * flags the neutral grey midpoint (a diverging ramp requires a hueless middle),
+ * and the lightness band flags steps that deliberately span light↔dark so the
+ * arms stay distinguishable.
+ */
+
+.tmx-fp {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0.75rem 0 0.25rem;
+
+  --tmx-fp-anchor: #184f95;
+  --tmx-fp-down: #5598e7;
+  --tmx-fp-even: #4b5563;
+  --tmx-fp-up: #eb6834;
+  --tmx-fp-stretch: #a92e1c;
+  --tmx-fp-other: var(--chc-text-muted, #6b7280);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme='light'])) .tmx-fp {
+    --tmx-fp-anchor: #256abf;
+    --tmx-fp-down: #6da7ec;
+    --tmx-fp-even: #6b7280;
+    --tmx-fp-up: #eda100;
+    --tmx-fp-stretch: #c2410c;
+  }
+}
+
+:root[data-theme='dark'] .tmx-fp {
+  --tmx-fp-anchor: #256abf;
+  --tmx-fp-down: #6da7ec;
+  --tmx-fp-even: #6b7280;
+  --tmx-fp-up: #eda100;
+  --tmx-fp-stretch: #c2410c;
+}
+
+.tmx-fp__heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--chc-text-muted, #6b7280);
+}
+
+.tmx-fp__realized {
+  font-size: 0.85rem;
+  color: var(--chc-text-primary, #1f2937);
+}
+
+/* 2px surface gap between stacked fills, per the mark spec — the segments must
+ * not touch, or two adjacent bands read as one. */
+.tmx-fp__bar {
+  gap: 2px;
+  border-radius: 4px;
+  min-height: 1.25rem;
+}
+
+/* The segmented bar prints its count in white on every fill, which fails on the
+ * two light steps. Measured against #ffffff vs #1f2937:
+ *
+ *            light            dark
+ *   DOWN     2.99 / 4.92      2.50 / 5.86
+ *   UP       3.20 / 4.59      2.17 / 6.78
+ *
+ * so those two carry dark ink and the rest keep white (all ≥ 4.83 on white).
+ * Found by rendering the bar and reading it, not by the palette validator —
+ * label-on-fill contrast is a separate question from fill-on-surface. */
+.tmx-fp__bar .chc-sb__seg[data-key='DOWN'],
+.tmx-fp__bar .chc-sb__seg[data-key='UP'] {
+  color: #1f2937;
+}
+
+.tmx-fp__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  font-size: 0.7rem;
+  color: var(--chc-text-secondary, #52514e);
+}
+
+.tmx-fp__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+/* A band with no matches stays listed — its absence is information (43.9% of
+ * ITA players have zero stretch matches) — but recedes. */
+.tmx-fp__legend-item.is-empty {
+  opacity: 0.45;
+}
+
+.tmx-fp__swatch {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 2px;
+  flex: 0 0 auto;
+}
+
+.tmx-fp__coverage {
+  font-size: 0.7rem;
+  color: var(--chc-text-muted, #6b7280);
+}

--- a/src/components/modals/participantFingerprint.test.ts
+++ b/src/components/modals/participantFingerprint.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The engine is only reached by the DOM shell; the pure core is handed its
+// matchUps. Mocked so importing the module does not pull in engine state.
+vi.mock('services/factory/engine', () => ({ tournamentEngine: { getParticipants: () => ({ matchUps: [] }) } }));
+vi.mock('i18n', () => ({ t: (key: string) => key }));
+vi.mock('courthive-components', () => ({ buildSegmentedBar: () => ({ element: {}, update: () => {} }) }));
+
+import { fingerprintData, displayBandKeys, resolveScaleName } from './participantFingerprint';
+import { fixtures } from 'tods-competition-factory';
+
+const { POLICY_COMPETITIVE_BANDS_DEFAULT } = fixtures.policies;
+
+// WTN: range [40, 1] so magnitude 39, ascending (LOWER is stronger). The default
+// policy's maxPct boundaries therefore resolve to +/-0.507 and +/-4.017.
+const wtn = (participantId: string, wtnRating?: number) => ({
+  participantId,
+  ...(wtnRating === undefined ? {} : { ratings: { SINGLES: [{ scaleName: 'WTN', scaleValue: { wtnRating } }] } }),
+});
+
+const matchUp = ({ own = 20, opp, winningSide, sets }: any) => ({
+  matchUpType: 'SINGLES',
+  ...(winningSide ? { winningSide } : {}),
+  score: { sets },
+  sides: [
+    { sideNumber: 1, participant: wtn('p1', own) },
+    { sideNumber: 2, participant: wtn(`o-${opp ?? 'x'}`, opp) },
+  ],
+});
+
+const DECISIVE_SETS = [
+  { side1Score: 6, side2Score: 0 },
+  { side1Score: 6, side2Score: 0 },
+];
+const COMPETITIVE_SETS = [
+  { side1Score: 6, side2Score: 4 },
+  { side1Score: 6, side2Score: 3 },
+];
+
+describe('resolveScaleName', () => {
+  it('picks a scale the factory can orient', () => {
+    expect(resolveScaleName(wtn('p1', 20))).toEqual('WTN');
+  });
+
+  it('skips a scale absent from ratingsParameters rather than guessing orientation', () => {
+    const participant = {
+      participantId: 'p1',
+      ratings: { SINGLES: [{ scaleName: 'HOUSE_LADDER', scaleValue: 10 }] },
+    };
+    expect(resolveScaleName(participant)).toBeUndefined();
+  });
+
+  it('returns undefined when the participant carries no ratings', () => {
+    expect(resolveScaleName(wtn('p1'))).toBeUndefined();
+    expect(resolveScaleName(undefined)).toBeUndefined();
+  });
+});
+
+describe('displayBandKeys', () => {
+  it('reads the five default keys, widest stretch first', () => {
+    expect(displayBandKeys(POLICY_COMPETITIVE_BANDS_DEFAULT)).toEqual(['STRETCH', 'UP', 'EVEN', 'DOWN', 'ANCHOR']);
+  });
+
+  it('follows a policy that declares a different vocabulary and count', () => {
+    const custom = {
+      competitiveBands: {
+        deltaBands: [{ key: 'EASIER', max: -2 }, { key: 'LEVEL', max: 2 }, { key: 'HARDER' }],
+      },
+    };
+    // Band count and names come from policy — nothing here is hardcoded.
+    expect(displayBandKeys(custom)).toEqual(['HARDER', 'LEVEL', 'EASIER']);
+  });
+
+  it('returns nothing when a policy declares no deltaBands', () => {
+    expect(displayBandKeys({ competitiveBands: { profileBands: { DECISIVE: 20, ROUTINE: 50 } } })).toEqual([]);
+  });
+});
+
+describe('fingerprintData', () => {
+  const participant = wtn('p1', 20);
+
+  it('bands both axes with exact counts', () => {
+    const matchUps = [
+      matchUp({ opp: 25, winningSide: 1, sets: DECISIVE_SETS }), // -5 => ANCHOR
+      matchUp({ opp: 20, winningSide: 1, sets: COMPETITIVE_SETS }), // 0 => EVEN
+      matchUp({ opp: 15, winningSide: 2, sets: COMPETITIVE_SETS }), // +5 => STRETCH
+    ];
+
+    const data: any = fingerprintData({ participantId: 'p1', participant, matchUps });
+
+    expect(data.scaleName).toEqual('WTN');
+    expect(data.exposure.counts).toEqual({ ANCHOR: 1, DOWN: 0, EVEN: 1, UP: 0, STRETCH: 1 });
+    expect(data.exposure.rated).toEqual(3);
+    expect(data.exposure.unrated).toEqual(0);
+    // 6-0 6-0 is a 0% spread; 6-4 6-3 is 58%.
+    expect(data.realized.counts).toEqual({ DECISIVE: 1, ROUTINE: 0, COMPETITIVE: 2 });
+    expect(data.realized.completed).toEqual(3);
+    expect(data.realized.ratios.COMPETITIVE).toBeCloseTo(66.67, 1);
+  });
+
+  it('counts an unrated opponent as unrated rather than banding it', () => {
+    const matchUps = [
+      matchUp({ opp: 25, winningSide: 1, sets: DECISIVE_SETS }),
+      matchUp({ opp: undefined, winningSide: 1, sets: DECISIVE_SETS }),
+    ];
+
+    const data: any = fingerprintData({ participantId: 'p1', participant, matchUps });
+
+    expect(data.exposure.rated).toEqual(1);
+    expect(data.exposure.unrated).toEqual(1);
+    // Both matches still count on the realized axis — a score needs no rating.
+    expect(data.realized.completed).toEqual(2);
+  });
+
+  it('reports no bands when the policy declares no deltaBands, without inventing a default', () => {
+    const data: any = fingerprintData({
+      policyDefinitions: { competitiveBands: { profileBands: { DECISIVE: 20, ROUTINE: 50 } } },
+      matchUps: [matchUp({ opp: 25, winningSide: 1, sets: DECISIVE_SETS })],
+      participantId: 'p1',
+      participant,
+    });
+
+    expect(data.exposure.deltaBandsApplied).toEqual(false);
+    expect(data.exposure.counts).toEqual({});
+    expect(data.bandKeys).toEqual([]);
+    // The delta axis still resolved — only the labelling was withheld.
+    expect(data.exposure.rated).toEqual(1);
+  });
+
+  it('still returns the realized axis when no rating scale resolves', () => {
+    const unrated = wtn('p1');
+    const data: any = fingerprintData({
+      matchUps: [matchUp({ own: undefined, opp: undefined, winningSide: 1, sets: COMPETITIVE_SETS })],
+      participantId: 'p1',
+      participant: unrated,
+    });
+
+    expect(data.scaleName).toBeUndefined();
+    expect(data.exposure.rated).toEqual(0);
+    expect(data.realized.counts.COMPETITIVE).toEqual(1);
+  });
+
+  it('returns undefined when there are no matchUps at all', () => {
+    expect(fingerprintData({ participantId: 'p1', participant, matchUps: [] })).toBeUndefined();
+  });
+
+  it('returns undefined when nothing is played and nothing is rated', () => {
+    const scheduled = {
+      matchUpType: 'SINGLES',
+      score: { sets: [] },
+      sides: [
+        { sideNumber: 1, participant: wtn('p1') },
+        { sideNumber: 2, participant: wtn('o1') },
+      ],
+    };
+    expect(fingerprintData({ participantId: 'p1', participant: wtn('p1'), matchUps: [scheduled] })).toBeUndefined();
+  });
+
+  it('renders nothing rather than a wrong bar when the policy is invalid', () => {
+    const broken = { competitiveBands: { deltaBands: [{ key: 'A', max: 1, maxPct: 10 }, { key: 'B' }] } };
+    const data = fingerprintData({
+      matchUps: [matchUp({ opp: 25, winningSide: 1, sets: DECISIVE_SETS })],
+      policyDefinitions: broken,
+      participantId: 'p1',
+      participant,
+    });
+    expect(data).toBeUndefined();
+  });
+
+  it('inverts with perspective — the same matchUp reads opposite for the opponent', () => {
+    const matchUps = [matchUp({ opp: 25, winningSide: 1, sets: DECISIVE_SETS })];
+
+    const own: any = fingerprintData({ participantId: 'p1', participant, matchUps });
+    const opponent: any = fingerprintData({
+      participant: wtn('o-25', 25),
+      participantId: 'o-25',
+      matchUps,
+    });
+
+    expect(own.exposure.counts.ANCHOR).toEqual(1);
+    expect(opponent.exposure.counts.STRETCH).toEqual(1);
+  });
+});

--- a/src/components/modals/participantFingerprint.ts
+++ b/src/components/modals/participantFingerprint.ts
@@ -1,0 +1,230 @@
+/**
+ * Inline competitive fingerprint for the participant profile modal — §6.2 of
+ * Mentat/planning/COMPETITIVE_FINGERPRINT.md.
+ *
+ * Two orthogonal axes, both computed LOCALLY by the factory from the matchUps
+ * already in memory: no network, no identity, works offline.
+ *
+ *   REALIZED   how close the matches actually were (score spread, unsigned).
+ *   EXPOSURE   who they were drawn against (signed rating delta) — the
+ *              five-segment bar. Needs a rating on both sides, so it appears
+ *              only when one resolves.
+ *
+ * Deliberately NOT here: the cross-tournament "Competitive journey" link-out.
+ * That needs the HiveID hop of §6.1, which does not exist yet, and the standard
+ * is never to render a dead link.
+ *
+ * Coverage is always stated. A bar drawn from four rated matchUps out of eleven
+ * would otherwise imply a completeness it does not have.
+ */
+import { fixtures, matchUpGovernor, factoryConstants } from 'tods-competition-factory';
+import { tournamentEngine } from 'services/factory/engine';
+import { buildSegmentedBar } from 'courthive-components';
+import { t } from 'i18n';
+
+import './participant-fingerprint.css';
+
+const { POLICY_COMPETITIVE_BANDS_DEFAULT } = fixtures.policies;
+const { getCompetitiveProfile } = matchUpGovernor;
+const { SINGLES } = factoryConstants.eventConstants;
+const { ratingsParameters } = fixtures;
+
+const POLICY_TYPE = 'competitiveBands';
+const COVERAGE_CLASS = 'tmx-fp__coverage';
+
+/**
+ * Band → CSS custom property. Only the DEFAULT vocabulary is mapped: band count
+ * and names come from policy, so a federation shipping three bands or its own
+ * names still renders — unmapped keys fall back to a neutral swatch rather than
+ * silently borrowing another band's colour.
+ *
+ * Colours are a diverging ramp (cool = played down, neutral = even, warm =
+ * played up) rather than good/bad hues: the whole point of the axis is that a
+ * healthy diet contains up, even AND down, so ANCHOR must not read as failure.
+ * Derived with the dataviz palette validator, not by eye — see the CSS.
+ */
+const BAND_VARS: Record<string, string> = {
+  ANCHOR: '--tmx-fp-anchor',
+  DOWN: '--tmx-fp-down',
+  EVEN: '--tmx-fp-even',
+  UP: '--tmx-fp-up',
+  STRETCH: '--tmx-fp-stretch',
+};
+
+const bandColor = (key: string): string => `var(${BAND_VARS[key] ?? '--tmx-fp-other'})`;
+const bandLabel = (key: string): string => t(`fingerprint.bands.${key}`, { defaultValue: key });
+
+/** The band keys a policy declares, widest-stretch first for display. */
+export function displayBandKeys(policyDefinitions: any): string[] {
+  const deltaBands = policyDefinitions?.[POLICY_TYPE]?.deltaBands ?? [];
+  // The policy list ascends by boundary (ANCHOR → STRETCH); the bar has always
+  // read stretch-first, matching the ITA fingerprint artifacts.
+  return deltaBands
+    .map((band: any) => band?.key)
+    .filter(Boolean)
+    .reverse();
+}
+
+/**
+ * A rating scale this participant actually carries AND the factory knows how to
+ * orient. An unknown scale is skipped rather than guessed: the factory refuses
+ * to infer orientation (guessing inverts every band), so passing one would only
+ * produce an error.
+ */
+export function resolveScaleName(participant: any): string | undefined {
+  const ratings = participant?.ratings?.[SINGLES] ?? [];
+  for (const rating of ratings) {
+    const scaleName = String(rating?.scaleName ?? '').toUpperCase();
+    if (scaleName && ratingsParameters[scaleName]) return scaleName;
+  }
+  return undefined;
+}
+
+function textRow(className: string, text: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = className;
+  el.textContent = text;
+  return el;
+}
+
+function buildLegend(bandKeys: string[], counts: Record<string, number>): HTMLElement {
+  const legend = document.createElement('div');
+  legend.className = 'tmx-fp__legend';
+
+  // Identity is never colour-alone: every band gets a swatch AND its name.
+  for (const key of bandKeys) {
+    const item = document.createElement('span');
+    item.className = 'tmx-fp__legend-item';
+    if (!counts[key]) item.classList.add('is-empty');
+
+    const swatch = document.createElement('span');
+    swatch.className = 'tmx-fp__swatch';
+    swatch.style.background = bandColor(key);
+
+    item.append(swatch, document.createTextNode(bandLabel(key)));
+    legend.appendChild(item);
+  }
+
+  return legend;
+}
+
+type FingerprintDataArgs = {
+  policyDefinitions?: any;
+  participantId: string;
+  participant: any;
+  matchUps: any[];
+};
+
+export type FingerprintData = {
+  exposure: any;
+  realized: any;
+  bandKeys: string[];
+  scaleName?: string;
+};
+
+/**
+ * The pure half: everything the block renders, with no DOM. Separated so it is
+ * unit-testable — TMX's vitest runs in node with no DOM, and DOM assertions
+ * belong to Playwright.
+ *
+ * Returns undefined when there is nothing honest to show: no completed matchUps
+ * AND no resolvable exposure, or a policy/scale the factory rejects (a
+ * configuration problem is surfaced by rendering nothing, never papered over
+ * with an empty bar).
+ */
+export function fingerprintData({
+  policyDefinitions = POLICY_COMPETITIVE_BANDS_DEFAULT,
+  participantId,
+  participant,
+  matchUps,
+}: FingerprintDataArgs): FingerprintData | undefined {
+  if (!matchUps?.length) return undefined;
+
+  const scaleName = resolveScaleName(participant);
+
+  const profile: any = getCompetitiveProfile({
+    policyDefinitions,
+    participantId,
+    scaleName,
+    matchUps,
+  });
+  if (profile?.error || !profile?.realized) return undefined;
+
+  const { realized, exposure } = profile;
+  if (!realized.completed && !exposure.rated) return undefined;
+
+  return { realized, exposure, scaleName, bandKeys: displayBandKeys(policyDefinitions) };
+}
+
+type FingerprintArgs = {
+  policyDefinitions?: any;
+  participantId: string;
+  participant: any;
+};
+
+/** The DOM shell. All decisions live in `fingerprintData`. */
+export function buildParticipantFingerprint({
+  policyDefinitions = POLICY_COMPETITIVE_BANDS_DEFAULT,
+  participantId,
+  participant,
+}: FingerprintArgs): HTMLElement | undefined {
+  // `withScaleValues` must be TOP-LEVEL here, not inside contextProfile: nested,
+  // the matchUp side participants come back with `ratings: {}` and the exposure
+  // axis silently finds nothing to band. Verified in the running app — the unit
+  // tests hand `fingerprintData` its matchUps, so they cannot catch this.
+  //
+  // `withMatchUps` returns the tournament's matchUps, not only this
+  // participant's; `getCompetitiveProfile` does the participant filtering.
+  const { matchUps } = tournamentEngine.getParticipants({
+    participantFilters: { participantIds: [participantId] },
+    withScaleValues: true,
+    withMatchUps: true,
+  });
+
+  const data = fingerprintData({ policyDefinitions, participantId, participant, matchUps: matchUps ?? [] });
+  if (!data) return undefined;
+
+  const { realized, exposure, scaleName, bandKeys } = data;
+
+  const section = document.createElement('div');
+  section.className = 'tmx-fp';
+
+  const heading = textRow('tmx-fp__heading', t('fingerprint.title'));
+  section.appendChild(heading);
+
+  if (realized.completed) {
+    const competitiveRatio = Math.round((realized.ratios.COMPETITIVE ?? 0) * 10) / 10;
+    section.appendChild(
+      textRow(
+        'tmx-fp__realized',
+        t('fingerprint.competitiveRatio', { pct: competitiveRatio, count: realized.completed }),
+      ),
+    );
+  }
+
+  if (exposure.deltaBandsApplied && exposure.rated) {
+    const bar = buildSegmentedBar({
+      segments: bandKeys.map((key) => ({ key, label: bandLabel(key), color: bandColor(key) })),
+    });
+    bar.update(exposure.counts);
+    bar.element.classList.add('tmx-fp__bar');
+    section.append(bar.element, buildLegend(bandKeys, exposure.counts));
+
+    // State the denominator and the scale. Without them the bar is a shape with
+    // no provenance — and provenance of the level is a §6.2 requirement.
+    section.appendChild(
+      textRow(
+        COVERAGE_CLASS,
+        exposure.unrated
+          ? t('fingerprint.coveragePartial', { rated: exposure.rated, unrated: exposure.unrated, scale: scaleName })
+          : t('fingerprint.coverage', { rated: exposure.rated, scale: scaleName }),
+      ),
+    );
+  } else if (scaleName) {
+    section.appendChild(textRow(COVERAGE_CLASS, t('fingerprint.noRatedOpponents', { scale: scaleName })));
+  } else {
+    section.appendChild(textRow(COVERAGE_CLASS, t('fingerprint.noRating')));
+  }
+
+  return section;
+}

--- a/src/components/modals/participantProfileModal.ts
+++ b/src/components/modals/participantProfileModal.ts
@@ -5,6 +5,7 @@
 import { getAvailablePolicies, getLevelDisplayLabel } from 'components/tables/pointsTable/policyUtils';
 import { headerSortElement } from 'components/tables/common/sorters/headerSortElement';
 import { fixtures, factoryConstants, unwrapOr } from 'tods-competition-factory';
+import { buildParticipantFingerprint } from './participantFingerprint';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { tournamentEngine } from 'services/factory/engine';
@@ -331,6 +332,11 @@ export function participantProfileModal({ participantId, participantIds, readOnl
   // Ratings & rankings chips
   const ratingsSection = buildRatingsSection(participant);
   if (ratingsSection) content.appendChild(ratingsSection);
+
+  // Competitive fingerprint — sits under the ratings it is computed from.
+  // Returns undefined when there is nothing honest to show.
+  const fingerprint = buildParticipantFingerprint({ participantId, participant });
+  if (fingerprint) content.appendChild(fingerprint);
 
   // Team affiliation + jersey number chips (only for individuals carrying
   // a teamAttributes[0] entry — set by the import wizard).

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2282,5 +2282,20 @@
       "errorEvents": "Could not create events from the plan",
       "errorEmpty": "Nothing to apply — every flight was unsupported or empty"
     }
+  },
+  "fingerprint": {
+    "title": "Competitive fingerprint",
+    "competitiveRatio": "Competitive ratio {{pct}}% of {{count}} completed",
+    "coverage": "{{rated}} rated on {{scale}}",
+    "coveragePartial": "{{rated}} rated on {{scale}} · {{unrated}} unrated",
+    "noRatedOpponents": "No opponent rated on {{scale}}",
+    "noRating": "No rating available for exposure",
+    "bands": {
+      "STRETCH": "Stretch",
+      "UP": "Up",
+      "EVEN": "Even",
+      "DOWN": "Down",
+      "ANCHOR": "Anchor"
+    }
   }
 }


### PR DESCRIPTION
§6.2 of [`COMPETITIVE_FINGERPRINT.md`](https://github.com/CourtHive/Mentat/blob/main/planning/COMPETITIVE_FINGERPRINT.md), unblocked by the factory's policy-shaped delta bands (factory #4602, merged).

> [!IMPORTANT]
> **DRAFT — do not merge before the factory publishes.** `getCompetitiveProfile` and the default policy's `deltaBands` do not exist in the pinned **6.22.1**; the `link:` override masks that locally. Gated on factory 6.23.0 → pin bump here.

## What it shows

| axis | what | when |
|---|---|---|
| **Realized** | competitive ratio over completed matchUps (score spread, unsigned) | whenever anything is completed |
| **Exposure** | the five-segment signed bar (rating delta) — who they were drawn against | when a rating scale resolves on both sides |

Both computed **locally by the factory** from matchUps already in memory: no network, no identity, works offline.

**Deliberately not included:** the cross-tournament "Competitive journey" link-out. It needs the §6.1 HiveID hop, which does not exist, and the standard is never a dead link.

## No new component, no hardcoded vocabulary

Reuses `buildSegmentedBar` from courthive-components — already driving the matchUps-page bars — rather than adding a visual. Band count and names come from **policy** `deltaBands`, so a federation shipping three bands or its own names renders correctly; unmapped keys take a neutral swatch instead of borrowing another band's colour.

## Honest coverage

The block always states the rated denominator, the unrated count, and the scale name. A bar drawn from four rated matchUps out of eleven otherwise implies a completeness it does not have. An unresolvable scale is *reported*, not hidden — and a scale absent from `ratingsParameters` is skipped rather than passed to the factory, which refuses to guess orientation (guessing inverts every band).

## Colour was computed, not eyeballed

A **diverging** ramp — cool = played down, neutral grey = even, warm = played up — rather than good/bad hues, because the axis's whole claim is that a healthy diet contains up, even **and** down. ANCHOR must not read as failure.

Both modes are stepped for their own surface (not an automatic flip) and validated:

| | worst adjacent CVD ΔE | normal-vision ΔE | contrast vs surface |
|---|---|---|---|
| light `#fcfcfb` | 18.4 | 18.4 | all ≥ 3:1 except one step at 2.91 |
| dark `#1a1a19` | 18.3 | 19.2 | **all five ≥ 3:1** |

The 2.91 step is relieved by the count label rendered inside every segment plus the legend beneath it. Two validator FAILs are **by design** and documented in the CSS so nobody "fixes" them: the chroma floor flags the neutral grey midpoint (a diverging ramp requires a hueless middle), and the lightness band flags steps that deliberately span light↔dark to keep the arms distinguishable.

Label ink is per-band, from measurement: white fails 4.5:1 on the two light fills (2.99 / 3.20 light, 2.50 / 2.17 dark) where dark ink clears comfortably. That is a label-on-fill question the palette validator does not cover — it surfaced only by rendering the bar and reading it.

## Running it caught the only real defect

With `withScaleValues` nested inside `contextProfile`, `getParticipants` returns side participants carrying `ratings: {}` — the exposure axis silently finds nothing to band and the bar simply **disappears, with no error anywhere**. It has to be a top-level param.

The unit tests hand `fingerprintData` its matchUps, so they structurally cannot catch that. **Journey 93 now does**, and it was falsified against the exact regression: reverting the fix takes the assertion from 5 segments to 0.

## Verification

| gate | result |
|---|---|
| `pnpm test --run` | **1047 passed** / 102 files (+14 new) |
| journey 93 (Playwright, real app) | passes; falsified against the regression above |
| `pnpm lint` (src + e2e) | clean, 0 warnings |
| `pnpm check-types` (src + e2e) | clean |
| `prettier --check` touched files | clean |
| rendered in both themes | screenshotted and read |

The 14 unit tests cover band vocabulary from policy, scale resolution, counts on both axes, unrated handling, perspective inversion, and the invalid-policy / nothing-to-show paths. **Mutation-tested:** hardcoding the band list fails 3 of them; accepting an unknown scale fails 1.

## Second commit — an unrelated fix I caused

`fix(test): exclude .claude worktrees from vitest discovery`. `exclude: ['e2e/**', …]` is root-anchored, so it misses `.claude/worktrees/<name>/e2e/**`: a per-session worktree (standard A8) gets its Playwright specs run by vitest **in the canonical checkout**, failing there while the worktree stays green — so the session that caused it never sees the failure. That is how I found it. Same class as factory #4604 (jest); this is the vitest analogue, and it too was falsified with a planted worktree-shaped spec.

## Follow-ups (not here)

- Honour a tournament-attached `competitiveBands` policy instead of always passing the default fixture — `getCompetitiveProfile` is pure by design and takes no `tournamentRecord`, so TMX needs an applied-policy read to thread it.
- The link-out, once §6.1 resolve-on-create writes a HiveID into `person.personOtherIds`.
