### PR TITLE
fix(scheduling): show own linked tournaments as reserved instead of empty courts

### DIFF
--- a/src/services/facilitySchedule/facilityScheduleHelpers.test.ts
+++ b/src/services/facilitySchedule/facilityScheduleHelpers.test.ts
@@ -110,6 +110,24 @@ describe('mergeReservedCellsIntoRows', () => {
     });
   });
 
+  it('labels an author cell with its tournamentName and leaves a view cell unnamed', () => {
+    // `author` = one of the viewer's own linked tournaments (server is willing to name it).
+    // `view` = another director's — must stay opaque: a court is taken, never by whom.
+    const rows: any[] = [{ rowId: 'r0' }, { rowId: 'r1' }];
+    mergeReservedCellsIntoRows(
+      rows,
+      [
+        { courtId: 'c0', courtOrder: 1, access: 'author', tournamentName: 'My Other Tournament' },
+        { courtId: 'c1', courtOrder: 2, access: 'view' },
+      ],
+      courtsData,
+      'C|',
+    );
+    expect(rows[0]['C|0'].reservation.tournamentName).toEqual('My Other Tournament');
+    expect(rows[1]['C|1'].reservation.tournamentName).toBeUndefined();
+    expect(rows[1]['C|1'].isReserved).toBe(true);
+  });
+
   it('never overwrites an owned matchUp (SAME_COURT_ORDER clash keeps the owned cell)', () => {
     const rows: any[] = [{ 'C|0': { matchUpId: 'own' } }];
     mergeReservedCellsIntoRows(rows, [{ courtId: 'c0', courtOrder: 1 }], [{ courtId: 'c0' }], 'C|');

--- a/src/services/facilitySchedule/facilityScheduleHelpers.ts
+++ b/src/services/facilitySchedule/facilityScheduleHelpers.ts
@@ -97,7 +97,10 @@ export function mergeReservedCellsIntoRows(
     if (rows[ri][key]?.matchUpId) continue;
     rows[ri][key] = {
       isReserved: true,
-      reservation: { scheduledTime: cell?.scheduledTime },
+      // `tournamentName` is present only on `author` cells — the viewer's own linked tournaments,
+      // which the server is willing to name. `view` peers arrive opaque and stay unnamed, so the
+      // rendered cell says a court is taken without saying by whom.
+      reservation: { scheduledTime: cell?.scheduledTime, tournamentName: cell?.tournamentName },
       schedule: { courtId: cell.courtId, courtOrder: cell.courtOrder, venueId: cell?.venueId },
     };
   }

--- a/src/services/facilitySchedule/reservedCells.test.ts
+++ b/src/services/facilitySchedule/reservedCells.test.ts
@@ -1,8 +1,9 @@
 /**
  * reservedCells — coordination-view fetch + cache of other facility-sharing tournaments' court
  * occupancy. The request sends the loaded (authored) tournament as the context; the server returns
- * its linked peers' projections tagged access:'author'|'view'. Only `view` peers are reserved slots
- * (a different director/provider); `author` peers render normally. No tournamentRecords are loaded.
+ * its linked peers' projections tagged access:'author'|'view'. BOTH are reserved slots: `view` peers
+ * (another director/provider) stay opaque, `author` peers (the viewer's own linked tournaments) are
+ * named. No tournamentRecords are loaded.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -56,18 +57,42 @@ describe('loadReservedCells', () => {
     expect(hasReservedCells(PRIMARY)).toBe(true);
   });
 
-  it('keeps only view-access cells — author peers render normally, not as reserved', async () => {
+  it('keeps BOTH author and view cells — an author peer occupies a real court', async () => {
+    // Regression: `author` cells used to be filtered out here on the assumption that they "render
+    // normally". Nothing loads peer records into the engine on the scheduling tab, so filtering them
+    // left the court rendering EMPTY while the director's own linked tournament played on it.
     fetchScheduleProjectionMock.mockResolvedValue(
       proj([
-        { tournamentId: 'own-linked', access: 'author', courtId: 'c1', courtOrder: 1, scheduledDate: DATE },
+        {
+          tournamentId: 'own-linked',
+          access: 'author',
+          tournamentName: 'My Other Tournament',
+          courtId: 'c1',
+          courtOrder: 1,
+          scheduledDate: DATE,
+        },
         viewCell({ courtOrder: 2, scheduledDate: DATE }),
       ]),
     );
 
     const count = await loadReservedCells(primaryRecord(['peer', 'own-linked']));
 
+    expect(count).toBe(2);
+    const cells = getReservedCellsForDate(DATE, PRIMARY);
+    expect(cells.map((c) => c.access).sort()).toEqual(['author', 'view']);
+    // the author cell is named; the view cell is not
+    expect(cells.find((c) => c.access === 'author')?.tournamentName).toEqual('My Other Tournament');
+    expect(cells.find((c) => c.access === 'view')?.tournamentName).toBeUndefined();
+  });
+
+  it('treats an untagged cell as reserved rather than dropping it', async () => {
+    // An unrecognised projection shape must not silently become an empty court.
+    fetchScheduleProjectionMock.mockResolvedValue(
+      proj([{ tournamentId: 'peer', courtId: 'c1', courtOrder: 1, scheduledDate: DATE }]),
+    );
+    const count = await loadReservedCells(primaryRecord(['peer']));
     expect(count).toBe(1);
-    expect(getReservedCellsForDate(DATE, PRIMARY).map((c) => c.access)).toEqual(['view']);
+    expect(getReservedCellsForDate(DATE, PRIMARY)).toHaveLength(1);
   });
 
   it('does not fetch and caches an empty set when there are no linked peers', async () => {

--- a/src/services/facilitySchedule/reservedCells.ts
+++ b/src/services/facilitySchedule/reservedCells.ts
@@ -4,16 +4,27 @@ import { fetchScheduleProjection } from 'services/apis/servicesApi';
 /**
  * Shared-facility reserved cells.
  *
- * A court slot taken by ANOTHER facility-sharing tournament the viewer can't author is shown in the
- * grid as a read-only "reserved" cell (see courthive-components `isReserved`). The data is a slim
- * `ScheduleCell[]` from the schedule projection — NOT loaded tournamentRecords. This module fetches
- * and caches those cells for the loaded tournament; `gridView` reads them per-date and injects them
- * into empty grid slots.
+ * A court slot taken by another facility-sharing tournament is shown in the grid as a read-only
+ * "reserved" cell (see courthive-components `isReserved`). The data is a slim `ScheduleCell[]` from
+ * the schedule projection — NOT loaded tournamentRecords. This module fetches and caches those cells
+ * for the loaded tournament; `gridView` reads them per-date and injects them into empty grid slots.
  *
  * The request is the coordination view: it sends the loaded (authored) tournament as the context, and
  * the server returns projections of its server-verified linked peers tagged `access:'author'|'view'`.
- * Only `view` peers (a different director/provider sharing the facility) are reserved cells — an
- * `author` peer is the viewer's own linked tournament and renders normally, not as a reserved slot.
+ * **Both** become reserved cells, for different reasons:
+ *
+ * - `view` — a different director/provider sharing the facility. Opaque: the cell shows that a court
+ *   is taken, never by whom (the server strips detail via `opaqueReservedCell`).
+ * - `author` — one of the viewer's OWN linked tournaments. Carries `tournamentName` so the director
+ *   can see which of their tournaments holds the court.
+ *
+ * `author` peers were previously filtered out here, on the assumption that they "render normally".
+ * They do not. Nothing loads peer tournamentRecords into the engine on the scheduling tab
+ * (`competitionEngine`/`tournamentEngine` are the same factory singletons over one state store, and
+ * TMX seeds a single record), so an author peer's matchUps were neither drawn nor reserved and the
+ * slot rendered EMPTY — a court shown free while the director's own linked tournament played on it.
+ * Until same-provider peers are loaded into the engine for a fully interactive integrated grid,
+ * reserved-and-named is the truthful representation.
  */
 
 let cache: { tournamentId: string; cells: any[] } | null = null;
@@ -39,8 +50,10 @@ export async function loadReservedCells(primaryRecord: any): Promise<number> {
       venueIds: primaryVenueIds(primaryRecord),
       silent: true,
     });
-    // Only `view` peers are reserved slots; `author` peers are the viewer's own and render normally.
-    const cells = (result?.data?.scheduleCells ?? []).filter((cell: any) => cell?.access === 'view');
+    // Both `view` and `author` peers occupy courts the viewer must not double-book. Cells with no
+    // access tag are treated as reserved too — a projection shape we don't recognise must not
+    // silently become an empty court.
+    const cells = result?.data?.scheduleCells ?? [];
     cache = { tournamentId: primaryId, cells };
     return cells.length;
   } catch {


### PR DESCRIPTION
Fixes a **false-empty court** in the shared-facility grid. Server half: CourtHive/competition-factory-server#886.

## The bug

`reservedCells.ts` filtered the coordination projection to `access === 'view'`, on the stated assumption that an `author` peer "renders normally".

It does not. Nothing loads peer tournamentRecords into the engine on the scheduling tab — `competitionEngine` and `tournamentEngine` are the same factory singletons over one state store, TMX seeds a single record, and the only `setTournamentRecord` call is in `linkedTournaments.ts:53` during the link mutation itself. So an author peer's matchUps were **neither drawn as matchUps nor shown reserved**, and the slot rendered **empty**.

Net effect: a director running two linked same-provider tournaments at one facility saw a court as **free** while their own other tournament was playing on it. That is worse than the pre-linking behaviour, and it is the case the design explicitly calls the common one (mostly-same-provider).

## The fix

Keep both access levels as reserved cells:

| access | meaning | rendering |
|---|---|---|
| `view` | another director/provider sharing the facility | opaque, unnamed — a court is taken, never by whom |
| `author` | one of the viewer's own linked tournaments | labelled with `tournamentName` |

Cells with **no** access tag are treated as reserved too — an unrecognised projection shape must not silently become an empty court.

## Scope — deliberately interim

This does **not** attempt the designed end state: loading same-provider peers into the engine so they render as normal, interactive matchUps. That is a load-bearing scheduling change with two caveats already documented in the plan (`saveTournamentRecord` persists only the primary; the `setState` calls in `gridView.ts` / `queueService.ts` are discard-reloads that would reset to primary-only). Rushing it is how the false-empty shipped in the first place. Reserved-and-named is the truthful representation until then.

## Verification

- lint 0 warnings, `check-types` clean (incl. e2e project), Prettier clean on touched files.
- vitest **1049 passed** (+2 vs the 1047 baseline), 102 files.
- The existing test that **encoded the bug as intended behaviour** ("keeps only view-access cells — author peers render normally") is inverted, with the regression explained in-place.
- Falsified: restoring the `view`-only filter fails 2 tests; dropping `tournamentName` from the injector fails 1. Both restored green.
