### PR TITLE
feat(officiating): surface official conflicts in the matchUp official picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.25.0",
+    "tods-competition-factory": "6.26.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }

--- a/src/components/popovers/matchUpActions.ts
+++ b/src/components/popovers/matchUpActions.ts
@@ -2,16 +2,18 @@
  * MatchUp actions popover menu.
  * Provides options for start/end time, official selection, and schedule clearing.
  */
-import { confirmDelegatedOutcome, openSetDelegatedOutcome } from 'services/crowd/delegatedOutcomeFlow';
 import { openNominateScorekeeper, removeScorekeeperNomination } from 'services/crowd/nominateScorekeeperFlow';
+import { confirmDelegatedOutcome, openSetDelegatedOutcome } from 'services/crowd/delegatedOutcomeFlow';
+import { evaluateCandidate, resolveConflictPolicy } from 'services/officiating/officialConflicts';
 import { setMatchUpSchedule } from 'components/tables/matchUpsTable/setMatchUpSchedule';
+import type { CandidateConflicts } from 'services/officiating/officialConflicts';
 import { openCrowdTrackersModal } from 'components/modals/crowdTrackersModal';
-import { readDelegatedOutcome } from 'services/crowd/delegatedOutcome';
 import { getScheduleDateRange } from 'pages/tournament/tabs/scheduleUtils';
 import { getActiveSessionCount } from 'services/crowd/crowdActivityIndex';
+import { readDelegatedOutcome } from 'services/crowd/delegatedOutcome';
+import { ParticipantRoleEnum, tools } from 'tods-competition-factory';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { printMatchCards } from 'components/modals/printMatchCards';
-import { ParticipantRoleEnum, tools } from 'tods-competition-factory';
 import { logMutationError } from 'functions/logMutationError';
 import { tournamentEngine } from 'services/factory/engine';
 import { timePicker } from 'components/modals/timePicker';
@@ -215,6 +217,21 @@ export function matchUpActions({
 
     const currentOfficialId = matchUp?.schedule?.official;
 
+    // Conflict state per candidate, computed locally — no fetch. Evaluated up front so a TD is never
+    // offered a choice that will be refused.
+    const conflictPolicy = resolveConflictPolicy();
+    const conflictByOfficial = new Map<string, CandidateConflicts>(
+      officials.map((official: any) => [
+        official.participantId,
+        evaluateCandidate({
+          officialParticipantId: official.participantId,
+          policyDefinitions: conflictPolicy,
+          matchUpId: matchUp.matchUpId,
+          drawId: matchUp.drawId,
+        }),
+      ]),
+    );
+
     const wrapper = document.createElement('div');
     wrapper.style.cssText = 'position:relative; padding:8px; padding-top:20px; min-width:160px;';
 
@@ -238,7 +255,27 @@ export function matchUpActions({
         li.style.backgroundColor = 'var(--tmx-accent-blue, #3273dc)';
         li.style.color = '#fff';
       }
+      const conflict = conflictByOfficial.get(official.participantId) ?? { level: 'none', reasons: [] };
+      const isBlocked = conflict.level === 'blocked';
+
       li.textContent = official.participantName ?? null;
+      if (conflict.level !== 'none') {
+        // Reasons come from the factory already human-readable, e.g. "Official shares a COACH grouping
+        // (Team Alpha) with this participant" — the UI lists them rather than composing a sentence.
+        li.title = conflict.reasons.join('\n');
+        const dot = document.createElement('span');
+        dot.textContent = '\u25cf';
+        dot.setAttribute('aria-hidden', 'true');
+        dot.style.cssText = `margin-left:6px; color:${isBlocked ? 'var(--tmx-danger, #d64545)' : 'var(--tmx-warning, #d99e00)'};`;
+        li.appendChild(dot);
+        li.setAttribute('data-conflict', conflict.level);
+      }
+      if (isBlocked) {
+        li.style.cursor = 'not-allowed';
+        li.style.opacity = '0.55';
+        li.setAttribute('aria-disabled', 'true');
+      }
+
       li.onmouseenter = () => {
         if (official.participantId !== currentOfficialId) li.style.backgroundColor = 'var(--chc-hover-bg, #f0f0f0)';
       };
@@ -247,6 +284,14 @@ export function matchUpActions({
       };
       li.onclick = (e) => {
         e.stopPropagation();
+        // A blocking conflict is not selectable. The factory refuses it too — this only avoids
+        // dispatching a mutation that is certain to be rejected.
+        if (isBlocked) return;
+        if (
+          conflict.level === 'warn' &&
+          !window.confirm(`${t('officiating.conflictWarning')}\n\n${conflict.reasons.join('\n')}`)
+        )
+          return;
         destroyOfficialTip();
         const methods = [
           {
@@ -255,6 +300,8 @@ export function matchUpActions({
               matchUpId: matchUp.matchUpId,
               drawId: matchUp.drawId,
               participantId: official.participantId,
+              // The factory gate is the enforcement point; the UI annotation is an affordance.
+              policyDefinitions: conflictPolicy,
             },
           },
         ];

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2297,5 +2297,8 @@
       "DOWN": "Down",
       "ANCHOR": "Anchor"
     }
+  },
+  "officiating": {
+    "conflictWarning": "This official has a potential conflict of interest with a participant in this match. Assign anyway?"
   }
 }

--- a/src/services/officiating/officialConflicts.test.ts
+++ b/src/services/officiating/officialConflicts.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure-helper coverage for the official conflict surface. Picker DOM behaviour belongs in a Playwright
+ * journey, not here (one DOM test layer per ecosystem).
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { getPolicyDefinitionsMock, getMatchUpOfficialConflictsMock } = vi.hoisted(() => ({
+  getPolicyDefinitionsMock: vi.fn(),
+  getMatchUpOfficialConflictsMock: vi.fn(),
+}));
+
+vi.mock('services/factory/engine', () => ({
+  tournamentEngine: {
+    getPolicyDefinitions: getPolicyDefinitionsMock,
+    getMatchUpOfficialConflicts: getMatchUpOfficialConflictsMock,
+  },
+}));
+
+import { evaluateCandidate, resolveConflictPolicy, summarizeConflicts } from './officialConflicts';
+import { fixtures, policyConstants } from 'tods-competition-factory';
+
+const { POLICY_TYPE_OFFICIATING_CONFLICT } = policyConstants;
+const COACH_GROUPING = 'COACH grouping';
+const { POLICY_OFFICIATING_CONFLICT_OF_INTEREST } = fixtures.policies;
+
+beforeEach(() => {
+  getPolicyDefinitionsMock.mockReset();
+  getMatchUpOfficialConflictsMock.mockReset();
+});
+
+describe('resolveConflictPolicy', () => {
+  it('prefers an attached provider policy', () => {
+    const attached = { [POLICY_TYPE_OFFICIATING_CONFLICT]: { conflictRules: { SAME_PERSON: { enabled: true } } } };
+    getPolicyDefinitionsMock.mockReturnValue({ policyDefinitions: attached });
+    expect(resolveConflictPolicy()).toBe(attached);
+  });
+
+  it('falls back to the bundled default when none is attached', () => {
+    getPolicyDefinitionsMock.mockReturnValue({ policyDefinitions: undefined });
+    expect(resolveConflictPolicy()).toBe(POLICY_OFFICIATING_CONFLICT_OF_INTEREST);
+  });
+
+  it('falls back when the engine returns nothing at all', () => {
+    getPolicyDefinitionsMock.mockReturnValue(undefined);
+    expect(resolveConflictPolicy()).toBe(POLICY_OFFICIATING_CONFLICT_OF_INTEREST);
+  });
+
+  it('falls back when policyDefinitions exists but carries no conflict policy', () => {
+    // A tournament with OTHER attached policies must not be read as "conflict checking configured off".
+    getPolicyDefinitionsMock.mockReturnValue({ policyDefinitions: { scoring: {} } });
+    expect(resolveConflictPolicy()).toBe(POLICY_OFFICIATING_CONFLICT_OF_INTEREST);
+  });
+});
+
+describe('summarizeConflicts', () => {
+  it('reports none for an empty conflict list', () => {
+    expect(summarizeConflicts({ conflicts: [], blocked: false })).toEqual({ level: 'none', reasons: [] });
+  });
+
+  it('reports warn with reasons when not blocked', () => {
+    const summary = summarizeConflicts({ conflicts: [{ reason: 'shares a grouping' }], blocked: false });
+    expect(summary).toEqual({ level: 'warn', reasons: ['shares a grouping'] });
+  });
+
+  it('reports blocked when the factory says blocked', () => {
+    const summary = summarizeConflicts({
+      conflicts: [{ reason: COACH_GROUPING }, { reason: 'declared relationship' }],
+      blocked: true,
+    });
+    expect(summary.level).toEqual('blocked');
+    expect(summary.reasons).toEqual([COACH_GROUPING, 'declared relationship']);
+  });
+
+  it('drops conflicts that carry no reason rather than rendering blanks', () => {
+    const summary = summarizeConflicts({ conflicts: [{ reason: 'real' }, {}], blocked: false });
+    expect(summary.reasons).toEqual(['real']);
+  });
+});
+
+describe('evaluateCandidate', () => {
+  const args = {
+    officialParticipantId: 'par-official',
+    policyDefinitions: POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+    matchUpId: 'm-1',
+    drawId: 'd-1',
+  };
+
+  it('passes drawId + matchUpId + officialParticipantId to the engine', () => {
+    getMatchUpOfficialConflictsMock.mockReturnValue({ conflicts: [], blocked: false });
+    evaluateCandidate(args);
+    expect(getMatchUpOfficialConflictsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ officialParticipantId: 'par-official', matchUpId: 'm-1', drawId: 'd-1' }),
+    );
+  });
+
+  it('surfaces a blocking conflict', () => {
+    getMatchUpOfficialConflictsMock.mockReturnValue({ conflicts: [{ reason: COACH_GROUPING }], blocked: true });
+    expect(evaluateCandidate(args)).toEqual({ level: 'blocked', reasons: [COACH_GROUPING] });
+  });
+
+  it('fails OPEN when the engine errors — a UI that cannot evaluate must not invent a refusal', () => {
+    // The factory gate on the mutation is the enforcement point; this is only an affordance.
+    getMatchUpOfficialConflictsMock.mockReturnValue({ error: { code: 'ERR_MISSING_CONFLICT_SOURCE' } });
+    expect(evaluateCandidate(args)).toEqual({ level: 'none', reasons: [] });
+  });
+});

--- a/src/services/officiating/officialConflicts.ts
+++ b/src/services/officiating/officialConflicts.ts
@@ -1,0 +1,83 @@
+/**
+ * Conflict-of-interest evaluation for the matchUp official picker.
+ *
+ * The factory can refuse a conflicted official assignment; until now nothing surfaced that to an
+ * operator, so the engine enforced a rule nobody could see. This module is the read side of that.
+ *
+ * Everything here is LOCAL. `tournamentEngine.getMatchUpOfficialConflicts` resolves the tournamentRecord
+ * and drawDefinition from engine state given a `drawId`, and a relationship declared as GROUP membership
+ * lives in the tournamentRecord itself — so there is no fetch, no API client and no dependency on an
+ * external officials registry. A registry record would add durable cross-tournament declarations; its
+ * absence is not a blocker, which matters because "no registry" must not silently mean "no conflicts".
+ */
+import { fixtures, policyConstants } from 'tods-competition-factory';
+import { tournamentEngine } from 'services/factory/engine';
+
+const { POLICY_OFFICIATING_CONFLICT_OF_INTEREST } = fixtures.policies;
+
+const { POLICY_TYPE_OFFICIATING_CONFLICT } = policyConstants;
+
+/** Severity of the worst conflict found for a candidate. `none` means evaluated and clean. */
+export type ConflictLevel = 'none' | 'warn' | 'blocked';
+
+export type CandidateConflicts = {
+  level: ConflictLevel;
+  /** Human-readable reasons straight from the factory — the UI lists them, it does not compose prose. */
+  reasons: string[];
+};
+
+/**
+ * Resolve the conflict policy: an attached provider policy wins, else the bundled default.
+ *
+ * Same shape as `tallyReportModal` / `getAttachedAvoidances`. The bundled default deliberately disables
+ * NATIONALITY and treats a bare shared grouping as WARN, escalating only GROUPs whose `participantRole`
+ * marks an authored relationship (COACH / MEDICAL / PHYSIO / TRAINER).
+ */
+export function resolveConflictPolicy(): any {
+  const { policyDefinitions } =
+    tournamentEngine.getPolicyDefinitions({
+      policyTypes: [POLICY_TYPE_OFFICIATING_CONFLICT],
+    }) ?? {};
+
+  return policyDefinitions?.[POLICY_TYPE_OFFICIATING_CONFLICT]
+    ? policyDefinitions
+    : POLICY_OFFICIATING_CONFLICT_OF_INTEREST;
+}
+
+/** Reduce a factory conflict list to the single worst level plus its reasons. */
+export function summarizeConflicts(result: any): CandidateConflicts {
+  const conflicts = result?.conflicts ?? [];
+  if (!conflicts.length) return { level: 'none', reasons: [] };
+
+  const reasons = conflicts.map((conflict: any) => conflict?.reason).filter(Boolean);
+  return { level: result?.blocked ? 'blocked' : 'warn', reasons };
+}
+
+/**
+ * Evaluate one candidate official against one matchUp.
+ *
+ * Fails OPEN by design: if the evaluation errors, the candidate is reported `none` rather than blocked.
+ * A UI that cannot evaluate must not invent a refusal — and it is not the enforcement point anyway, the
+ * factory gate on the mutation is. That gate re-runs the same check server-side with the same policy.
+ */
+export function evaluateCandidate({
+  officialParticipantId,
+  policyDefinitions,
+  matchUpId,
+  drawId,
+}: {
+  officialParticipantId: string;
+  policyDefinitions: any;
+  matchUpId: string;
+  drawId: string;
+}): CandidateConflicts {
+  const result: any = (tournamentEngine as any).getMatchUpOfficialConflicts({
+    officialParticipantId,
+    policyDefinitions,
+    matchUpId,
+    drawId,
+  });
+
+  if (result?.error) return { level: 'none', reasons: [] };
+  return summarizeConflicts(result);
+}


### PR DESCRIPTION
The first **operator-visible** conflict-of-interest surface. The factory can evaluate and refuse a conflicted official assignment; until now nothing reached it, so the engine enforced a rule nobody could see.

## What a TD sees

Each candidate in the existing official picker (`matchUpActions.ts`) is evaluated **before** selection:

| state | rendering | click |
|---|---|---|
| `blocked` | red dot, dimmed, `aria-disabled` | does nothing |
| `warn` | amber dot | confirms first |
| `none` | unchanged | unchanged |

Reasons come from the factory already human-readable — *"Official shares a COACH grouping (Team Alpha) with this participant"* — so the UI lists them in the tooltip rather than composing prose of its own.

## Three deliberate choices

**The UI is not the enforcement point.** The dispatch carries `policyDefinitions`, so the factory's gate refuses a blocked assignment regardless of what the picker did. Annotation is an affordance.

**Evaluation fails OPEN.** If the check cannot run, the candidate is reported clean rather than the UI inventing a refusal it has no authority to make — and the mutation gate still applies.

**Policy fallback is careful.** An attached provider policy wins; otherwise the bundled default. Critically, a tournament with *other* attached policies but no conflict policy also falls back — that must not be read as "conflict checking configured off".

## No new dependencies

Evaluation is pure local computation. `tournamentEngine.getMatchUpOfficialConflicts` resolves `tournamentRecord` + `drawDefinition` from engine state given a `drawId`, and a relationship declared as GROUP membership lives in the tournamentRecord itself — so **no fetch, no API client, no officials-registry dependency**. That matters: a registry-less deployment must not silently mean "no conflicts".

## Factory pin → 6.26.0

Required, not incidental: the picker passes `officialParticipantId` and relies on `SHARED_GROUPING`, both of which landed in 6.26.0. CI strips the `link:` override and installs the pin, so the branch could not go green until it moved. Local development is unaffected — `pnpm-workspace.yaml` still carries `link:../factory`, which wins locally, and the lockfile records the link specifier rather than a version.

Verified against the **published tarball** rather than git ancestry: 6.26.0's declarations carry `getMatchUpOfficialConflicts` and `officialParticipantId`, and the method is present in the production bundle.

## Verification

Full CI-equivalent gate run locally on the rebased branch:

- `pnpm lint` — 0 warnings (`src e2e electron`)
- `pnpm check-types` — clean across all three legs
- `pnpm format:check` — clean
- `pnpm attr-audit --ci` — exit 0
- `pnpm test --run` — **1060 tests / 103 files** (+11 vs the 1049 baseline)

Falsified, each red then restored: removing the policy fallback (3 failures — a tournament with no attached policy would check nothing); ignoring `blocked` so everything downgrades to warn (2); failing *closed* on error so the UI invents refusals (1).

Pure helpers only in vitest; picker DOM behaviour belongs in a Playwright journey (one DOM test layer per ecosystem) — a follow-up, along with the other six i18n locales for `officiating.conflictWarning`.
