### PR TITLE
feat(publishing): request cache warming when a draw is released

### DIFF
--- a/src/services/mutation/mutationRequest.ts
+++ b/src/services/mutation/mutationRequest.ts
@@ -31,6 +31,13 @@ interface MutationParams {
   methods: MutationMethod[];
   engine?: string;
   callback?: (result: ExecutionResult) => void;
+  /**
+   * Ask the server to re-seed the per-event payloads this mutation evicts, so the first public
+   * reader does not pay a cache miss. Set it when a reader is imminent — releasing a draw — and
+   * leave it off otherwise, because building the payload is the cost the default path avoids.
+   * Server-side only; the factory never sees it.
+   */
+  warmCache?: boolean;
 }
 
 // ── Pure helpers (testable without DOM) ──
@@ -76,7 +83,7 @@ export async function mutationRequest(params: MutationParams): Promise<void> {
   }
   resetActivityTimer();
 
-  const { tournamentRecord, methods, engine = TOURNAMENT_ENGINE, callback } = params;
+  const { tournamentRecord, methods, engine = TOURNAMENT_ENGINE, callback, warmCache } = params;
   const state = getLoginState();
 
   const completion = (result?: any): void => {
@@ -118,7 +125,7 @@ export async function mutationRequest(params: MutationParams): Promise<void> {
   });
 
   const mutate = (saveLocal?: boolean) =>
-    makeMutation({ offline, methods, factoryEngine, tournamentIds, completion, saveLocal });
+    makeMutation({ offline, methods, factoryEngine, tournamentIds, completion, saveLocal, warmCache });
   if (!inDateRange) {
     queryDateRange({ state, providerIds, mutate });
     return;
@@ -233,6 +240,7 @@ async function makeMutation({
   factoryEngine,
   tournamentIds,
   saveLocal,
+  warmCache,
 }: {
   offline: any;
   methods: any[];
@@ -240,6 +248,7 @@ async function makeMutation({
   factoryEngine: any;
   tournamentIds: string[];
   saveLocal?: boolean;
+  warmCache?: boolean;
 }): Promise<void> {
   const hasProvider = !!factoryEngine.getTournament().tournamentRecord?.parentOrganisation?.organisationId;
   const resolvedMethods = applyDevOverrides(methods, window['dev']?.params);
@@ -283,7 +292,10 @@ async function makeMutation({
     };
     if (debugConfig.get().log?.verbose) console.log('%c invoking remote', 'color: lightblue');
     emitTmx({
-      data: { type: 'executionQueue', payload: { methods: resolvedMethods, tournamentIds, rollbackOnError: true } },
+      data: {
+        type: 'executionQueue',
+        payload: { methods: resolvedMethods, tournamentIds, rollbackOnError: true, warmCache },
+      },
       ackCallback,
     });
     if (strategy === LOCAL_FIRST) {
@@ -301,7 +313,7 @@ async function makeMutation({
         if (!isSessionValid()) {
           reportSessionLost({
             source: 'mutation-timeout',
-            retry: () => replayServerMutation({ methods, factoryEngine, tournamentIds, saveLocal }),
+            retry: () => replayServerMutation({ methods, factoryEngine, tournamentIds, saveLocal, warmCache }),
           });
           return completion({ error: { message: 'Session expired', code: 'SESSION_EXPIRED' } });
         }
@@ -329,11 +341,13 @@ export function replayServerMutation({
   factoryEngine,
   tournamentIds,
   saveLocal,
+  warmCache,
 }: {
   methods: any[];
   factoryEngine: any;
   tournamentIds: string[];
   saveLocal?: boolean;
+  warmCache?: boolean;
 }): void {
   const ackCallback = (ack: any) => {
     const missingTournament = ack?.error?.code === 'ERR_MISSING_TOURNAMENT';
@@ -345,7 +359,7 @@ export function replayServerMutation({
     void localSave(saveLocal || missingTournament);
   };
   emitTmx({
-    data: { type: 'executionQueue', payload: { methods, tournamentIds, rollbackOnError: true } },
+    data: { type: 'executionQueue', payload: { methods, tournamentIds, rollbackOnError: true, warmCache } },
     ackCallback,
   });
 }

--- a/src/services/publishing/toggleDrawPublishState.ts
+++ b/src/services/publishing/toggleDrawPublishState.ts
@@ -37,5 +37,8 @@ export const toggleDrawPublishState = (eventRow) => (_, cell) => {
       logMutationError('toggleDrawPublishState', result);
     }
   };
-  mutationRequest({ methods, callback: postMutation });
+  // Both directions use PUBLISH_EVENT here (drawIdsToAdd vs drawIdsToRemove), so the publish
+  // signal is which list is populated — warm only when a draw is being ADDED, since that is the
+  // moment a public reader is imminent.
+  mutationRequest({ methods, callback: postMutation, warmCache: !!drawIdsToAdd });
 };

--- a/src/services/publishing/toggleEventPublishState.ts
+++ b/src/services/publishing/toggleEventPublishState.ts
@@ -32,5 +32,7 @@ export const toggleEventPublishState = (nestedTables) => (_, cell) => {
       logMutationError('toggleEventPublishState', result);
     }
   };
-  mutationRequest({ methods, callback: postMutation });
+  // Warm only on PUBLISH: releasing a draw is the moment a public reader is imminent, so seeding
+  // the event payload saves them the cache miss. Unpublishing has no reader to serve.
+  mutationRequest({ methods, callback: postMutation, warmCache: method === PUBLISH_EVENT });
 };

--- a/src/services/publishing/togglePublishWarmCache.test.ts
+++ b/src/services/publishing/togglePublishWarmCache.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mutationRequest = vi.fn();
+vi.mock('services/mutation/mutationRequest', () => ({ mutationRequest: (args: any) => mutationRequest(args) }));
+vi.mock('functions/logMutationError', () => ({ logMutationError: vi.fn() }));
+vi.mock('services/factory/engine', () => ({
+  tournamentEngine: { q: { publishState: () => ({ status: { published: true } }) } },
+}));
+vi.mock('constants/mutationConstants', () => ({
+  PUBLISH_EVENT: 'publishEvent',
+  UNPUBLISH_EVENT: 'unPublishEvent',
+}));
+
+import { toggleEventPublishState } from './toggleEventPublishState';
+import { toggleDrawPublishState } from './toggleDrawPublishState';
+
+/**
+ * `warmCache` asks the server to rebuild the event payload so the first public reader after a draw
+ * release does not pay a cache miss. It is opt-in precisely because that rebuild is expensive
+ * (~92ms for a Grand-Slam-shaped tournament's five events), so it must be sent ONLY when a reader is
+ * actually imminent — publishing. Sending it on unpublish would pay the cost for nobody.
+ */
+describe('publish toggles set warmCache only when releasing', () => {
+  const cellFor = (rowData: any) => ({
+    getRow: () => ({ getData: () => rowData, update: vi.fn() }),
+  });
+
+  beforeEach(() => mutationRequest.mockClear());
+
+  describe('toggleEventPublishState', () => {
+    const nestedTables = new Map([['e1', { getRows: () => [] }]]);
+
+    it('warms when publishing an unpublished event', () => {
+      toggleEventPublishState(nestedTables)(null, cellFor({ eventId: 'e1', published: false }));
+
+      const args = mutationRequest.mock.calls[0][0];
+      expect(args.methods[0].method).toBe('publishEvent');
+      expect(args.warmCache).toBe(true);
+    });
+
+    it('does NOT warm when unpublishing', () => {
+      toggleEventPublishState(nestedTables)(null, cellFor({ eventId: 'e1', published: true }));
+
+      const args = mutationRequest.mock.calls[0][0];
+      expect(args.methods[0].method).toBe('unPublishEvent');
+      expect(args.warmCache).toBe(false);
+    });
+  });
+
+  describe('toggleDrawPublishState', () => {
+    // Both directions use PUBLISH_EVENT here, so the signal is drawIdsToAdd vs drawIdsToRemove —
+    // the method name alone cannot distinguish them.
+    const eventRow = { getData: () => ({ eventId: 'e1' }), update: vi.fn() };
+
+    it('warms when adding a draw to the published set', () => {
+      toggleDrawPublishState(eventRow)(null, cellFor({ eventId: 'e1', drawId: 'd1', published: false }));
+
+      const args = mutationRequest.mock.calls[0][0];
+      expect(args.methods[0].params.drawIdsToAdd).toEqual(['d1']);
+      expect(args.warmCache).toBe(true);
+    });
+
+    it('does NOT warm when removing a draw', () => {
+      toggleDrawPublishState(eventRow)(null, cellFor({ eventId: 'e1', drawId: 'd1', published: true }));
+
+      const args = mutationRequest.mock.calls[0][0];
+      expect(args.methods[0].params.drawIdsToRemove).toEqual(['d1']);
+      expect(args.warmCache).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Publishing a draw is the moment a public reader is imminent, so ask the server to re-seed the event payload rather than leaving the first viewer to pay a cache miss.

## What

- optional `warmCache` on `mutationRequest`, threaded into **both** `executionQueue` emit sites — including the retry path, so a replayed mutation warms too
- `toggleEventPublishState` warms on `publishEvent`, not on `unPublishEvent`
- `toggleDrawPublishState` warms on `drawIdsToAdd` — both directions use `publishEvent` there, so the method name cannot distinguish them

## Why opt-in

Rebuilding the payload costs **~92 ms** for a Grand-Slam-shaped tournament's five events (measured with `Mentat/tools/slam-scale-bench`). It is sent only when a reader is actually arriving. Unpublishing has no reader to serve.

Server-side only — the factory never sees the flag.

## ⚠️ Depends on CFS #897

Without it, `warmCache` is read on the HTTP path but **not** the WebSocket path TMX uses, so this would be inert. Merge CFS #897 first.

## Verification

- lint 0, types 0
- `TZ=UTC vitest` — **104 files / 1064 tests** pass
- new `togglePublishWarmCache.test.ts` covers all four cases, and **both directions were falsified**: forcing warm-always fails the two 'does NOT warm' tests, forcing warm-never fails the two 'warms' tests