### PR TITLE
feat(participants): let a GROUP carry a participantRole

### DIFF
--- a/src/components/tables/participantsTable/getGroupingsColumns.ts
+++ b/src/components/tables/participantsTable/getGroupingsColumns.ts
@@ -6,7 +6,7 @@ import { toggleOpenClose, openClose } from '../common/formatters/openClose';
 import { eventsFormatter } from '../common/formatters/eventsFormatter';
 import { participantActions } from '../../popovers/participantActions';
 import { teamProfileModal } from '../../modals/teamProfileModal';
-import { participantConstants } from 'tods-competition-factory';
+import { participantConstants, participantRoles } from 'tods-competition-factory';
 import { navigateToEvent } from '../common/navigateToEvent';
 import { threeDots } from '../common/formatters/threeDots';
 import { headerMenu } from '../common/headerMenu';
@@ -15,6 +15,7 @@ import { CENTER, IS_OPEN, LEFT, RIGHT } from 'constants/tmxConstants';
 import { t } from 'i18n';
 
 const { GROUP, TEAM } = participantConstants;
+const { OTHER } = participantRoles;
 
 export function getGroupingsColumns({
   view,
@@ -79,6 +80,23 @@ export function getGroupingsColumns({
       title: t('tables.groupings.name'),
       minWidth: 200,
       widthGrow: 1,
+    },
+    {
+      // GROUP only. A group's role is what escalates a SHARED_GROUPING conflict from WARN to BLOCK, so a
+      // TD needs to see at a glance which groups carry a blocking relationship. OTHER is the neutral
+      // default and is left blank rather than rendered as a badge, so only meaningful roles draw the eye.
+      formatter: (cell: any) => {
+        const role = cell.getValue();
+        return role && role !== OTHER ? `<span class="tmx-role-badge">${role}</span>` : '';
+      },
+      title: t('pages.participants.groupRole'),
+      visible: view === GROUP,
+      field: 'participantRole',
+      headerHozAlign: CENTER,
+      hozAlign: CENTER,
+      headerSort: true,
+      minWidth: 110,
+      editor: false,
     },
     {
       sorter: (a: any, b: any) => a?.[0]?.eventName?.localeCompare(b?.[0]?.eventName, undefined, { numeric: true }),

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -18,6 +18,7 @@ export const REMOVE_MATCHUP_TIMEKEEPER = 'removeMatchUpTimekeeper';
 export const ADD_MATCHUP_SCHEDULE_ITEMS = 'addMatchUpScheduleItems';
 export const ADD_ONLINE_RESOURCE = 'addOnlineResource';
 export const ADD_PARTICIPANTS = 'addParticipants';
+export const CREATE_GROUP_PARTICIPANT = 'createGroupParticipant';
 export const ADD_PARTICIPANT_TIME_ITEM = 'addParticipantTimeItem';
 
 export const ATTACH_CONSOLATION_STRUCTURES = 'attachConsolationStructures';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2146,7 +2146,8 @@
         "male": "Male",
         "female": "Female",
         "unknown": "Unknown"
-      }
+      },
+      "groupRole": "Group role"
     }
   },
   "overlays": {
@@ -2300,5 +2301,12 @@
   },
   "officiating": {
     "conflictWarning": "This official has a potential conflict of interest with a participant in this match. Assign anyway?"
+  },
+  "participantRoles": {
+    "OTHER": "Other",
+    "COACH": "Coach",
+    "MEDICAL": "Medical",
+    "PHYSIO": "Physio",
+    "TRAINER": "Trainer"
   }
 }

--- a/src/pages/tournament/tabs/participantTab/editGroupingParticipant.test.ts
+++ b/src/pages/tournament/tabs/participantTab/editGroupingParticipant.test.ts
@@ -1,0 +1,141 @@
+/**
+ * GROUP participantRole surface.
+ *
+ * Before this, `editGroupingParticipant` hardcoded `participantType === TEAM ? COMPETITOR : OTHER`, so
+ * every GROUP a TD could create landed as OTHER — the one value that falls through
+ * `ConflictRule.roleSeverity` to base severity. The COACH/MEDICAL/PHYSIO/TRAINER → BLOCK escalation in
+ * factory 6.26.0 was therefore unreachable from the UI, and `SHARED_GROUPING` could only ever WARN.
+ *
+ * These assert the dispatched params, since that is where the bug lived. The final block is the
+ * end-to-end proof: a COACH group actually produces `blocked: true` from the factory.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mutationRequestMock } = vi.hoisted(() => ({ mutationRequestMock: vi.fn() }));
+const { drawerOpenMock } = vi.hoisted(() => ({ drawerOpenMock: vi.fn() }));
+const { renderFormMock } = vi.hoisted(() => ({ renderFormMock: vi.fn() }));
+const { renderButtonsMock } = vi.hoisted(() => ({ renderButtonsMock: vi.fn() }));
+
+vi.mock('services/mutation/mutationRequest', () => ({ mutationRequest: mutationRequestMock }));
+vi.mock('services/context', () => ({ context: { drawer: { open: drawerOpenMock } } }));
+vi.mock('courthive-components', () => ({
+  renderForm: renderFormMock,
+  renderButtons: renderButtonsMock,
+  validators: { nameValidator: () => () => true },
+}));
+
+import { editGroupingParticipant } from './editGroupingParticipant';
+import { participantConstants, participantRoles } from 'tods-competition-factory';
+
+const { COACH, COMPETITOR, OTHER } = participantRoles;
+const { GROUP, TEAM } = participantConstants;
+const TEAM_ALPHA = 'Team Alpha';
+
+/** Drive the drawer: render the form, then invoke Save. */
+function openAndSave(args: any, inputs: Record<string, any>) {
+  renderFormMock.mockReturnValue(inputs);
+  editGroupingParticipant(args);
+  // content() builds `inputs`; footer wiring is mocked, so call the save path via the drawer content.
+  const { content } = drawerOpenMock.mock.calls.at(-1)?.[0] ?? {};
+  // renderForm is mocked, so the element is never touched — no DOM needed (vitest here is node-env;
+  // DOM behaviour belongs in Playwright).
+  content?.({} as any);
+  return renderFormMock.mock.calls.at(-1)?.[1];
+}
+
+/** Render the drawer then click Save, returning the dispatched methods. */
+function save(args: any, inputs: Record<string, any>) {
+  openAndSave(args, inputs);
+  const { footer } = drawerOpenMock.mock.calls.at(-1)?.[0] ?? {};
+  footer?.({} as any, () => {});
+  const buttons = renderButtonsMock.mock.calls.at(-1)?.[1] ?? [];
+  buttons.find((b: any) => b.label === 'Save')?.onClick?.();
+  return mutationRequestMock.mock.calls.at(-1)?.[0]?.methods ?? [];
+}
+
+beforeEach(() => {
+  mutationRequestMock.mockReset();
+  drawerOpenMock.mockReset();
+  renderFormMock.mockReset();
+  renderButtonsMock.mockReset();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('group role field', () => {
+  it('offers a participantRole select for GROUP', () => {
+    const fields = openAndSave({ participantType: GROUP }, {});
+    const roleField = fields?.find((f: any) => f.field === 'participantRole');
+    expect(roleField).toBeDefined();
+    expect(roleField.options.map((o: any) => o.value)).toContain(COACH);
+    // OTHER is the default so an ordinary grouping behaves exactly as before this select existed.
+    expect(roleField.value).toEqual(OTHER);
+  });
+
+  it('does NOT offer the select for TEAM', () => {
+    // teamProfileModal filters rosters on participantRole === COMPETITOR; a settable TEAM role would
+    // silently break roster rendering.
+    const fields = openAndSave({ participantType: TEAM }, {});
+    expect(fields?.find((f: any) => f.field === 'participantRole')).toBeUndefined();
+  });
+
+  it('preselects an existing group role when editing', () => {
+    const fields = openAndSave(
+      { participantType: GROUP, participant: { participantId: 'g1', participantRole: COACH } },
+      {},
+    );
+    const roleField = fields?.find((f: any) => f.field === 'participantRole');
+    expect(roleField.value).toEqual(COACH);
+    expect(roleField.options.find((o: any) => o.value === COACH).selected).toBe(true);
+  });
+});
+
+describe('dispatched params — where the bug actually lived', () => {
+  it('sends the selected role when creating a GROUP', () => {
+    const methods = save(
+      { participantType: GROUP },
+      { participantName: { value: TEAM_ALPHA }, participantRole: { value: COACH } },
+    );
+    expect(methods).toHaveLength(1);
+    expect(methods[0].params.participantRole).toEqual(COACH);
+  });
+
+  it('creates a GROUP through createGroupParticipant, not the hand-built ADD_PARTICIPANTS path', () => {
+    // The factory creator validates that every member is an INDIVIDUAL in the tournament; the
+    // hand-built path skips that check.
+    const methods = save(
+      { participantType: GROUP, individualParticipantIds: ['p1', 'p2'] },
+      { participantName: { value: TEAM_ALPHA }, participantRole: { value: COACH } },
+    );
+    expect(methods[0].method).toEqual('createGroupParticipant');
+    expect(methods[0].params.groupName).toEqual(TEAM_ALPHA);
+    expect(methods[0].params.individualParticipantIds).toEqual(['p1', 'p2']);
+  });
+
+  it('defaults a GROUP to OTHER when no role is chosen', () => {
+    const methods = save({ participantType: GROUP }, { participantName: { value: 'Squad' } });
+    expect(methods[0].params.participantRole).toEqual(OTHER);
+  });
+
+  it('still pins TEAM to COMPETITOR via addParticipants', () => {
+    const methods = save({ participantType: TEAM }, { participantName: { value: 'The Team' } });
+    expect(methods[0].method).toEqual('addParticipants');
+    expect(methods[0].params.participants[0].participantRole).toEqual(COMPETITOR);
+  });
+
+  it('updates the role on an existing GROUP', () => {
+    const methods = save(
+      { participantType: GROUP, participant: { participantId: 'g1', participantRole: OTHER } },
+      { participantName: { value: TEAM_ALPHA }, participantRole: { value: COACH } },
+    );
+    expect(methods[0].method).toEqual('modifyParticipant');
+    expect(methods[0].params.participant.participantRole).toEqual(COACH);
+  });
+
+  it('does not send a participantRole when editing a TEAM', () => {
+    const methods = save(
+      { participantType: TEAM, participant: { participantId: 't1' } },
+      { participantName: { value: 'The Team' } },
+    );
+    expect(methods[0].params.participant.participantRole).toBeUndefined();
+  });
+});

--- a/src/pages/tournament/tabs/participantTab/editGroupingParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/editGroupingParticipant.ts
@@ -8,11 +8,27 @@ import { mutationRequest } from 'services/mutation/mutationRequest';
 import { isFunction } from 'functions/typeOf';
 import { context } from 'services/context';
 
-import { ADD_PARTICIPANTS, MODIFY_PARTICIPANT } from 'constants/mutationConstants';
+import { ADD_PARTICIPANTS, CREATE_GROUP_PARTICIPANT, MODIFY_PARTICIPANT } from 'constants/mutationConstants';
 import { RIGHT, SUCCESS } from 'constants/tmxConstants';
+import { t } from 'i18n';
 
-const { COMPETITOR, OTHER } = participantRoles;
-const { TEAM } = participantConstants;
+const { COACH, COMPETITOR, MEDICAL, OTHER, PHYSIO, TRAINER } = participantRoles;
+const { GROUP, TEAM } = participantConstants;
+
+/**
+ * Roles a GROUP can carry. A GROUP expresses a relationship between its members, and that relationship is
+ * what `SHARED_GROUPING` conflict-of-interest checks escalate on: the factory's bundled policies map
+ * COACH / MEDICAL / PHYSIO / TRAINER to BLOCK via `ConflictRule.roleSeverity`, while anything else — OTHER
+ * included — falls through to the rule's base severity (WARN).
+ *
+ * OTHER stays the default so an ordinary grouping behaves exactly as it did before this select existed.
+ * CAPTAIN is deliberately absent from the blocking roles in factory policy (CA, 2026-08-15); it is offered
+ * here only if it is added there, to avoid implying an escalation that would not happen.
+ *
+ * TEAM is NOT offered a role select: it is pinned to COMPETITOR because `teamProfileModal` filters rosters
+ * on `participantRole === COMPETITOR`, and `createTeamsFromAttributes` builds TEAMs the same way.
+ */
+const GROUP_ROLE_OPTIONS = [OTHER, COACH, MEDICAL, PHYSIO, TRAINER];
 
 export function editGroupingParticipant({
   individualParticipantIds,
@@ -30,10 +46,12 @@ export function editGroupingParticipant({
   table?: any;
 }): any {
   const PARTICIPANT_NAME = 'participantName';
+  const isGroup = participantType === GROUP;
   const values = {
     [PARTICIPANT_NAME]: participant?.[PARTICIPANT_NAME],
     nickname: participant?.participantOtherName || '',
     useOtherName: participant?.useOtherName ?? false,
+    participantRole: participant?.participantRole || OTHER,
   };
   let inputs: any;
 
@@ -60,6 +78,22 @@ export function editGroupingParticipant({
         label: 'Prefer nickname in draws',
         checkbox: true,
       },
+      // GROUP only — see GROUP_ROLE_OPTIONS. Hidden entirely for TEAM rather than disabled, so there is
+      // no impression that a TEAM's role is configurable.
+      ...(isGroup
+        ? [
+            {
+              options: GROUP_ROLE_OPTIONS.map((role) => ({
+                label: t(`participantRoles.${role}`, { defaultValue: role }),
+                selected: role === values.participantRole,
+                value: role,
+              })),
+              value: values.participantRole,
+              label: t('pages.participants.groupRole'),
+              field: 'participantRole',
+            },
+          ]
+        : []),
     ]);
   };
 
@@ -106,6 +140,10 @@ export function editGroupingParticipant({
     const participantOtherName = inputs.nickname?.value || undefined;
     const useOtherName = inputs.useOtherName?.checked ?? false;
 
+    // A TD discovers a relationship at least as often AFTER creating the group as before, so the role
+    // must be editable, not create-only.
+    const roleUpdate = isGroup ? { participantRole: inputs.participantRole?.value || values.participantRole } : {};
+
     const methods = [
       {
         method: MODIFY_PARTICIPANT,
@@ -115,6 +153,7 @@ export function editGroupingParticipant({
             participantOtherName,
             participantName,
             useOtherName,
+            ...roleUpdate,
           },
         },
       },
@@ -123,20 +162,40 @@ export function editGroupingParticipant({
   }
 
   function addParticipant(): void {
-    const participantRole = participantType === TEAM ? COMPETITOR : OTHER;
-    const newParticipant = {
-      individualParticipantIds: individualParticipantIds || participant?.individualParticipantIds || [],
-      participantName: inputs[PARTICIPANT_NAME]?.value,
-      participantRole,
-      participantType,
-    };
+    // TEAM is pinned to COMPETITOR; a GROUP takes the selected role, defaulting to OTHER.
+    const participantRole = participantType === TEAM ? COMPETITOR : inputs.participantRole?.value || OTHER;
+    const memberIds = individualParticipantIds || participant?.individualParticipantIds || [];
+    const participantName = inputs[PARTICIPANT_NAME]?.value;
 
-    const methods = [
-      {
-        params: { participants: [newParticipant] },
-        method: ADD_PARTICIPANTS,
-      },
-    ];
+    // GROUPs go through the factory's purpose-built creator, which validates that every member is an
+    // INDIVIDUAL in the tournament (INVALID_PARTICIPANT_TYPE otherwise). The hand-built ADD_PARTICIPANTS
+    // path skips that check, so it is kept only for TEAM where the existing behaviour is relied upon.
+    const methods = isGroup
+      ? [
+          {
+            method: CREATE_GROUP_PARTICIPANT,
+            params: {
+              individualParticipantIds: memberIds,
+              groupName: participantName,
+              participantRole,
+            },
+          },
+        ]
+      : [
+          {
+            params: {
+              participants: [
+                {
+                  individualParticipantIds: memberIds,
+                  participantName,
+                  participantRole,
+                  participantType,
+                },
+              ],
+            },
+            method: ADD_PARTICIPANTS,
+          },
+        ];
     mutationRequest({ methods, callback: postMutation });
   }
 

--- a/src/services/officiating/groupRoleEscalation.test.ts
+++ b/src/services/officiating/groupRoleEscalation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * End-to-end proof that the GROUP role escalation is reachable from what TMX can now author.
+ *
+ * Before `editGroupingParticipant` gained a role select, every GROUP a TD could create landed as OTHER —
+ * the one value that falls through `ConflictRule.roleSeverity` to the rule's base severity. So
+ * SHARED_GROUPING could only ever WARN, and anyone testing conflict blocking would have concluded it was
+ * broken. This asserts both halves of the distinction against the real factory.
+ */
+import {
+  fixtures,
+  mocksEngine,
+  participantConstants,
+  participantRoles,
+  tournamentEngine,
+} from 'tods-competition-factory';
+import { describe, expect, it } from 'vitest';
+
+const { COACH, OFFICIAL, OTHER } = participantRoles;
+const { INDIVIDUAL } = participantConstants;
+
+/** Fresh tournament each time so groups from one case cannot contaminate the other. */
+function conflictsForGroupRole(participantRole: string) {
+  const {
+    tournamentRecord,
+    drawIds: [drawId],
+  } = mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 8 }], setState: true, nonRandom: 1 });
+  const tournamentId = tournamentRecord.tournamentId;
+
+  const { participant: official }: any = tournamentEngine.addParticipant({
+    returnParticipant: true,
+    tournamentId,
+    participant: {
+      participantRole: OFFICIAL,
+      participantType: INDIVIDUAL,
+      person: { standardFamilyName: 'Umpire', standardGivenName: 'Chair' },
+    },
+  });
+
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps();
+  const matchUp = matchUps.find((m: any) => m.sides?.every((s: any) => s?.participantId));
+
+  const created: any = tournamentEngine.createGroupParticipant({
+    individualParticipantIds: [official.participantId, matchUp.sides[0].participantId],
+    groupName: `Group ${participantRole}`,
+    participantRole,
+    tournamentId,
+  });
+  expect(created.success).toEqual(true);
+
+  return (tournamentEngine as any).getMatchUpOfficialConflicts({
+    policyDefinitions: fixtures.policies.POLICY_OFFICIATING_CONFLICT_OF_INTEREST,
+    officialParticipantId: official.participantId,
+    matchUpId: matchUp.matchUpId,
+    drawId,
+  });
+}
+
+describe('GROUP participantRole drives conflict severity', () => {
+  it('a COACH group BLOCKS the official assignment', () => {
+    const result: any = conflictsForGroupRole(COACH);
+    expect(result.error).toBeUndefined();
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].groupRole).toEqual(COACH);
+    expect(result.conflicts[0].severity).toEqual('BLOCK');
+    expect(result.blocked).toBe(true);
+  });
+
+  it('an OTHER group only WARNS — the pre-fix behaviour, now the neutral default', () => {
+    const result: any = conflictsForGroupRole(OTHER);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].groupRole).toEqual(OTHER);
+    expect(result.conflicts[0].severity).toEqual('WARN');
+    expect(result.blocked).toBe(false);
+  });
+});


### PR DESCRIPTION
Makes the conflict-of-interest **BLOCK** escalation reachable. Until now it was not.

## The gap

`editGroupingParticipant.ts` hardcoded the role:

```ts
const participantRole = participantType === TEAM ? COMPETITOR : OTHER;
```

with no role input on the form. So **every GROUP a TD could create landed as `OTHER`** — precisely the value that falls through `ConflictRule.roleSeverity` to the rule's base severity. The `COACH` / `MEDICAL` / `PHYSIO` / `TRAINER` → `BLOCK` escalation shipped in factory 6.26.0 existed in both bundled policies and **could not be authored**. `SHARED_GROUPING` could only ever WARN, so anyone testing conflict blocking would reasonably have concluded it was broken.

## Changes

- **Role select on the grouping editor, GROUP only**, defaulting to `OTHER` so an ordinary grouping behaves exactly as before this existed.
- **Editable after creation**, not create-only — a TD discovers a relationship at least as often after making the group as before.
- **GROUP creation moves to `createGroupParticipant`**, the factory's purpose-built creator, which validates that every member is an INDIVIDUAL in the tournament (`INVALID_PARTICIPANT_TYPE` otherwise). The hand-built `ADD_PARTICIPANTS` path skipped that check and is kept only for TEAM, where existing behaviour is relied on.
- **Role badge on GROUP rows** so a blocking group is distinguishable at a glance. `OTHER` renders blank — only meaningful roles draw the eye.

**TEAM stays pinned to `COMPETITOR`.** `teamProfileModal` filters rosters on it and `createTeamsFromAttributes` builds TEAMs the same way, so a settable TEAM role would quietly break roster rendering. The select is hidden for TEAM rather than disabled, so there is no impression it is configurable.

## Avoidance interaction — checked, and it cuts both ways

Draw avoidance consumes groupings by **`participantType` only** (`avoidance/addParticipantGroupings.ts:24`) — there is no role filter. So:

- Setting a role **cannot regress avoidance**; the field is invisible to it.
- But a COI group **is** visible to avoidance: recording "this umpire coaches these players" makes those players share a grouping, so under a group-keyed avoidance policy they would be kept apart in the draw. Possibly desirable — but now a conscious choice rather than a surprise. `participantRole` is exactly the discriminator that would let avoidance filter relationship groups later; this creates the option without forcing it.

Separate lane, no collision: `createTeamsFromAttributes` builds **TEAM** participants with `COMPETITOR`, not GROUPs.

## Verification

Full CI-equivalent gate locally: `pnpm lint` 0 warnings, `check-types` clean on all three legs, `format:check` clean, `attr-audit --ci` exit 0, **1075 tests / 106 files** (+11 vs the 1064 baseline).

**`groupRoleEscalation.test.ts` is the proof the gap is closed** — end to end against the real factory, with a fresh tournament per case so groups cannot contaminate each other:

- a `COACH` group → `severity: BLOCK`, `blocked: true`
- an `OTHER` group → `severity: WARN`, `blocked: false`

Falsified, each red then restored: restoring the hardcoded role (the original bug); offering the select for TEAM; dropping the role from the edit path.

Unit tests assert the **dispatched params**, not just the rendered field — that is where the bug actually lived. Node-env vitest with no DOM (Playwright remains the DOM layer).

## Follow-ups

- i18n: `pages.participants.groupRole` + `participantRoles.*` in `en.json` only; other locales follow the usual sync.
- Playwright journey covering the select and the badge.
