### PR TITLE
fix(deps): update courthive-components to 3.13.2 and pdf-factory to 0.8.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.13.1",
+    "courthive-components": "3.13.2",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.4",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.16",
+    "pdf-factory": "0.8.17",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",


### PR DESCRIPTION
Consumer bumps following the library releases in the current cascade — `courthive-components@3.13.2` and `pdf-factory@0.8.17` are both published.

The components bump is the commit `Mentat/scripts/bump-components-consumers.sh` generated; TMX's `main` is protected and requires the `lint` check, so it is routed through a PR while the other three consumers (courthive-public, courthive-ams/client, epixodic) took it by direct push. The pdf-factory bump is folded in here rather than opening a second PR — TMX is its only consumer.

Both are manifest-only: TMX resolves each through a `link:` override in `pnpm-workspace.yaml`, so no lockfile entry changes.

`pnpm check-types` passes locally against both bumps.

Sequenced deliberately ahead of TMX release PR #1252, so 8.18.0 ships pinned to the current libraries rather than to superseded ones.