### PR TITLE
fix(deps): update tods-competition-factory to 6.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.23.0",
+    "tods-competition-factory": "6.24.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Part of the ecosystem cascade for factory **6.24.0**, run via `Mentat/scripts/bump-factory-consumers.sh`.

TMX is the only consumer that needed a PR: its `main` requires the `lint` status check, so the script's direct push was rejected (`GH006: Protected branch update failed`). The other 10 consumers landed directly.

## What 6.24.0 contains

The sanctioning tier vocabulary unification — `sanctioningLevel` and `sanctioningTier` collapsed onto one `TierClassification { system, value }`, shared with `tournamentTier`. **TMX is a passive beneficiary**: it already reads `tournamentTier`, and a tournament activated from sanctioning now carries one natively instead of only as a CODES extension.

Manifest-only, no lockfile change — TMX carries `tods-competition-factory: link:../factory` in `pnpm-workspace.yaml`, so the lockfile records the version-agnostic link and the pin is what CI and deploys resolve.

## Verification

- `pnpm lint` — clean (src + e2e), 0 warnings
- `pnpm check-types` — clean (both tsconfigs)
- `pnpm test --run` — **1047 passed** / 102 files
- `pnpm build` — succeeds

Also verified against the **published** 6.24.0 tarball rather than trusting the release: `sanctioningTier` present in the published dist, `sanctioningLevel` absent, and a create→activate round-trip yields `tournamentTier: { system: 'ITF', value: 'W50' }`.