### PR TITLE
chore(git): ignore the .claude tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@ storybook-static
 .*.un~
 .*un~
 .idea
+
+# Per-session Claude Code state: `settings.local.json` is personal, and
+# `.claude/worktrees/` holds git worktrees — architectural standard A8 makes a
+# worktree under here the standard way to isolate a building session, so this
+# directory is tooling, never source. Untracked it showed as a permanent pending
+# change in every `git status`, and left one `git add -A` away from committing an
+# entire nested worktree. (A9 is the sibling fix: keeping that same directory out
+# of test discovery.)
+.claude


### PR DESCRIPTION
`.claude/` holds two things that are never source: `settings.local.json` (personal Claude Code settings) and `worktrees/` (git worktrees).

Architectural standard **A8** makes a worktree under `.claude/worktrees/` the standard way to isolate a building session, so this directory now appears in any repo where a session has run.

## Why it is worth fixing rather than ignoring

Untracked, it showed as a permanent pending entry in every `git status`:

```text
?? .claude/
```

That reads as "this repo has uncommitted work" when **nothing is modified at all** — which is exactly how it was reported to me. It also sat one `git add -A` away from committing an entire nested git worktree, which is the accident the staging-discipline rule already exists to prevent.

## Relationship to #1265

**A9** is the sibling fix, already landed here in #1265: keeping this same directory out of *test discovery*, after vitest collected a worktree as a second copy of the whole suite. Same directory, same root cause — this closes the version-control half.

## Scope

factory is currently the only one of **22** ecosystem repos that ignores `.claude`. courthive-ingest has the same pending entry today; the other 20 simply have not had a session create the directory yet, and will show it the moment one does. Worth a sweep, but this PR is deliberately just TMX — one line, no behaviour change.

Verified with `git check-ignore -v .claude` (reports the new rule at `.gitignore:59`) and by confirming `git status --porcelain` is empty afterwards.