### PR TITLE
fix(deps): update tods-competition-factory to 6.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.24.0",
+    "tods-competition-factory": "6.25.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Part of the ecosystem fan-out of `tods-competition-factory@6.25.0` (published; release PR merged upstream).

Ten of eleven consumers took this bump by direct push from `Mentat/scripts/bump-factory-consumers.sh`. TMX's `main` is protected and requires the `lint` status check, so its commit is routed through a PR instead — same change, same script-generated commit.

Manifest-only by design: TMX resolves factory through a `link:../factory` override in `pnpm-workspace.yaml`, so the lockfile carries no version entry to update.

The script's `pnpm check-types` gate passed for TMX before the commit was created.