### PR TITLE
ci: keep the lockfile instead of deleting it before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,20 @@ jobs:
             if (after !== before) fs.writeFileSync('pnpm-workspace.yaml', after);
           }
           "
-          rm -f pnpm-lock.yaml
 
-      - run: pnpm install
+      # The lockfile is KEPT and the install is --no-frozen-lockfile, rather than
+      # `rm -f pnpm-lock.yaml`. Stripping the overrides makes the lockfile stale and
+      # CI defaults to frozen, so something has to give — but deleting it re-resolves
+      # EVERY dependency, which collides with `minimumReleaseAge: 1440` above the
+      # moment any transitive dep published within the last 24h. That fails an
+      # unrelated PR with ERR_PNPM_NO_MATURE_MATCHING_VERSION and nothing the author
+      # can act on. It is not theoretical: it fired in competition-factory-server on
+      # @storybook/csf-plugin@10.5.8, published 98 seconds inside the window.
+      #
+      # Keeping the lockfile re-resolves only the five stripped overrides — which are
+      # exactly the packages minimumReleaseAgeExclude already exempts — and installs
+      # everything else at its locked version, so CI is deterministic too.
+      - run: pnpm install --no-frozen-lockfile
       - run: pnpm lint
 
       # Formatting gate. Nothing enforced prettier before this: the pre-commit


### PR DESCRIPTION
## Problem

`ci.yml` deletes the lockfile after stripping the `link:` overrides:

```yaml
rm -f pnpm-lock.yaml
- run: pnpm install
```

That re-resolves **every** dependency from the registry, which collides with `minimumReleaseAge: 1440` in
`pnpm-workspace.yaml`. Any transitive dep published within the last 24 hours fails the install — on a PR that
touches none of it, with an error its author cannot act on:

```
[ERR_PNPM_NO_MATURE_MATCHING_VERSION] 2 versions do not meet the minimumReleaseAge constraint:
  @storybook/builder-vite@10.5.8 was published at 2026-08-13T13:52:22Z,
  within the minimumReleaseAge cutoff (2026-08-13T13:50:44Z)
```

That is not hypothetical — it is a real failure, caught in `competition-factory-server` while adding CI there
(CourtHive/competition-factory-server#883). The packages were **98 seconds** too fresh. TMX has the identical
combination (`minimumReleaseAge: 1440` + `rm -f pnpm-lock.yaml`) and has simply not been unlucky yet.

`courthive-query` is immune only incidentally: it has no `link:` overrides, so it never deletes its lockfile.

## Change

Keep the lockfile; install with `--no-frozen-lockfile`.

Something has to give, because stripping the overrides makes the lockfile stale and CI defaults to frozen. But
keeping it re-resolves only the five stripped overrides — `tods-competition-factory`, `courthive-components`,
`@courthive/provider-config`, `@courthive/scoring-visualizations`, `pdf-factory` — which are **exactly** the
packages `minimumReleaseAgeExclude` already exempts. Everything else installs at its locked version, so CI
becomes deterministic as well as unblocked.

## Verification

Rehearsed in a clean clone of `main`, applying this workflow's own strip step:

```
CI=true pnpm install --no-frozen-lockfile     → Done in 13s, exit 0

tods-competition-factory        -> .pnpm/tods-competition-factory@6.22.1
courthive-components            -> .pnpm/courthive-components@3.13.1_…
@courthive/provider-config      -> .pnpm/@courthive+provider-config@0.13.0
pdf-factory                     -> .pnpm/pdf-factory@0.8.16_…
@courthive/scoring-visualizations -> .pnpm/@courthive+scoring-visualizations@0.2.12_…
```

All five resolve from the registry — no dangling symlinks, which is what the strip step exists to prevent. The
three gates this workflow runs all pass in that same clean clone:

```
pnpm lint          PASS
pnpm format:check  PASS
pnpm attr-audit --ci  PASS
```

## Note

This is independent of the open TMX PR #1265 (Vitest `.claude` worktree exclusion) — different file, no
conflict, either order.
