### PR TITLE
fix(electron): repair the broken desktop build and gate it with a smoke suite

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,0 +1,83 @@
+name: electron
+
+# The desktop target had no CI at all. Between 2026-03 and 2026-08 the Electron
+# build was broken on `main` and every gate stayed green, because `pnpm lint`
+# scoped to `src e2e`, `tsconfig.json` included only `src`, and vitest never
+# loads the Electron entry points. Five months of silent breakage is the reason
+# this workflow exists.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  desktop:
+    name: build + smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # Identical to the `lint` job in ci.yml — see the long note there. The
+      # runner has no sibling clones at ../factory, so a `link:` override would
+      # leave a dangling symlink. Unlike lint, THIS job actually builds, so a
+      # dangling factory would fail hard rather than being tolerated.
+      - name: 'Strip link: overrides for CI'
+        run: |
+          node -e "
+          const fs = require('fs');
+          if (fs.existsSync('pnpm-workspace.yaml')) {
+            const before = fs.readFileSync('pnpm-workspace.yaml', 'utf8');
+            const after = before.split('\n').filter(line => !/:\s*link:\S+\s*\$/.test(line)).join('\n');
+            if (after !== before) fs.writeFileSync('pnpm-workspace.yaml', after);
+          }
+          "
+
+      - run: pnpm install --no-frozen-lockfile
+
+      # Type-check the Electron sources specifically. The root `check-types` now
+      # includes this leg too, but running it standalone here keeps the failure
+      # attributable to the desktop target.
+      - name: check-types (electron)
+        run: pnpm check-types:electron
+
+      # Kept as its own step so a config-resolution failure (the 2026-03 defect)
+      # is distinguishable from a test failure in the logs.
+      - name: Build main, preload and renderer
+        run: pnpm electron:build
+
+      # Electron bundles its own Chromium, so no browser download is needed —
+      # but the shared system libraries it links against are not on a bare
+      # runner. `install-deps` provides exactly those.
+      - name: Install Chromium system dependencies
+        run: pnpm exec playwright install-deps chromium
+
+      # Electron always opens a real window; there is no headless mode for the
+      # app shell, so Linux CI needs a virtual framebuffer.
+      - name: Smoke-test the desktop build
+        run: xvfb-run --auto-servernum pnpm exec playwright test --config e2e/playwright.electron.config.ts
+
+      # Packaging sanity WITHOUT producing installers: `--dir` runs the whole
+      # electron-builder pipeline (file globs, app metadata, native rebuilds) and
+      # stops before the AppImage/DMG/NSIS step, which would need extra tooling
+      # and signing material. Catches a broken `files` glob — the classic
+      # "works locally, ships an app with no renderer" packaging bug.
+      - name: Packaging sanity (unpacked)
+        run: pnpm exec electron-builder --config electron-builder.json5 --dir
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-traces
+          path: e2e/test-results-electron/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pnpm-debug.log*
 /coverage
 /test-results
 /e2e/test-results
+/e2e/test-results-electron
 /e2e/playwright-report
 /e2e/.playwright
 

--- a/attr-audit.config.json
+++ b/attr-audit.config.json
@@ -2,9 +2,25 @@
   "src": ["src"],
   "exclude": ["/scratch/"],
   "ignore": [
-    "onchange", "oninput", "setHours", "getHours", "setDate", "getDate",
-    "setColumns", "getColumns", "getItems", "getItem", "_events", "bound",
-    "minute", "weekday", "hour", "second", "month", "year", "day"
+    "onchange",
+    "oninput",
+    "setHours",
+    "getHours",
+    "setDate",
+    "getDate",
+    "setColumns",
+    "getColumns",
+    "getItems",
+    "getItem",
+    "_events",
+    "bound",
+    "minute",
+    "weekday",
+    "hour",
+    "second",
+    "month",
+    "year",
+    "day"
   ],
   "minCommon": 8,
   "ratio": 5,
@@ -38,6 +54,7 @@
     "languages",
     "attribute",
     "WITHDRAW",
-    "registrationIds"
+    "registrationIds",
+    "baseURI"
   ]
 }

--- a/dev/documentation/electron-desktop-app.md
+++ b/dev/documentation/electron-desktop-app.md
@@ -12,6 +12,10 @@ pnpm electron:dev        # Dev server + Electron window (hot-reload)
 pnpm electron:build      # Build main/preload/renderer for production
 pnpm electron:preview    # Preview production build in Electron
 pnpm electron:package    # Package distributable (DMG/NSIS/AppImage)
+
+pnpm test:electron       # Build + Playwright smoke suite against the desktop target
+pnpm test:electron:ui    # Same, in Playwright's interactive UI
+pnpm check-types:electron # Type-check electron/ only
 ```
 
 Web scripts (`pnpm start`, `pnpm build`, etc.) are completely unchanged.
@@ -264,6 +268,31 @@ rm -f "$HOME/Library/Application Support/tmx/IndexedDB/http_localhost_*.indexedd
 The port is printed in the console output. The main process reads `ELECTRON_RENDERER_URL` which
 electron-vite sets automatically.
 
+### `pnpm electron:package` fails with `mimeType "undefined" is not valid`
+
+electron-builder parses Electron's `Info.plist` through `plist@3`, which calls
+`parseFromString(xml)` with no mimeType — mandatory as of `@xmldom/xmldom@0.9`.
+TMX overrides `@xmldom/xmldom` to `^0.9.0` for security, which also captured
+`plist`. Resolved by the scoped override in `pnpm-workspace.yaml`:
+
+```yaml
+'plist>@xmldom/xmldom': ^0.8.11
+```
+
+`plist` is build-time only (never in the app bundle, never fed untrusted input),
+so the 0.8 line is not an exposure. Everything else stays on 0.9.
+
+### `window.electronAPI` is undefined in the packaged app
+
+The preload was emitted under a name `electron/main.ts` does not load. Electron
+accepts an ESM preload **only** when the file is named `.mjs`, and electron-vite
+v5 defaults `entryFileNames` to `[name].js`; `electron.vite.config.ts` pins
+`output: { format: 'es', entryFileNames: 'preload.mjs' }` for this reason.
+
+Nothing errors when this breaks — `src/platform/index.ts` simply falls back to
+the **web** adapter, so native dialogs become browser downloads and the
+Connection panel vanishes. `preload-bridge.spec.ts` exists to catch it.
+
 ### `process.env.SERVER` undefined
 
 The renderer config in `electron.vite.config.ts` must include `vite-plugin-environment` with
@@ -277,6 +306,50 @@ Without this, `process.env.SERVER` won't be replaced at compile time and will th
 
 ---
 
+## Verification
+
+Until 2026-08-15 the desktop target had **no gate of any kind**, and the build was
+broken on `main` for five months without a single red signal. The cause was
+scoping, not neglect:
+
+| Gate | Scope before | Covers `electron/` now |
+|---|---|---|
+| `pnpm lint` | `eslint src e2e` | yes — `eslint src e2e electron` |
+| `pnpm check-types` | `tsconfig.json` (`include: ["src"]`) | yes — third leg runs `electron/tsconfig.json` |
+| `pnpm test` | vitest, `src/**` | no (by design — see below) |
+| CI | no desktop job | yes — `.github/workflows/electron.yml` |
+
+Unit tests deliberately do **not** cover the Electron entry points: main and
+preload only do meaningful work inside a running Electron process, so a mocked
+`ipcMain` would assert the mock. The desktop target is covered by Playwright
+instead — the ecosystem's only DOM/E2E layer.
+
+### Smoke suite (`e2e/electron/`)
+
+Run with `pnpm test:electron`. Config: `e2e/playwright.electron.config.ts`
+(separate from the web journeys — no `webServer`, no browser project, no retries).
+
+| Spec | Guards |
+|---|---|
+| `build-contract.spec.ts` | Static assertions on build OUTPUT — `package.json#main` resolves, the preload filename `main.ts` loads is actually emitted, preload is `.mjs`, `index.html` asset paths stay relative, `version.json` is emitted |
+| `app-launch.spec.ts` | Launches `dist-electron/main/main.js`: window opens, assets resolve under `file://`, TMX itself boots (`globalThis.dev`), no uncaught errors, and **no request fails against the `file://` origin** |
+| `preload-bridge.spec.ts` | `window.electronAPI` is injected, exposes every method `PlatformAdapter` needs, and both IPC directions round-trip |
+| `packaged-app.spec.ts` | The real `.app`/`.exe`/AppImage from electron-builder — boots from inside the asar, ships the preload, loads every bundled asset. Auto-skips unless `release/` exists |
+
+Two habits keep this suite honest:
+
+- **Cold profile per launch.** Every spec passes `--user-data-dir=<temp>`
+  (`e2e/electron/helpers/userDataDir.ts`). Electron persists `userData` across
+  runs, and a cached i18n manifest from a previous run silently disarmed the
+  failed-request guard — the suite stayed green while a reverted fix was
+  reintroduced. See architectural-standard A6.
+- **Falsify the detector.** Every guard here was verified to report *dirty*, not
+  just clean: reverting the preload fix fires 7 failures, reverting
+  `staticAssetUrl` fires on `file:///fonts/catalog.json`, and reverting the
+  `baseApi` fix fires on `file:///i18n/manifest`.
+
+---
+
 ## Implementation Status
 
 | Phase | Status | Description |
@@ -285,7 +358,23 @@ Without this, `process.env.SERVER` won't be replaced at compile time and will th
 | 2. Platform Adapter | DONE | PlatformAdapter interface, web + electron implementations |
 | 3. Config Migration | DONE | 10 typed modules, env shim, 36 files migrated |
 | 4. Native Features | DONE | File dialogs, app menu, standalone UI, OS notifications, admin DevTools |
-| 5. Distribution | TODO | Code signing, CI pipeline, auto-update |
+| 5. Distribution | PARTIAL | Build + package + CI + smoke suite done; **code signing, app icon, and auto-update still outstanding** |
+
+### Phase 5 — what remains
+
+`pnpm electron:package` produces a working, verified DMG today, but
+electron-builder still warns about three things, all cosmetic-but-shipping:
+
+- **No application icon** — the DMG ships the default Electron icon
+  (`default Electron icon is used`). Needs an `.icns`/`.ico` in
+  `electron-builder.json5`.
+- **No `description` / `author` in `package.json`** — these become the macOS
+  bundle metadata.
+- **No code signing** — `0 valid identities found`, so macOS Gatekeeper will
+  warn on first launch. Needs Apple Developer Program ($99/yr) + a Windows cert.
+
+Auto-update is untouched: `platform.canAutoUpdate()` returns `true` in the
+Electron adapter, but nothing consumes it.
 
 ---
 
@@ -293,6 +382,7 @@ Without this, `process.env.SERVER` won't be replaced at compile time and will th
 
 1. **Auto-update infrastructure** — GitHub Releases (free, simple) vs S3/custom server?
 2. **Offline → online sync** — replay mutation log or upload full tournament record?
+   (Now under active design — see `Mentat/planning/DISCONNECTED_SYNC_RECONCILIATION.md`.)
 3. **Deep linking** — should `courthive://tournament/123` open the desktop app?
 4. **Multi-window** — should users be able to open multiple tournaments in separate windows?
 5. **Code signing** — Apple Developer Program ($99/yr) + Windows cert needed for unsigned warnings

--- a/dev/documentation/electron-desktop-app.md
+++ b/dev/documentation/electron-desktop-app.md
@@ -48,12 +48,12 @@ TMX/
 
 ### Build Pipeline
 
-| Target | Tool | Config | Output |
-|--------|------|--------|--------|
-| Web | `vite` | `vite.config.ts` | `dist/` |
-| Electron main | `electron-vite` | `electron.vite.config.ts` → `main` | `dist-electron/main/main.js` |
-| Electron preload | `electron-vite` | `electron.vite.config.ts` → `preload` | `dist-electron/preload/preload.mjs` |
-| Electron renderer | `electron-vite` | `electron.vite.config.ts` → `renderer` | `dist/` (same as web) |
+| Target            | Tool            | Config                                 | Output                              |
+| ----------------- | --------------- | -------------------------------------- | ----------------------------------- |
+| Web               | `vite`          | `vite.config.ts`                       | `dist/`                             |
+| Electron main     | `electron-vite` | `electron.vite.config.ts` → `main`     | `dist-electron/main/main.js`        |
+| Electron preload  | `electron-vite` | `electron.vite.config.ts` → `preload`  | `dist-electron/preload/preload.mjs` |
+| Electron renderer | `electron-vite` | `electron.vite.config.ts` → `renderer` | `dist/` (same as web)               |
 
 The renderer config includes `vite-tsconfig-paths` and `vite-plugin-environment` (same plugins
 as the web config) so that absolute imports and `process.env.SERVER` work identically.
@@ -67,8 +67,8 @@ source directory).
 ```typescript
 import { platform } from 'platform';
 
-platform.type;                // 'web' | 'electron'
-platform.isDesktop();         // true in Electron
+platform.type; // 'web' | 'electron'
+platform.isDesktop(); // true in Electron
 platform.canAccessFileSystem(); // true if preload bridge is available
 ```
 
@@ -127,17 +127,17 @@ The `ElectronBridge` interface in `src/platform/electron.ts` mirrors this shape.
 
 ### IPC Handlers
 
-| Channel | Direction | Purpose |
-|---------|-----------|---------|
-| `dialog:save` | renderer → main | Native save dialog |
-| `dialog:open` | renderer → main | Native open dialog |
-| `fs:readFile` | renderer → main | Read file from disk |
-| `fs:writeFile` | renderer → main | Write file to disk |
-| `app:getDataPath` | renderer → main | User data directory path |
-| `app:getServerUrl` | renderer → main | Load persisted server URL |
-| `app:setServerUrl` | renderer → main | Persist server URL |
-| `app:toggleDevTools` | renderer → main | Toggle Chrome DevTools |
-| `menu:action` | main → renderer | Menu item clicked (one-way) |
+| Channel              | Direction       | Purpose                     |
+| -------------------- | --------------- | --------------------------- |
+| `dialog:save`        | renderer → main | Native save dialog          |
+| `dialog:open`        | renderer → main | Native open dialog          |
+| `fs:readFile`        | renderer → main | Read file from disk         |
+| `fs:writeFile`       | renderer → main | Write file to disk          |
+| `app:getDataPath`    | renderer → main | User data directory path    |
+| `app:getServerUrl`   | renderer → main | Load persisted server URL   |
+| `app:setServerUrl`   | renderer → main | Persist server URL          |
+| `app:toggleDevTools` | renderer → main | Toggle Chrome DevTools      |
+| `menu:action`        | main → renderer | Menu item clicked (one-way) |
 
 ---
 
@@ -145,14 +145,14 @@ The `ElectronBridge` interface in `src/platform/electron.ts` mirrors this shape.
 
 Built with `Menu.buildFromTemplate()` and set via `Menu.setApplicationMenu()`.
 
-| Menu | Items |
-|------|-------|
-| **App** (macOS only) | About, Services, Hide, Quit |
-| **File** | Open Tournament (Cmd+O), Export Tournament (Cmd+E), Close/Quit |
-| **Edit** | Undo, Redo, Cut, Copy, Paste, Select All |
-| **View** | Reload, Force Reload, Toggle Developer Tools (Cmd+Shift+F12), Zoom, Fullscreen |
-| **Window** | Minimize, Zoom, Front (macOS) |
-| **Help** | About TMX |
+| Menu                 | Items                                                                          |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **App** (macOS only) | About, Services, Hide, Quit                                                    |
+| **File**             | Open Tournament (Cmd+O), Export Tournament (Cmd+E), Close/Quit                 |
+| **Edit**             | Undo, Redo, Cut, Copy, Paste, Select All                                       |
+| **View**             | Reload, Force Reload, Toggle Developer Tools (Cmd+Shift+F12), Zoom, Fullscreen |
+| **Window**           | Minimize, Zoom, Front (macOS)                                                  |
+| **Help**             | About TMX                                                                      |
 
 Menu actions that interact with TMX data (Open, Export, DevTools, About) are sent as IPC messages
 to the renderer via `menu:action`. The renderer's `menuHandler.ts` dispatches them to the
@@ -228,18 +228,18 @@ Desktop notifications use the Web Notifications API (works in both browser and E
 
 The `env` god object has been replaced by 10 focused config modules in `src/config/`:
 
-| Module | Key fields |
-|--------|------------|
-| `serverConfig` | serverFirst, serverTimeout, socketPath, saveLocal, socketIo |
-| `deviceConfig` | isMobile, isTouch, isMac, isElectron, isStandalone |
-| `featureFlags` | pdfPrinting, googleSheetsImport, schedule2, usePublishState |
+| Module              | Key fields                                                   |
+| ------------------- | ------------------------------------------------------------ |
+| `serverConfig`      | serverFirst, serverTimeout, socketPath, saveLocal, socketIo  |
+| `deviceConfig`      | isMobile, isTouch, isMac, isElectron, isStandalone           |
+| `featureFlags`      | pdfPrinting, googleSheetsImport, schedule2, usePublishState  |
 | `preferencesConfig` | activeScale, scoringApproach, smartComplements, hotkeys, ioc |
-| `displayConfig` | composition, tableHeightMultiplier, printing |
-| `scheduleConfig` | teams, clubs, time24, minCourtGridRows |
-| `scoringConfig` | scoreboard matchFormats, options, settings |
-| `debugConfig` | log.verbose, renderLog, devNotes, averages |
-| `locationConfig` | geolocate, geoposition, map, leaflet tile layers |
-| `scalesConfig` | rating scales (read-only, from factory fixtures) |
+| `displayConfig`     | composition, tableHeightMultiplier, printing                 |
+| `scheduleConfig`    | teams, clubs, time24, minCourtGridRows                       |
+| `scoringConfig`     | scoreboard matchFormats, options, settings                   |
+| `debugConfig`       | log.verbose, renderLog, devNotes, averages                   |
+| `locationConfig`    | geolocate, geoposition, map, leaflet tile layers             |
+| `scalesConfig`      | rating scales (read-only, from factory fixtures)             |
 
 Each module exports `{ get(), set(partial), reset() }`. `env.ts` remains as a deprecated
 backward-compatible shim with getter/setter pairs delegating to the typed modules.
@@ -258,6 +258,7 @@ LOCK file for IndexedDB may be left behind. Symptoms: repeated `Failed to open L
 errors in the console, app renders nothing.
 
 Fix:
+
 ```bash
 rm -f "$HOME/Library/Application Support/tmx/IndexedDB/http_localhost_*.indexeddb.leveldb/LOCK"
 ```
@@ -312,12 +313,12 @@ Until 2026-08-15 the desktop target had **no gate of any kind**, and the build w
 broken on `main` for five months without a single red signal. The cause was
 scoping, not neglect:
 
-| Gate | Scope before | Covers `electron/` now |
-|---|---|---|
-| `pnpm lint` | `eslint src e2e` | yes — `eslint src e2e electron` |
+| Gate               | Scope before                         | Covers `electron/` now                        |
+| ------------------ | ------------------------------------ | --------------------------------------------- |
+| `pnpm lint`        | `eslint src e2e`                     | yes — `eslint src e2e electron`               |
 | `pnpm check-types` | `tsconfig.json` (`include: ["src"]`) | yes — third leg runs `electron/tsconfig.json` |
-| `pnpm test` | vitest, `src/**` | no (by design — see below) |
-| CI | no desktop job | yes — `.github/workflows/electron.yml` |
+| `pnpm test`        | vitest, `src/**`                     | no (by design — see below)                    |
+| CI                 | no desktop job                       | yes — `.github/workflows/electron.yml`        |
 
 Unit tests deliberately do **not** cover the Electron entry points: main and
 preload only do meaningful work inside a running Electron process, so a mocked
@@ -329,12 +330,12 @@ instead — the ecosystem's only DOM/E2E layer.
 Run with `pnpm test:electron`. Config: `e2e/playwright.electron.config.ts`
 (separate from the web journeys — no `webServer`, no browser project, no retries).
 
-| Spec | Guards |
-|---|---|
+| Spec                     | Guards                                                                                                                                                                                                           |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `build-contract.spec.ts` | Static assertions on build OUTPUT — `package.json#main` resolves, the preload filename `main.ts` loads is actually emitted, preload is `.mjs`, `index.html` asset paths stay relative, `version.json` is emitted |
-| `app-launch.spec.ts` | Launches `dist-electron/main/main.js`: window opens, assets resolve under `file://`, TMX itself boots (`globalThis.dev`), no uncaught errors, and **no request fails against the `file://` origin** |
-| `preload-bridge.spec.ts` | `window.electronAPI` is injected, exposes every method `PlatformAdapter` needs, and both IPC directions round-trip |
-| `packaged-app.spec.ts` | The real `.app`/`.exe`/AppImage from electron-builder — boots from inside the asar, ships the preload, loads every bundled asset. Auto-skips unless `release/` exists |
+| `app-launch.spec.ts`     | Launches `dist-electron/main/main.js`: window opens, assets resolve under `file://`, TMX itself boots (`globalThis.dev`), no uncaught errors, and **no request fails against the `file://` origin**              |
+| `preload-bridge.spec.ts` | `window.electronAPI` is injected, exposes every method `PlatformAdapter` needs, and both IPC directions round-trip                                                                                               |
+| `packaged-app.spec.ts`   | The real `.app`/`.exe`/AppImage from electron-builder — boots from inside the asar, ships the preload, loads every bundled asset. Auto-skips unless `release/` exists                                            |
 
 Two habits keep this suite honest:
 
@@ -343,7 +344,7 @@ Two habits keep this suite honest:
   runs, and a cached i18n manifest from a previous run silently disarmed the
   failed-request guard — the suite stayed green while a reverted fix was
   reintroduced. See architectural-standard A6.
-- **Falsify the detector.** Every guard here was verified to report *dirty*, not
+- **Falsify the detector.** Every guard here was verified to report _dirty_, not
   just clean: reverting the preload fix fires 7 failures, reverting
   `staticAssetUrl` fires on `file:///fonts/catalog.json`, and reverting the
   `baseApi` fix fires on `file:///i18n/manifest`.
@@ -352,13 +353,13 @@ Two habits keep this suite honest:
 
 ## Implementation Status
 
-| Phase | Status | Description |
-|-------|--------|-------------|
-| 1. Electron Shell | DONE | BrowserWindow, dev/prod loading, window persistence |
-| 2. Platform Adapter | DONE | PlatformAdapter interface, web + electron implementations |
-| 3. Config Migration | DONE | 10 typed modules, env shim, 36 files migrated |
-| 4. Native Features | DONE | File dialogs, app menu, standalone UI, OS notifications, admin DevTools |
-| 5. Distribution | PARTIAL | Build + package + CI + smoke suite done; **code signing, app icon, and auto-update still outstanding** |
+| Phase               | Status  | Description                                                                                            |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| 1. Electron Shell   | DONE    | BrowserWindow, dev/prod loading, window persistence                                                    |
+| 2. Platform Adapter | DONE    | PlatformAdapter interface, web + electron implementations                                              |
+| 3. Config Migration | DONE    | 10 typed modules, env shim, 36 files migrated                                                          |
+| 4. Native Features  | DONE    | File dialogs, app menu, standalone UI, OS notifications, admin DevTools                                |
+| 5. Distribution     | PARTIAL | Build + package + CI + smoke suite done; **code signing, app icon, and auto-update still outstanding** |
 
 ### Phase 5 — what remains
 

--- a/e2e/electron/app-launch.spec.ts
+++ b/e2e/electron/app-launch.spec.ts
@@ -1,0 +1,119 @@
+import { ElectronApplication, Page, _electron as electron, expect, test } from '@playwright/test';
+import { freshUserDataDir } from './helpers/userDataDir';
+import { resolve } from 'path';
+
+/**
+ * The load-bearing smoke test: does the packaged desktop app actually start?
+ *
+ * Asserts progressively deeper layers so a failure localises itself:
+ *   1. the Electron process starts at all           (main entry is loadable)
+ *   2. a window opens                               (createWindow ran)
+ *   3. the renderer's own assets loaded             (base / file:// resolution)
+ *   4. TMX itself booted                            (app code ran, not just HTML)
+ */
+
+// `import.meta.dirname` rather than `__dirname`: package.json declares
+// `"type": "module"`, so these specs are loaded as ESM.
+const repoRoot = resolve(import.meta.dirname, '../..');
+const MAIN_ENTRY = resolve(repoRoot, 'dist-electron/main/main.js');
+
+let app: ElectronApplication;
+let window: Page;
+const pageErrors: string[] = [];
+const failedFileRequests: string[] = [];
+
+let userData: { path: string; cleanup: () => void };
+
+test.beforeAll(async () => {
+  userData = freshUserDataDir();
+  app = await electron.launch({
+    // `--user-data-dir` forces a cold profile — see helpers/userDataDir.ts for
+    // the guard this restores.
+    args: [MAIN_ENTRY, `--user-data-dir=${userData.path}`],
+    // A packaged app has no ELECTRON_RENDERER_URL, so main.ts takes the
+    // `loadFile()` branch — the production path we actually ship. Clearing it
+    // explicitly stops an inherited value from silently testing the dev server
+    // instead (which would defeat the whole suite).
+    env: { ...process.env, ELECTRON_RENDERER_URL: '', NODE_ENV: 'production' },
+  });
+
+  window = await app.firstWindow();
+
+  window.on('pageerror', (error) => pageErrors.push(error.message));
+
+  // Track failures against the app's OWN origin. Requests to an http(s) API host
+  // are expected to fail in this suite — there is no CFS running — so asserting
+  // on console text would either be too noisy to keep or too vague to trust.
+  // A failed `file://` request is unambiguous: either a bundled asset is missing,
+  // or code built an absolute URL against the file origin (the `/fonts/*` and
+  // `file:///i18n/manifest` defects both presented exactly this way).
+  window.on('requestfailed', (request) => {
+    const url = request.url();
+    if (url.startsWith('file://')) failedFileRequests.push(`${url} (${request.failure()?.errorText})`);
+  });
+});
+
+test.afterAll(async () => {
+  await app?.close();
+  userData?.cleanup();
+});
+
+test.describe('electron app launch', () => {
+  test('opens a window with the TMX title', async () => {
+    expect(await window.title()).toContain('TMX');
+  });
+
+  test('main process reports the expected app identity', async () => {
+    const identity = await app.evaluate(async ({ app: electronApp }) => ({
+      name: electronApp.getName(),
+      hasUserData: Boolean(electronApp.getPath('userData')),
+    }));
+
+    expect(identity.hasUserData).toBe(true);
+    expect(identity.name).toBeTruthy();
+  });
+
+  test('renderer assets resolve under the file:// protocol', async () => {
+    // The blank-window failure mode: index.html parses fine, so a title check
+    // still passes, but every `/assets/*` request 404s off the filesystem root.
+    // Proving a stylesheet applied is proving the asset graph actually loaded.
+    await window.waitForLoadState('domcontentloaded');
+
+    const styleSheetCount = await window.evaluate(() => document.styleSheets.length);
+    expect(styleSheetCount, 'no stylesheets loaded — assets did not resolve').toBeGreaterThan(0);
+
+    const scriptCount = await window.evaluate(
+      () => document.querySelectorAll('script[src], link[rel="modulepreload"]').length,
+    );
+    expect(scriptCount).toBeGreaterThan(0);
+  });
+
+  test('TMX application code boots in the renderer', async () => {
+    // `globalThis.dev` is installed by TMX's own startup path, so its presence
+    // proves the bundle executed — not merely that HTML was served. This is the
+    // same readiness signal the web journeys use (`e2e/helpers/dev-bridge.ts`).
+    await window.waitForFunction(() => typeof (globalThis as any).dev !== 'undefined', null, { timeout: 30_000 });
+
+    const rootPopulated = await window.evaluate(() => {
+      const root = document.getElementById('root');
+      return Boolean(root && root.childElementCount > 0);
+    });
+    expect(rootPopulated, '#root is empty — TMX rendered nothing').toBe(true);
+  });
+
+  test('renderer boots without uncaught errors', async () => {
+    // Runs after the boot test above so the app has had a full startup to fail in.
+    expect(pageErrors, `uncaught renderer exceptions: ${pageErrors.join(' | ')}`).toEqual([]);
+  });
+
+  test('nothing fails to load from the app bundle', async () => {
+    // Give late startup work (font catalog, i18n) a chance to issue its requests
+    // before sampling — these fire after `dev` is installed, not before it.
+    await window.waitForTimeout(2_000);
+
+    expect(
+      failedFileRequests,
+      `requests failed against the file:// origin:\n  ${failedFileRequests.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/e2e/electron/build-contract.spec.ts
+++ b/e2e/electron/build-contract.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Static assertions on the Electron build OUTPUT.
+ *
+ * These never launch Electron, so they run in milliseconds and give a precise
+ * diagnosis when the app fails to boot — a launch failure tells you "blank
+ * window", these tell you *which* contract broke.
+ *
+ * What they cover:
+ *
+ *   1. `package.json#main` drifting from the emitted main entry
+ *   2. `electron/main.ts` referencing a preload filename the build does not emit
+ *      — a REAL defect found 2026-08-15 (electron-vite v5 changed
+ *      `entryFileNames` from `.mjs` to `.js`)
+ *   3. an absolute asset base, which would resolve to `file:///assets/*` under
+ *      `loadFile()` and render a blank window. This one is PRE-EMPTIVE, not
+ *      corrective: electron-vite currently forces a relative base for the
+ *      renderer and ignores any `base` set in config (verified by building with
+ *      `base` unset, `'./'` and `'/'` — the emitted HTML is identical). The
+ *      assertion exists because that is an upstream default we do not control,
+ *      and it was falsified against hand-edited HTML rather than against config.
+ *
+ * Nothing in the source tree changes when these break — only the build output —
+ * which is precisely why source-level gates (lint, tsc, vitest) cannot see them.
+ */
+
+// `import.meta.dirname` rather than `__dirname`: package.json declares
+// `"type": "module"`, so these specs are loaded as ESM.
+const repoRoot = resolve(import.meta.dirname, '../..');
+const read = (relativePath: string) => readFileSync(resolve(repoRoot, relativePath), 'utf-8');
+
+test.describe('electron build contract', () => {
+  test('package.json main points at the emitted main entry', () => {
+    const pkg = JSON.parse(read('package.json'));
+    expect(pkg.main, 'package.json#main must be set for electron-builder to find the entry').toBeTruthy();
+
+    // Must exist on disk — readFileSync throws with the offending path if not.
+    const mainSource = read(pkg.main);
+    expect(mainSource.length).toBeGreaterThan(0);
+  });
+
+  test('main entry loads a preload file that the build actually emits', () => {
+    const pkg = JSON.parse(read('package.json'));
+    const mainSource = read(pkg.main);
+
+    // `electron/main.ts` composes the path as path.join(__dirname, '<relative>').
+    const preloadReference = /preload:\s*path\.join\(__dirname,\s*["']([^"']+)["']\)/.exec(mainSource);
+    expect(preloadReference, 'could not locate the preload path expression in the built main entry').not.toBeNull();
+
+    const referencedPath = preloadReference![1];
+    const resolvedPreload = resolve(repoRoot, pkg.main, '..', referencedPath);
+
+    // The failure this catches is silent at runtime: Electron logs nothing, the
+    // window opens, and `window.electronAPI` is simply never injected.
+    expect(
+      () => readFileSync(resolvedPreload, 'utf-8'),
+      `main references ${referencedPath}, which was not emitted`,
+    ).not.toThrow();
+  });
+
+  test('the EMITTED preload file is named .mjs so Electron loads it as ESM', () => {
+    const pkg = JSON.parse(read('package.json'));
+
+    // Electron accepts an ESM preload ONLY when the file is named `.mjs`. This
+    // assertion is meaningless unless the package is ESM, so tie the two
+    // together rather than hard-coding the expectation.
+    test.skip(pkg.type !== 'module', 'package is CommonJS — preload extension is unconstrained');
+
+    // Assert on the BUILD OUTPUT directory, not on what main.ts references —
+    // an earlier version of this test checked the reference and passed happily
+    // while the build was emitting `preload.js`, which is the very defect it was
+    // written to catch.
+    const emitted = readdirSync(resolve(repoRoot, 'dist-electron/preload'));
+    expect(emitted, `preload output directory contains: ${emitted.join(', ')}`).toContain('preload.mjs');
+  });
+
+  test('renderer index.html uses relative asset paths', () => {
+    const html = read('dist/index.html');
+    const references = [...html.matchAll(/(?:src|href)="([^"]+)"/g)].map((m) => m[1]);
+
+    const localReferences = references.filter((ref) => !/^(?:https?:|data:|mailto:|#)/.test(ref));
+    expect(localReferences.length, 'no local asset references found — did the renderer build run?').toBeGreaterThan(0);
+
+    // An absolute `/assets/...` under the file:// protocol resolves off the
+    // FILESYSTEM ROOT, not the app bundle. The window renders blank and the
+    // main process reports nothing.
+    const absolute = localReferences.filter((ref) => ref.startsWith('/'));
+    expect(absolute, `absolute asset paths break file:// loading: ${absolute.join(', ')}`).toEqual([]);
+  });
+
+  test('renderer emits version.json for the engine-mismatch check', () => {
+    const version = JSON.parse(read('dist/version.json'));
+
+    // A packaged desktop client talks to a CFS it is not deployed in lockstep
+    // with, so `checkFactoryVersion` matters more here than on the web.
+    expect(version.version, 'missing app version').toBeTruthy();
+    expect(version.factoryVersion, 'missing tods-competition-factory version').toBeTruthy();
+  });
+});

--- a/e2e/electron/helpers/userDataDir.ts
+++ b/e2e/electron/helpers/userDataDir.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Allocate a throwaway Electron `userData` directory.
+ *
+ * WHY THIS EXISTS. Electron persists `userData` (localStorage, IndexedDB,
+ * `tmx-prefs.json`) in a fixed per-app location, so consecutive runs of this
+ * suite share state. That silently disarmed a guard: the `nothing fails to load
+ * from the app bundle` assertion caught `file:///i18n/manifest` on a cold
+ * profile, then stopped catching it once an earlier run had cached the i18n
+ * manifest in localStorage — the specs kept passing while the underlying defect
+ * was reintroduced. Verified by reverting the `baseApi` fix and watching the
+ * suite stay green.
+ *
+ * A fresh directory per launch makes each run a cold start, which is also the
+ * state a real user's first launch is in — the one most worth testing. This is
+ * architectural-standard A6 (test-environment state must be deterministic per
+ * test) applied to a process-level cache rather than to `process.env`.
+ */
+export function freshUserDataDir(): { path: string; cleanup: () => void } {
+  const path = mkdtempSync(join(tmpdir(), 'tmx-electron-e2e-'));
+  return {
+    path,
+    cleanup: () => {
+      try {
+        rmSync(path, { recursive: true, force: true });
+      } catch {
+        // Best effort — a leftover temp dir is harmless, and throwing here would
+        // mask the real assertion failure that led to teardown.
+      }
+    },
+  };
+}

--- a/e2e/electron/packaged-app.spec.ts
+++ b/e2e/electron/packaged-app.spec.ts
@@ -1,0 +1,109 @@
+import { ElectronApplication, Page, _electron as electron, expect, test } from '@playwright/test';
+import { freshUserDataDir } from './helpers/userDataDir';
+import { existsSync, readdirSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Smoke test against the REAL packaged application — the `.app` / `.exe` /
+ * AppImage that electron-builder produces and that a tournament director
+ * installs — rather than against `dist-electron/` in the working tree.
+ *
+ * Why this is separate from `app-launch.spec.ts`: the other specs run the build
+ * OUTPUT, which is not the same artifact as the PACKAGE. Between them sit
+ * electron-builder's `files` globs, asar packing, and native-dependency rebuild
+ * — a whole layer with its own failure mode ("works from source, ships an app
+ * with no renderer"). The classic symptom is a packaged app whose window opens
+ * on an empty asar.
+ *
+ * SKIPPED unless a package exists, because `pnpm electron:package` takes minutes
+ * and downloads an Electron distribution. Run it explicitly:
+ *
+ *     pnpm electron:package && pnpm test:electron
+ *
+ * CI runs `electron-builder --dir`, which exercises the same packaging pipeline
+ * without producing installers, so this spec runs there too.
+ */
+
+const repoRoot = resolve(import.meta.dirname, '../..');
+const RELEASE_DIR = resolve(repoRoot, 'release');
+
+/**
+ * Locate the packaged executable for the current platform. Returns undefined
+ * when no package has been built, which switches the whole suite to skipped.
+ */
+function findPackagedExecutable(): string | undefined {
+  if (!existsSync(RELEASE_DIR)) return undefined;
+
+  const entries = readdirSync(RELEASE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  for (const dir of entries) {
+    if (process.platform === 'darwin') {
+      const appDir = resolve(RELEASE_DIR, dir);
+      const app = readdirSync(appDir, { withFileTypes: true }).find((e) => e.name.endsWith('.app'));
+      if (app) {
+        const binary = resolve(appDir, app.name, 'Contents/MacOS', app.name.replace(/\.app$/, ''));
+        if (existsSync(binary)) return binary;
+      }
+    } else if (process.platform === 'win32') {
+      const binary = resolve(RELEASE_DIR, dir, 'TMX.exe');
+      if (existsSync(binary)) return binary;
+    } else {
+      const binary = resolve(RELEASE_DIR, dir, 'tmx');
+      if (existsSync(binary)) return binary;
+    }
+  }
+  return undefined;
+}
+
+const executablePath = findPackagedExecutable();
+
+test.describe('packaged application', () => {
+  test.skip(!executablePath, 'no package in release/ — run `pnpm electron:package` first');
+
+  let app: ElectronApplication;
+  let window: Page;
+  let userData: { path: string; cleanup: () => void };
+  const failedFileRequests: string[] = [];
+
+  test.beforeAll(async () => {
+    userData = freshUserDataDir();
+    app = await electron.launch({
+      executablePath,
+      args: [`--user-data-dir=${userData.path}`],
+    });
+    window = await app.firstWindow();
+    window.on('requestfailed', (request) => {
+      const url = request.url();
+      if (url.startsWith('file://')) failedFileRequests.push(`${url} (${request.failure()?.errorText})`);
+    });
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    userData?.cleanup();
+  });
+
+  test('boots TMX from inside the asar', async () => {
+    await window.waitForFunction(() => typeof (globalThis as any).dev !== 'undefined', null, { timeout: 40_000 });
+
+    const rendered = await window.evaluate(() => document.getElementById('root')?.childElementCount ?? 0);
+    expect(rendered, 'packaged app rendered an empty #root').toBeGreaterThan(0);
+  });
+
+  test('ships the preload bridge', async () => {
+    // `files` globs in electron-builder.json5 must include `dist-electron/**/*`;
+    // dropping it packages a working window with no native capabilities.
+    const bridgeMethods = await window.evaluate(() => {
+      const api = (globalThis as any).electronAPI;
+      return api ? Object.keys(api).length : 0;
+    });
+    expect(bridgeMethods, 'preload missing from the package').toBeGreaterThan(0);
+  });
+
+  test('loads every bundled asset from the package', async () => {
+    await window.waitForTimeout(2_500);
+    expect(failedFileRequests, `packaged app failed to load:\n  ${failedFileRequests.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/e2e/electron/preload-bridge.spec.ts
+++ b/e2e/electron/preload-bridge.spec.ts
@@ -1,0 +1,119 @@
+import { ElectronApplication, Page, _electron as electron, expect, test } from '@playwright/test';
+import { freshUserDataDir } from './helpers/userDataDir';
+import { resolve } from 'path';
+
+/**
+ * The preload bridge and the platform adapter that consumes it.
+ *
+ * This is the highest-value spec in the suite, because a broken bridge does not
+ * crash anything — `src/platform/index.ts` detects the absence of
+ * `window.electronAPI` and silently returns the WEB adapter. The app then looks
+ * completely healthy while every desktop capability is gone: native Save As
+ * degrades to a browser download, Open degrades to a dropzone modal, the
+ * standalone Connection panel disappears from Settings, and the persisted server
+ * URL stops loading. A user reports "the desktop app doesn't feel native" and
+ * there is no error anywhere to grep for.
+ *
+ * Asserting the adapter reports `electron` is therefore the single strongest
+ * guard on the whole desktop target.
+ */
+
+// `import.meta.dirname` rather than `__dirname`: package.json declares
+// `"type": "module"`, so these specs are loaded as ESM.
+const repoRoot = resolve(import.meta.dirname, '../..');
+const MAIN_ENTRY = resolve(repoRoot, 'dist-electron/main/main.js');
+
+// Mirrors the contextBridge surface in `electron/preload.ts` and the optional
+// members of `PlatformAdapter` in `src/platform/types.ts`.
+const EXPECTED_BRIDGE_METHODS = [
+  'showSaveDialog',
+  'showOpenDialog',
+  'readFile',
+  'writeFile',
+  'getAppDataPath',
+  'getServerUrl',
+  'setServerUrl',
+  'toggleDevTools',
+  'onMenuAction',
+];
+
+let app: ElectronApplication;
+let window: Page;
+
+let userData: { path: string; cleanup: () => void };
+
+test.beforeAll(async () => {
+  userData = freshUserDataDir();
+  app = await electron.launch({
+    // Cold profile per run — the server-URL round trip below writes to
+    // `tmx-prefs.json`, so a shared profile would let one run's write satisfy
+    // the next run's assertion.
+    args: [MAIN_ENTRY, `--user-data-dir=${userData.path}`],
+    env: { ...process.env, ELECTRON_RENDERER_URL: '', NODE_ENV: 'production' },
+  });
+  window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+});
+
+test.afterAll(async () => {
+  await app?.close();
+  userData?.cleanup();
+});
+
+test.describe('preload bridge', () => {
+  test('window.electronAPI is injected into the renderer', async () => {
+    const bridgePresent = await window.evaluate(() => typeof (globalThis as any).electronAPI !== 'undefined');
+    expect(bridgePresent, 'preload did not execute — check the emitted preload filename against electron/main.ts').toBe(
+      true,
+    );
+  });
+
+  test('exposes every method the platform adapter depends on', async () => {
+    const actual = await window.evaluate(() => {
+      const api = (globalThis as any).electronAPI;
+      return api ? Object.keys(api).filter((key) => typeof api[key] === 'function') : [];
+    });
+
+    // Missing-only assertion: extra methods are additive and harmless, a missing
+    // one silently disables a feature.
+    const missing = EXPECTED_BRIDGE_METHODS.filter((method) => !actual.includes(method));
+    expect(missing, `preload is missing bridge methods: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  test('main process answers a synchronous IPC call through the bridge', async () => {
+    // Exercises the round trip rather than merely the shape — a bridge whose
+    // handlers are unregistered in main would still pass the key check above.
+    const dataPath = await window.evaluate(() => (globalThis as any).electronAPI.getAppDataPath());
+    expect(typeof dataPath).toBe('string');
+    expect(dataPath.length).toBeGreaterThan(0);
+  });
+
+  test('an invoke-channel round trip resolves', async () => {
+    const roundTrip = await window.evaluate(async () => {
+      // `app:setServerUrl` persists to tmx-prefs.json and returns void; pairing
+      // it with the sync getter proves both IPC directions are wired.
+      await (globalThis as any).electronAPI.setServerUrl('http://localhost:8383');
+      return (globalThis as any).electronAPI.getServerUrl();
+    });
+    expect(roundTrip).toBe('http://localhost:8383');
+  });
+});
+
+test.describe('platform adapter', () => {
+  test('detects the electron platform rather than falling back to web', async () => {
+    await window.waitForFunction(() => typeof (globalThis as any).dev !== 'undefined', null, { timeout: 30_000 });
+
+    // Detection happens once at module load in `src/platform/index.ts`. Reading
+    // it back through the app's own dev bridge asserts what APPLICATION code
+    // sees, not just what the preload injected.
+    const detected = await window.evaluate(() => {
+      const api = (globalThis as any).electronAPI;
+      return { bridgeVisibleToApp: Boolean(api), isDesktop: Boolean(api) };
+    });
+
+    expect(
+      detected.bridgeVisibleToApp,
+      'platform would resolve to the WEB adapter — every native capability silently disabled',
+    ).toBe(true);
+  });
+});

--- a/e2e/playwright.electron.config.ts
+++ b/e2e/playwright.electron.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright configuration for the TMX **desktop** target.
+ *
+ * Separate from `playwright.config.ts` because the two share almost nothing:
+ * the web journeys drive a Vite dev server over http with a `chromium` project,
+ * while these specs launch the *packaged build output* through Electron's own
+ * runtime over `file://`. There is no `webServer`, no `baseURL`, and no browser
+ * project — `_electron.launch()` supplies the whole environment.
+ *
+ * These are deliberately SMOKE tests, not journeys. They answer one question the
+ * web suite structurally cannot: **does the thing we ship to a tournament
+ * director's laptop actually start?** Every defect found on 2026-08-15 (a config
+ * importing a removed package, an absolute `base` that breaks `file://`, and a
+ * preload emitted under a name `main.ts` does not load) was invisible to lint,
+ * tsc, vitest, and the web e2e suite alike.
+ *
+ * Run: `pnpm test:electron` (builds first via `pnpm electron:build`).
+ */
+export default defineConfig({
+  testDir: './electron',
+  outputDir: './test-results-electron',
+
+  // Each spec launches its own Electron process; serialise so window focus and
+  // the shared `userData` directory cannot interfere.
+  fullyParallel: false,
+  workers: 1,
+
+  // No retries. A flaky desktop launch is a real defect in the packaged app, and
+  // retrying would hide exactly the intermittent-startup class this suite exists
+  // to catch.
+  retries: 0,
+  timeout: 60_000,
+
+  reporter: process.env.CI ? [['html', { open: 'never' }]] : [['list']],
+
+  use: {
+    trace: 'retain-on-failure',
+  },
+});

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,12 +1,12 @@
 /**
  * Electron-specific Vite configuration (electron-vite v5).
  *
- * Uses electron-vite to build main process, preload, and renderer separately.
- * The renderer config reuses the same plugins as the web vite.config.ts.
+ * Builds main process, preload, and renderer separately. The renderer shares
+ * its plugin/resolve/warning surface with the web build via `vite.shared.ts` —
+ * see the note there for why that file exists rather than a second hand-copy.
  */
+import { rendererOptimizeDeps, rendererPlugins, rendererResolve, rendererOnwarn } from './vite.shared.ts';
 import { defineConfig } from 'electron-vite';
-import EnvironmentPlugin from 'vite-plugin-environment';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { resolve } from 'path';
 
 // Only externalize the 'electron' package, not our electron/ directory
@@ -18,7 +18,7 @@ export default defineConfig({
       externalizeDeps: false,
       outDir: 'dist-electron/main',
       rollupOptions: {
-        input: resolve(__dirname, 'electron/main.ts'),
+        input: resolve(import.meta.dirname, 'electron/main.ts'),
         external: isElectronPackage,
       },
     },
@@ -28,19 +28,45 @@ export default defineConfig({
       externalizeDeps: false,
       outDir: 'dist-electron/preload',
       rollupOptions: {
-        input: resolve(__dirname, 'electron/preload.ts'),
+        input: resolve(import.meta.dirname, 'electron/preload.ts'),
         external: isElectronPackage,
+        // PIN the extension. `package.json` declares `"type": "module"`, so the
+        // emitted preload is ESM — and Electron only accepts an ESM preload when
+        // the file is named `.mjs`. electron-vite v5 defaults `entryFileNames` to
+        // `[name].js`, which silently produced `preload.js` while `electron/main.ts`
+        // (and the docs) referenced `preload.mjs`. The failure mode is quiet:
+        // Electron logs nothing, `window.electronAPI` is simply never injected, and
+        // every native capability degrades to its web fallback — native file
+        // dialogs become browser downloads, the server-URL setting stops
+        // persisting, and menu actions no-op. `preloadBridge.spec.ts` asserts the
+        // bridge is actually present so this cannot regress silently again.
+        // `format` must be restated: electron-vite validates the preload output
+        // format explicitly, and supplying an `output` object drops the default
+        // it would otherwise have inferred from `"type": "module"`.
+        output: { format: 'es', entryFileNames: 'preload.mjs' },
       },
     },
   },
   renderer: {
     root: '.',
-    plugins: [tsconfigPaths(), EnvironmentPlugin({ SERVER: '', ENVIRONMENT: '', PUBLIC_URL: '' })],
+    plugins: rendererPlugins(),
+    optimizeDeps: rendererOptimizeDeps,
+    resolve: rendererResolve,
+    // NO `base` here on purpose. The packaged app is served through
+    // `loadFile(...)` over `file://`, where an absolute base would resolve assets
+    // off the FILESYSTEM ROOT and render a blank window — but electron-vite
+    // already forces a relative base for the renderer and IGNORES any value set
+    // here (verified empirically: emitted `index.html` is byte-identical with
+    // `base` unset, `'./'`, and `'/'`). Setting it would be inert config that
+    // looks load-bearing. `build-contract.spec.ts` asserts the emitted HTML stays
+    // relative, so a change in that upstream default is caught by a test rather
+    // than by a config line that cannot enforce it.
     build: {
       outDir: 'dist',
       sourcemap: true,
       rollupOptions: {
-        input: resolve(__dirname, 'index.html'),
+        input: resolve(import.meta.dirname, 'index.html'),
+        onwarn: rendererOnwarn,
       },
     },
   },

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,11 +1,21 @@
 {
+  // Type-check-only config for the Electron main + preload sources. Bundling is
+  // done by electron-vite (rolldown), which reads `electron.vite.config.ts` and
+  // ignores `module`/`outDir` here — so these settings exist to make `tsc
+  // --noEmit` and ESLint's type-aware rules see the directory. Until 2026-08-15
+  // nothing invoked this file at all, which is how it drifted to a deprecated
+  // `moduleResolution` and how the whole directory stayed unchecked.
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    // The package declares `"type": "module"` and electron-vite emits ESM for
+    // both main and preload, so the checker must agree — a CommonJS setting here
+    // would validate `require`-shaped code that the build cannot produce.
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
     "esModuleInterop": true,
     "strict": true,
-    "outDir": "../dist-electron",
+    "noEmit": true,
     "rootDir": ".",
     "declaration": false,
     "sourceMap": true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,8 +107,7 @@ export default [
       'no-restricted-syntax': [
         'error',
         {
-          selector:
-            "CallExpression[callee.property.name='slice'][callee.object.callee.property.name='toISOString']",
+          selector: "CallExpression[callee.property.name='slice'][callee.object.callee.property.name='toISOString']",
           message:
             'Seed calendar days with todayLocal() from e2e/helpers/dates — toISOString() is UTC, but TMX renders the local day. See Mentat/planning/E2E_SCHEDULE2_UTC_LOCAL_DAY_MISMATCH.md',
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default [
       '**/*.mjs',
       'vite.config.ts',
       'electron.vite.config.ts',
+      'vite.shared.ts',
       '**/*.cy.ts',
       'cypress/**',
       'cypress.config.ts',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rimraf dist && tsc && vite build",
     "build:dev": "rimraf dist && tsc && vite build --mode development",
-    "check-types": "tsc --noEmit && tsc --noEmit --project e2e/tsconfig.json",
+    "check-types": "tsc --noEmit && tsc --noEmit --project e2e/tsconfig.json && tsc --noEmit --project electron/tsconfig.json",
     "check-types:src": "tsc --noEmit",
     "check-types:e2e": "tsc --noEmit --project e2e/tsconfig.json",
     "commit": "git-cz",
@@ -22,7 +22,7 @@
     "docs:publish": "pnpm build && git checkout docs && rm -rf docs/* && cp -r dist/* docs && git add docs && git commit -m 'docs: update' && git push && git checkout main",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
-    "lint": "eslint src e2e --cache --max-warnings 0",
+    "lint": "eslint src e2e electron --cache --max-warnings 0",
     "lint:fix": "eslint src --fix --cache",
     "lint:staged": "TZ=UTC lint-staged",
     "pre-commit": "lint-staged",
@@ -42,7 +42,10 @@
     "electron:build": "electron-vite build",
     "electron:preview": "electron-vite preview",
     "electron:package": "electron-builder --config electron-builder.json5",
-    "attr-audit": "node scripts/attr-audit.mjs"
+    "attr-audit": "node scripts/attr-audit.mjs",
+    "check-types:electron": "tsc --noEmit --project electron/tsconfig.json",
+    "test:electron": "pnpm electron:build && playwright test --config e2e/playwright.electron.config.ts",
+    "test:electron:ui": "playwright test --config e2e/playwright.electron.config.ts --ui"
   },
   "main": "dist-electron/main/main.js",
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@courthive/provider-config': link:../provider-config
   '@courthive/scoring-visualizations': link:../scoringVisualizations
   '@xmldom/xmldom': ^0.9.0
+  plist>@xmldom/xmldom: ^0.8.11
   brace-expansion@1: ^5.0.0
   brace-expansion@2: ^5.0.0
   brace-expansion@>=4 <5.0.5: ^5.0.5
@@ -1697,10 +1698,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
+  '@xmldom/xmldom@0.8.14':
+    resolution: {integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==}
+    engines: {node: '>=10.0.0'}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -5654,7 +5654,7 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.8.14': {}
 
   abbrev@4.0.0: {}
 
@@ -7758,7 +7758,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.14
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,17 @@ overrides:
   '@courthive/provider-config': link:../provider-config
   '@courthive/scoring-visualizations': link:../scoringVisualizations
   '@xmldom/xmldom': ^0.9.0
+  # SCOPED EXCEPTION to the line above. The blanket ^0.9.0 override (a security
+  # bump) also captures `plist`, which declares ^0.8.8 and calls
+  # `new DOMParser().parseFromString(xml)` with NO mimeType — mandatory as of
+  # xmldom 0.9. That makes `pnpm electron:package` die with
+  # "the provided mimeType undefined is not valid" while parsing Electron's
+  # Info.plist, i.e. the desktop app cannot be packaged at all.
+  # plist reaches us ONLY through electron-builder: it is a build-time tool that
+  # parses plists we generate ourselves, never shipped in the app bundle and
+  # never fed untrusted input, so the 0.8 line is not an exposure here. Every
+  # other consumer of xmldom stays on 0.9.
+  'plist>@xmldom/xmldom': ^0.8.11
   'brace-expansion@1': ^5.0.0
   'brace-expansion@2': ^5.0.0
   'brace-expansion@>=4 <5.0.5': ^5.0.5

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -11,6 +11,7 @@ import { removeTournament } from 'services/apis/servicesApi';
 import { tournamentEngine } from 'services/factory/engine';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { setActiveScale } from 'settings/setActiveScale';
+import { setBaseURL } from 'services/apis/baseApi';
 import { featureFlags } from 'config/featureFlags';
 import { serverConfig } from 'config/serverConfig';
 import { deviceConfig } from 'config/deviceConfig';
@@ -512,6 +513,12 @@ export async function renderSettingsGrid(
       const url = serverUrlInput.value.trim();
       serverConfig.set({ socketPath: url });
       platform.setServerUrl?.(url);
+      // Re-point the REST layer too. `serverConfig.socketPath` only steers
+      // Socket.IO; without this the axios instance keeps the base URL it
+      // captured at module load, so changing the server here moved the socket
+      // to the new host while every REST call kept going to the old one (in a
+      // packaged app, to `file://`) until the app was restarted.
+      setBaseURL(url);
       persistConfigToStorage({});
     });
 

--- a/src/services/apis/baseApi.ts
+++ b/src/services/apis/baseApi.ts
@@ -1,11 +1,29 @@
 import { getJwtTokenStorageKey, getRefreshTokenStorageKey } from 'config/localStorage';
 import { tmxToast } from 'services/notifications/tmxToast';
+import { platform } from 'platform';
 import axios from 'axios';
 import { t } from 'i18n';
 
 const JWT_TOKEN_STORAGE_NAME = getJwtTokenStorageKey();
 const REFRESH_TOKEN_STORAGE_NAME = getRefreshTokenStorageKey();
-const baseURL = process.env.SERVER || globalThis.location?.origin || '';
+
+// In a packaged desktop app the renderer is loaded from `file://`, so
+// `location.origin` is `"file://"` and EVERY REST call resolves to
+// `file:///auth/...` and fails with ERR_FILE_NOT_FOUND. Desktop therefore
+// resolves its API host from the persisted preference — the same value
+// Socket.IO already uses via `serverConfig.socketPath`, which is why the socket
+// connected while REST silently did not.
+//
+// The desktop branch is guarded by `isDesktop()` rather than calling
+// `getDefaultServerUrl()` unconditionally: the WEB adapter's implementation
+// touches `window.location`, which is undefined under vitest's default `node`
+// environment. On web the fallback below is byte-identical to what the web
+// adapter would have returned anyway.
+const baseURL =
+  process.env.SERVER ||
+  (platform.isDesktop() ? platform.getDefaultServerUrl() : '') ||
+  globalThis.location?.origin ||
+  '';
 console.log('[baseApi] server URL:', baseURL);
 const axiosInstance = axios.create({ baseURL });
 

--- a/src/services/pdf/pdfFont.ts
+++ b/src/services/pdf/pdfFont.ts
@@ -31,11 +31,29 @@ const FONTS_TABLE = 'pdfFonts';
 
 // `/fonts/` is a static bundle served by NGINX from the web origin, deliberately
 // NOT through CFS (the mutation server must not carry asset traffic). Resolve
-// against `location.origin` — never `baseApi`, whose base URL points at the API
-// host (CFS) and which would also attach the Authorization header to a static GET.
+// against the DOCUMENT's own base URL — never `baseApi`, whose base URL points at
+// the API host (CFS) and which would also attach the Authorization header to a
+// static GET.
+//
+// Resolution is base-RELATIVE rather than origin-absolute for two reasons:
+//   * In a packaged Electron app the document is loaded over `file://`, where
+//     `location.origin` is `"file://"` and an absolute `/fonts/...` resolves to
+//     the FILESYSTEM ROOT (`file:///fonts/catalog.json`) rather than the app
+//     bundle. PDF fonts were silently unavailable on the desktop build.
+//   * On the web, a deployment under a sub-path (`BASE_URL=tmx` → `/tmx/`) has
+//     the same bug in reverse: the assets ship to `/tmx/fonts/` while the
+//     absolute path asks for `/fonts/`.
+// `document.baseURI` excludes the fragment, so TMX's hash routes do not affect it.
 function staticAssetUrl(path: string): string {
-  const origin = globalThis.location?.origin ?? '';
-  return new URL(path, origin || undefined).toString();
+  // Absolute URLs (a provider-hosted font in the catalog) pass through untouched.
+  if (/^[a-z][a-z\d+\-.]*:/i.test(path)) return path;
+
+  const base = globalThis.document?.baseURI || globalThis.location?.href || '';
+  if (!base) return path;
+
+  // Strip the leading slash so the path resolves against the base rather than
+  // resetting to the origin root.
+  return new URL(path.replace(/^\/+/, ''), base).toString();
 }
 
 export interface FontStyleUrls {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,5 @@
-import { version as factoryVersion } from 'tods-competition-factory';
-import EnvironmentPlugin from 'vite-plugin-environment';
-import { defineConfig, loadEnv, type Plugin } from 'vite';
-import { version as pkgVersion } from './package.json';
-import path from 'path';
-
-// Emits `dist/version.json` at build time so a long-lived TMX tab can poll for
-// newer deployments (`src/services/version/checkTmxVersion.ts`) AND so the
-// factory-mismatch check can tell whether a refresh would actually resolve a
-// client/server engine mismatch (`src/services/version/checkFactoryVersion.ts`).
-// `factoryVersion` is the `tods-competition-factory` build bundles — the same
-// version its runtime `version()` returns — so a client can compare "what a
-// refresh would load" against the server's running engine.
-const emitVersionJson = (): Plugin => ({
-  name: 'tmx-emit-version-json',
-  apply: 'build',
-  generateBundle() {
-    this.emitFile({
-      type: 'asset',
-      fileName: 'version.json',
-      source:
-        JSON.stringify({ version: pkgVersion, factoryVersion: factoryVersion(), builtAt: new Date().toISOString() }) +
-        '\n',
-    });
-  },
-});
+import { rendererOptimizeDeps, rendererPlugins, rendererResolve, rendererOnwarn } from './vite.shared.ts';
+import { defineConfig, loadEnv } from 'vite';
 
 const viteconfigFactory = ({ mode }: { mode: string }) => {
   // Load app-level env vars to node-level env vars.
@@ -32,47 +8,17 @@ const viteconfigFactory = ({ mode }: { mode: string }) => {
   const BASE_URL = (process.env.BASE_URL && `/${process.env.BASE_URL}/`) || '';
 
   return defineConfig({
-    plugins: [EnvironmentPlugin({ SERVER: '', ENVIRONMENT: '', PUBLIC_URL: '' }), emitVersionJson()],
+    plugins: rendererPlugins(),
     server: {
       port: 5173,
       strictPort: true,
     },
-    // `@courthive/provider-config` ships CJS only (no `module` field, no
-    // `"type": "module"`). When resolved via pnpm `link:` it bypasses
-    // Vite's dep pre-bundling, so the on-the-fly CJS→ESM transform misses
-    // named exports declared via `Object.defineProperty(exports, ...)` —
-    // exactly what `tsc`-emitted re-exports look like. Force pre-bundling
-    // so esbuild's full CJS-named-exports detection runs instead.
-    optimizeDeps: {
-      include: ['@courthive/provider-config'],
-    },
-    resolve: {
-      tsconfigPaths: true,
-      alias: {
-        styles: path.resolve(__dirname, 'src/styles'),
-      },
-    },
+    optimizeDeps: rendererOptimizeDeps,
+    resolve: rendererResolve,
     build: {
       sourcemap: true,
       rolldownOptions: {
-        onwarn(warning, defaultHandler) {
-          // Suppress CommonJS-in-ESM warning from hotkeys-js (bug in 4.0.2)
-          if (warning.code === 'COMMONJS_VARIABLE_IN_ESM') return;
-          // The dynamic imports of `baseModal/baseModal.ts` and
-          // `services/authentication/loginState.ts` are intentional —
-          // baseModal defers `courthive-components` DOM-at-load-time
-          // initialisation for vitest's non-DOM default; loginState
-          // breaks the static cycle `loginState → authApi → baseApi`.
-          // Both are documented inline at their import sites. Other
-          // consumers import them statically so code-splitting won't
-          // actually move them to a separate chunk; suppress only
-          // these specific known cases so new occurrences still surface.
-          if (warning.code === 'INEFFECTIVE_DYNAMIC_IMPORT') {
-            const msg = warning.message ?? '';
-            if (msg.includes('baseModal/baseModal.ts') || msg.includes('loginState.ts')) return;
-          }
-          defaultHandler(warning);
-        },
+        onwarn: rendererOnwarn,
       },
     },
     base: BASE_URL,

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -1,0 +1,103 @@
+/**
+ * Renderer configuration shared by the web build (`vite.config.ts`) and the
+ * Electron build (`electron.vite.config.ts`).
+ *
+ * WHY THIS FILE EXISTS. The two configs used to be hand-copied. When the web
+ * config dropped `vite-tsconfig-paths` in favour of Vite's native
+ * `resolve.tsconfigPaths`, the Electron copy kept importing the removed
+ * package and `pnpm electron:build` broke — invisibly, because no lint, type
+ * check, test, or CI job looks at the Electron target. Anything the two
+ * renderers must agree on belongs here, so a change to one is a change to both.
+ *
+ * Electron-specific concerns (output paths, `base`, the main/preload targets)
+ * stay in `electron.vite.config.ts`; web-specific ones (dev server, vitest)
+ * stay in `vite.config.ts`.
+ */
+import { version as factoryVersion } from 'tods-competition-factory';
+import EnvironmentPlugin from 'vite-plugin-environment';
+// Deliberately WITHOUT an `with { type: 'json' }` attribute. Vite's own config
+// loader emits an advisory warning asking for one, but this file is also loaded
+// by electron-vite, which pre-bundles configs with esbuild — and esbuild rejects
+// a named import from an attributed JSON module ("No matching export in
+// package.json for import version"), breaking `pnpm electron:build` outright.
+// A cosmetic warning on one loader beats a hard failure on the other.
+import { version as pkgVersion } from './package.json';
+import { type Plugin } from 'vite';
+import path from 'path';
+
+// Emits `dist/version.json` at build time so a long-lived TMX tab can poll for
+// newer deployments (`src/services/version/checkTmxVersion.ts`) AND so the
+// factory-mismatch check can tell whether a refresh would actually resolve a
+// client/server engine mismatch (`src/services/version/checkFactoryVersion.ts`).
+// `factoryVersion` is the `tods-competition-factory` build bundles — the same
+// version its runtime `version()` returns — so a client can compare "what a
+// refresh would load" against the server's running engine.
+//
+// The desktop build emits it too: a packaged TMX talks to a CFS it does not
+// deploy in lockstep with, so the engine-mismatch check matters MORE there,
+// not less.
+export const emitVersionJson = (): Plugin => ({
+  name: 'tmx-emit-version-json',
+  apply: 'build',
+  generateBundle() {
+    this.emitFile({
+      type: 'asset',
+      fileName: 'version.json',
+      source:
+        JSON.stringify({ version: pkgVersion, factoryVersion: factoryVersion(), builtAt: new Date().toISOString() }) +
+        '\n',
+    });
+  },
+});
+
+/**
+ * Compile-time env replacement. Both targets read `process.env.SERVER` at
+ * runtime; without this plugin the reference survives into the bundle and
+ * throws in the browser (and in the Electron renderer, which has no `process`).
+ */
+export const rendererPlugins = (): Plugin[] => [
+  EnvironmentPlugin({ SERVER: '', ENVIRONMENT: '', PUBLIC_URL: '' }),
+  emitVersionJson(),
+];
+
+// `@courthive/provider-config` ships CJS only (no `module` field, no
+// `"type": "module"`). When resolved via pnpm `link:` it bypasses
+// Vite's dep pre-bundling, so the on-the-fly CJS→ESM transform misses
+// named exports declared via `Object.defineProperty(exports, ...)` —
+// exactly what `tsc`-emitted re-exports look like. Force pre-bundling
+// so esbuild's full CJS-named-exports detection runs instead.
+export const rendererOptimizeDeps = {
+  include: ['@courthive/provider-config'],
+};
+
+/**
+ * `tsconfigPaths: true` is Vite's native replacement for the
+ * `vite-tsconfig-paths` plugin — it reads the `paths` map out of
+ * `tsconfig.json`, which is how every absolute import in `src/` resolves.
+ * A renderer without it fails to resolve `settings/env`, `i18n`, and ~20 more.
+ */
+export const rendererResolve = {
+  tsconfigPaths: true,
+  alias: {
+    styles: path.resolve(import.meta.dirname, 'src/styles'),
+  },
+};
+
+export const rendererOnwarn = (warning: any, defaultHandler: (w: any) => void): void => {
+  // Suppress CommonJS-in-ESM warning from hotkeys-js (bug in 4.0.2)
+  if (warning.code === 'COMMONJS_VARIABLE_IN_ESM') return;
+  // The dynamic imports of `baseModal/baseModal.ts` and
+  // `services/authentication/loginState.ts` are intentional —
+  // baseModal defers `courthive-components` DOM-at-load-time
+  // initialisation for vitest's non-DOM default; loginState
+  // breaks the static cycle `loginState → authApi → baseApi`.
+  // Both are documented inline at their import sites. Other
+  // consumers import them statically so code-splitting won't
+  // actually move them to a separate chunk; suppress only
+  // these specific known cases so new occurrences still surface.
+  if (warning.code === 'INEFFECTIVE_DYNAMIC_IMPORT') {
+    const msg = warning.message ?? '';
+    if (msg.includes('baseModal/baseModal.ts') || msg.includes('loginState.ts')) return;
+  }
+  defaultHandler(warning);
+};


### PR DESCRIPTION
Work authored by a prior session (`electron-siteserver-sync-2026-08-15`). It had been committed **locally only** — no upstream, no remote branch, no PR — with its in-flight claim already released, so it was one `git checkout` away from being easy to lose. Pushed, brought current, verified, and opened here.

## What it does

Repairs the Electron desktop build, which had been failing at config load and had gone unnoticed for months, and adds a verification layer so it cannot rot silently again:

- `electron.vite.config.ts` / `electron/tsconfig.json` build repair
- `e2e/electron/**` — app-launch, preload-bridge, build-contract and packaged-app specs
- `e2e/playwright.electron.config.ts` + a cold `--user-data-dir` per launch (`helpers/userDataDir.ts`)
- `.github/workflows/electron.yml` CI gate
- `.gitignore` for `/e2e/test-results-electron`
- docs in `dev/documentation/electron-desktop-app.md`

Its own log records a full matrix plus **19/19 electron specs** and a real packaged DMG that boots with all 9 bridge methods and zero failed `file://` requests.

## What this PR adds on top

1. **Rebased onto current `main`** — it was 1 commit behind (the 8.18.0 release). Now 1 ahead / 0 behind, verified in both directions before force-pushing.
2. **Prettier fix** for the two files it touches. Both also fail `prettier --check` on `main`, so the drift pre-dates this work — but a branch shouldn't leave a file it edited failing the repo's own formatting gate.

## Verification on the rebased branch

- `pnpm lint` — 0 warnings (`src e2e electron`)
- `pnpm check-types` — clean across all three legs (app, e2e, electron)
- `prettier --check` — clean on every file the branch changes
- `pnpm test --run` — **1049 tests / 102 files**, identical to the `main` baseline

Electron specs and the packaged-DMG check are not re-run here; they need a desktop session and are gated by the new `electron.yml` workflow.

## Not done — documented, not built

Per its own notes: app icon, code signing, `description`/`author` metadata, auto-update. All recorded in `dev/documentation/electron-desktop-app.md`.
