### PR TITLE
fix(participants): render the GROUP role badge and make the role editable

### DIFF
--- a/e2e/journeys/94-official-picker-conflict-states.spec.ts
+++ b/e2e/journeys/94-official-picker-conflict-states.spec.ts
@@ -1,0 +1,281 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { createMutationCollector } from '../helpers/mutation-collector';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 94 — matchUp official picker: conflict-of-interest states.
+ *
+ * The picker annotates each candidate official before selection — none / warn / blocked — from a
+ * purely local `tournamentEngine.getMatchUpOfficialConflicts` evaluation, where the declaration is
+ * GROUP membership in the tournamentRecord itself. A GROUP's `participantRole` is what escalates
+ * SHARED_GROUPING from WARN to BLOCK.
+ *
+ * This is the only layer that can test it. TMX vitest is node-env by design, so
+ * `officialConflicts.test.ts` covers the pure classification helpers and nothing that renders:
+ * the dot, the `data-conflict` attribute, the not-selectable row, the confirm dialog, and — the part
+ * that actually matters — whether a click dispatches `addMatchUpOfficial` at all.
+ *
+ * Assertions run against the *dispatched mutation params*, not just the DOM. A picker that paints
+ * the right badge and still dispatches a blocked assignment is the failure worth catching, and it is
+ * invisible to anything that only reads the rendered row.
+ *
+ * Note the deliberate asymmetry in what the three states enforce: BLOCK refuses in the UI *and* at
+ * the factory gate (the mutation carries `policyDefinitions`, so the engine re-runs the same check);
+ * WARN only asks. The UI is an affordance — the gate is the check.
+ */
+
+const MATCHUPS = S.TOURNAMENT_MATCHUPS;
+// The picker is a hand-built `<ul>` of `<li>` rows in its own tippy. `:not(.menu-list)` keeps it
+// distinct from the three-dot action menu, which renderMenu emits as `<ul class="menu-list">` —
+// same container, same tag, different thing.
+const PICKER_ROW = '.tippy-content ul:not(.menu-list) > li';
+
+const CLEAN_OFFICIAL = 'Chair Unaffiliated';
+const WARN_OFFICIAL = 'Chair Grouped';
+const BLOCK_OFFICIAL = 'Chair Coach';
+
+interface Seeded {
+  tournamentId: string;
+  matchUpId: string;
+  /** Name of the competitor on side 1 — how the journey finds the matchUp's row in the table. */
+  sideOneName: string;
+}
+
+/**
+ * Seed a draw plus three officials whose only difference is the GROUP they share with a competitor
+ * in the target matchUp:
+ *
+ *   - CLEAN  — in no group at all                       → none
+ *   - WARN   — in an OTHER group with side 1            → WARN (shared grouping, neutral role)
+ *   - BLOCK  — in a COACH group with side 2             → BLOCK (role escalation)
+ *
+ * Each conflicted official is grouped with a *different* side so a bug that attributes a conflict to
+ * the wrong participant cannot accidentally produce the expected badge on both rows.
+ *
+ * Persisted with a single `addTournament` after all mutations so the write does not race the
+ * fire-and-forget persist inside `dev.load` (same gotcha as journeys 29 and 57).
+ */
+async function seedOfficialsWithGroupings(page: Page): Promise<Seeded> {
+  return page.evaluate(
+    async ({ cleanName, warnName, blockName }) => {
+      await dev.tmx2db.initDB();
+
+      const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'E2E Official Conflicts',
+        tournamentAttributes: { tournamentId: 'e2e-official-conflicts' },
+        participantsProfile: { scaledParticipantsCount: 16 },
+        drawProfiles: [{ eventName: 'Conflict Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      });
+      const tournamentId = tournamentRecord.tournamentId as string;
+
+      const addOfficial = (participantName: string) => {
+        const { participant }: any = dev.factory.tournamentEngine.addParticipant({
+          returnParticipant: true,
+          tournamentId,
+          participant: {
+            participantRole: dev.factory.participantRoles.OFFICIAL,
+            participantType: 'INDIVIDUAL',
+            participantName,
+            person: {
+              standardGivenName: participantName.split(' ')[0],
+              standardFamilyName: participantName.split(' ').slice(1).join(' '),
+            },
+          },
+        });
+        return participant.participantId as string;
+      };
+
+      // The clean official's id is deliberately discarded — being in no group at all is the point.
+      addOfficial(cleanName);
+      const warnId = addOfficial(warnName);
+      const blockId = addOfficial(blockName);
+
+      const { matchUps } = dev.factory.tournamentEngine.allTournamentMatchUps();
+      const matchUp = matchUps.find((m: any) => m.sides?.every((s: any) => s?.participantId));
+      if (!matchUp) throw new Error('No fully-populated matchUp in the seeded draw');
+
+      const group = (individualParticipantIds: string[], groupName: string, participantRole: string) => {
+        const created: any = dev.factory.tournamentEngine.createGroupParticipant({
+          individualParticipantIds,
+          participantRole,
+          groupName,
+          tournamentId,
+        });
+        if (!created?.success) throw new Error(`createGroupParticipant failed for ${groupName}`);
+      };
+
+      // OTHER is the neutral marker — a shared grouping with no declared relationship. WARN.
+      group([warnId, matchUp.sides[0].participantId], 'Training Squad', dev.factory.participantRoles.OTHER);
+      // COACH is an authored relationship. BLOCK.
+      group([blockId, matchUp.sides[1].participantId], 'Coaching Group', dev.factory.participantRoles.COACH);
+
+      const mutated = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+      await dev.tmx2db.addTournament(mutated);
+
+      const sideOneName = matchUp.sides[0].participant?.participantName;
+      if (!sideOneName) throw new Error('Seeded matchUp side 1 has no participantName to locate its row by');
+
+      return { tournamentId, matchUpId: matchUp.matchUpId as string, sideOneName: sideOneName as string };
+    },
+    { cleanName: CLEAN_OFFICIAL, warnName: WARN_OFFICIAL, blockName: BLOCK_OFFICIAL },
+  );
+}
+
+/**
+ * Open the target matchUp's three-dot menu and choose "Select official".
+ *
+ * The three-dot tippy is created on demand inside Tabulator's cellClick and shown in the same click,
+ * so the first click is consumed. Poll rather than assume a click count (journey 91's approach).
+ */
+async function openOfficialPicker(page: Page, sideOneName: string) {
+  const targetRow = page.locator(`${MATCHUPS} .tabulator-row`).filter({ hasText: sideOneName }).first();
+  await expect(targetRow).toBeVisible({ timeout: 10_000 });
+
+  const threeDots = targetRow.locator('.fa-ellipsis-vertical');
+  const menu = page.locator('.tippy-content .menu-list');
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (await menu.isVisible().catch(() => false)) break;
+    await threeDots.click({ force: true });
+    await page.waitForTimeout(250);
+  }
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+
+  await menu.locator('a', { hasText: 'Select official' }).click();
+  await expect(page.locator(PICKER_ROW).first()).toBeVisible({ timeout: 5_000 });
+}
+
+const pickerRow = (page: Page, name: string) => page.locator(PICKER_ROW).filter({ hasText: name });
+
+test.describe('Journey 94 — official picker conflict states', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('annotates none / warn / blocked, and only dispatches what it should', async ({ page }) => {
+    const seed = await seedOfficialsWithGroupings(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(seed.tournamentId);
+    await tournament.navigateToMatchUps();
+    await page.waitForSelector(`${MATCHUPS} .tabulator-row`, { state: 'visible', timeout: 10_000 });
+
+    await openOfficialPicker(page, seed.sideOneName);
+
+    // --- annotation -------------------------------------------------------------------------
+
+    const clean = pickerRow(page, CLEAN_OFFICIAL);
+    const warn = pickerRow(page, WARN_OFFICIAL);
+    const blocked = pickerRow(page, BLOCK_OFFICIAL);
+
+    // All three candidates are offered — the picker annotates rather than filters, so a TD can see
+    // *why* an official is unavailable instead of wondering where they went.
+    await expect(clean).toHaveCount(1);
+    await expect(warn).toHaveCount(1);
+    await expect(blocked).toHaveCount(1);
+
+    // Clean: no conflict marker at all. `data-conflict` is only set when there is something to say,
+    // so its absence is the assertion — and it also guards the seed: if the evaluation silently
+    // errored, every row would look like this one and the two below would fail.
+    await expect(clean).not.toHaveAttribute('data-conflict', /.*/);
+    await expect(clean).not.toHaveAttribute('aria-disabled', /.*/);
+
+    await expect(warn).toHaveAttribute('data-conflict', 'warn');
+    await expect(warn).not.toHaveAttribute('aria-disabled', /.*/);
+    // Reasons come from the factory already human-readable; the row lists them in its title.
+    expect((await warn.getAttribute('title')) ?? '').not.toEqual('');
+
+    await expect(blocked).toHaveAttribute('data-conflict', 'blocked');
+    await expect(blocked).toHaveAttribute('aria-disabled', 'true');
+    expect((await blocked.getAttribute('title')) ?? '').toContain('COACH');
+
+    // --- blocked: not selectable ------------------------------------------------------------
+
+    const collector = createMutationCollector(page);
+
+    // No dialog should appear for a blocked row — it is refused outright, not confirmed. Fail loudly
+    // if one does rather than letting Playwright's auto-dismiss hide a downgrade to WARN.
+    let unexpectedDialog = '';
+    const failOnDialog = (dialog: any) => {
+      unexpectedDialog = dialog.message();
+      return dialog.dismiss();
+    };
+    page.on('dialog', failOnDialog);
+
+    await blocked.click({ force: true });
+    await page.waitForTimeout(500);
+
+    expect(unexpectedDialog).toEqual('');
+    expect(collector.getMethodNames()).not.toContain('addMatchUpOfficial');
+    // The picker stays open — a refused click is not a dismissal.
+    await expect(blocked).toBeVisible();
+    page.off('dialog', failOnDialog);
+
+    // --- warn: confirm required, and declining dispatches nothing ---------------------------
+
+    const dismiss = (dialog: any) => dialog.dismiss();
+    page.on('dialog', dismiss);
+    await warn.click({ force: true });
+    await page.waitForTimeout(500);
+    expect(collector.getMethodNames()).not.toContain('addMatchUpOfficial');
+    page.off('dialog', dismiss);
+
+    // --- warn: accepting the confirm dispatches, carrying the policy ------------------------
+
+    const accept = (dialog: any) => dialog.accept();
+    page.on('dialog', accept);
+    await warn.click({ force: true });
+
+    const entry = await collector.waitForMethod('addMatchUpOfficial', 8_000);
+    page.off('dialog', accept);
+
+    const dispatched = entry.methods.find((m) => m.method === 'addMatchUpOfficial');
+    const params = dispatched?.params as Record<string, any>;
+    expect(params.matchUpId).toEqual(seed.matchUpId);
+    // The UI is an affordance; the factory gate is the enforcement point. That only holds if the
+    // mutation actually carries the policy — assert the param, not the intent.
+    expect(params.policyDefinitions).toBeTruthy();
+
+    collector.detach();
+  });
+
+  test('a clean official dispatches with no confirm at all', async ({ page }) => {
+    const seed = await seedOfficialsWithGroupings(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(seed.tournamentId);
+    await tournament.navigateToMatchUps();
+    await page.waitForSelector(`${MATCHUPS} .tabulator-row`, { state: 'visible', timeout: 10_000 });
+
+    await openOfficialPicker(page, seed.sideOneName);
+
+    const collector = createMutationCollector(page);
+    let sawDialog = false;
+    const failOnDialog = (dialog: any) => {
+      sawDialog = true;
+      return dialog.dismiss();
+    };
+    page.on('dialog', failOnDialog);
+
+    await pickerRow(page, CLEAN_OFFICIAL).click({ force: true });
+
+    const entry = await collector.waitForMethod('addMatchUpOfficial', 8_000);
+    page.off('dialog', failOnDialog);
+
+    // An unconflicted assignment must not interrogate the TD — over-prompting is what gets a
+    // conflict check switched off.
+    expect(sawDialog).toBe(false);
+
+    const params = entry.methods.find((m) => m.method === 'addMatchUpOfficial')?.params as Record<string, any>;
+    expect(params.matchUpId).toEqual(seed.matchUpId);
+    expect(params.policyDefinitions).toBeTruthy();
+
+    collector.detach();
+  });
+});

--- a/e2e/journeys/95-group-participant-role.spec.ts
+++ b/e2e/journeys/95-group-participant-role.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { createMutationCollector } from '../helpers/mutation-collector';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 95 — GROUP `participantRole`: the badge and the edit round-trip.
+ *
+ * A GROUP's role is the discriminator that escalates a SHARED_GROUPING conflict from WARN to BLOCK
+ * (journey 94 is the other half). So a TD has to be able to both *see* which groups carry a blocking
+ * relationship and *change* one when they learn about it — which is usually after the group exists.
+ *
+ * Both halves were broken when this journey was written, and both were invisible to the unit tests
+ * that already covered the surface:
+ *
+ *   - `editGroupingParticipant.test.ts` calls the editor directly, so it proved the role select exists
+ *     and dispatches correctly while nothing in the UI could open it for a GROUP: the row's three-dot
+ *     menu offered only "Delete participant".
+ *   - nothing asserted the groupings row shape, so `mapTeamParticipant` dropping `participantRole` left
+ *     the badge column reading `undefined` on every row — visible column, populated record, empty cell.
+ *
+ * The lesson each encodes: assert the real call path, not the component in isolation.
+ */
+
+const TEAMS_TABLE = S.TOURNAMENT_TEAMS;
+const ROWS = `${TEAMS_TABLE} .tabulator-row`;
+// Relative on purpose — it is chained under a row locator, where an absolute `#tournamentTeams …`
+// selector would be searched as a descendant of the row and never match.
+const ROLE_CELL = '.tabulator-cell[tabulator-field="participantRole"]';
+
+const COACH_GROUP = 'Coaching Group';
+const NEUTRAL_GROUP = 'Training Squad';
+
+/** Seed two GROUPs differing only in role: one COACH (blocking), one OTHER (the neutral default). */
+async function seedGroups(page: Page): Promise<string> {
+  return page.evaluate(
+    async ({ coachGroup, neutralGroup }) => {
+      await dev.tmx2db.initDB();
+
+      const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'E2E Group Roles',
+        tournamentAttributes: { tournamentId: 'e2e-group-roles' },
+        participantsProfile: { scaledParticipantsCount: 8 },
+        drawProfiles: [{ eventName: 'Role Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      });
+      const tournamentId = tournamentRecord.tournamentId as string;
+
+      const { participants } = dev.factory.tournamentEngine.getParticipants({
+        participantFilters: { participantTypes: ['INDIVIDUAL'] },
+      });
+      const ids = participants.map((p: any) => p.participantId);
+
+      const group = (individualParticipantIds: string[], groupName: string, participantRole: string) => {
+        const created: any = dev.factory.tournamentEngine.createGroupParticipant({
+          individualParticipantIds,
+          participantRole,
+          groupName,
+          tournamentId,
+        });
+        if (!created?.success) throw new Error(`createGroupParticipant failed for ${groupName}`);
+      };
+
+      group(ids.slice(0, 2), coachGroup, dev.factory.participantRoles.COACH);
+      group(ids.slice(2, 4), neutralGroup, dev.factory.participantRoles.OTHER);
+
+      const mutated = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+      await dev.tmx2db.addTournament(mutated);
+      return tournamentId;
+    },
+    { coachGroup: COACH_GROUP, neutralGroup: NEUTRAL_GROUP },
+  );
+}
+
+/**
+ * Navigate to the groupings table in GROUP view via the participant chips — the route the operator
+ * takes. A hard `page.goto` of the same URL reloads the SPA before the seed has rehydrated and the
+ * table renders empty.
+ */
+async function gotoGroupView(page: Page, tournamentId: string) {
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  await tournament.navigateToParticipants();
+  await page.locator('.participant-chip i.fa-users').first().click({ force: true });
+  await expect(page.locator(ROWS).first()).toBeVisible({ timeout: 10_000 });
+}
+
+const groupRow = (page: Page, name: string) => page.locator(ROWS).filter({ hasText: name }).first();
+
+/** Open a group row's three-dot menu. The tippy is created and shown inside the same cellClick, so the
+ *  first click is consumed — poll rather than assume a count (journey 91). */
+async function openRowMenu(page: Page, name: string) {
+  const threeDots = groupRow(page, name).locator('.fa-ellipsis-vertical');
+  const menu = page.locator('.tippy-content .menu-list');
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (await menu.isVisible().catch(() => false)) break;
+    await threeDots.click({ force: true });
+    await page.waitForTimeout(250);
+  }
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+  return menu;
+}
+
+test.describe('Journey 95 — GROUP participantRole badge + edit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('renders a badge for a blocking role and nothing for the neutral default', async ({ page }) => {
+    const tournamentId = await seedGroups(page);
+    await gotoGroupView(page, tournamentId);
+
+    // The role column is GROUP-only; prove it is actually on screen before reading cells, so an empty
+    // badge cannot be mistaken for a hidden column.
+    await expect(page.locator(`${TEAMS_TABLE} .tabulator-col[tabulator-field="participantRole"]`)).toBeVisible();
+
+    const coachBadge = groupRow(page, COACH_GROUP).locator('.tmx-role-badge');
+    await expect(coachBadge).toHaveCount(1);
+    await expect(coachBadge).toHaveText('COACH');
+
+    // OTHER is the neutral marker and is deliberately rendered blank rather than badged, so only
+    // meaningful roles draw the eye. Assert the absence of a badge, not the absence of text — a badge
+    // reading "OTHER" would be the regression.
+    await expect(groupRow(page, NEUTRAL_GROUP).locator('.tmx-role-badge')).toHaveCount(0);
+    expect((await groupRow(page, NEUTRAL_GROUP).locator(ROLE_CELL).innerText()).trim()).toEqual('');
+  });
+
+  test('the role is editable after creation, and the badge follows', async ({ page }) => {
+    const tournamentId = await seedGroups(page);
+    await gotoGroupView(page, tournamentId);
+
+    const menu = await openRowMenu(page, NEUTRAL_GROUP);
+    // The affordance itself is the assertion: without it the role is create-only, whatever the editor
+    // is capable of.
+    await expect(menu).toContainText('Edit group');
+    await menu.locator('a', { hasText: 'Edit group' }).click();
+
+    const drawer = page.locator(S.TMX_DRAWER);
+    const roleSelect = drawer.locator('select').last();
+    await expect(roleSelect).toBeVisible({ timeout: 5_000 });
+
+    // The select must open on the group's *current* role, not a fresh default — an editor that always
+    // reads OTHER would silently reset any group a TD opens and saves.
+    await expect(roleSelect).toHaveValue('OTHER');
+    // Every blocking role the factory policy escalates on is offered. Assert option *values*, not
+    // labels: the labels are i18n'd title case ("Coach"), while the value is the factory enum the
+    // mutation carries — asserting the label would pass against a select that submits the wrong thing.
+    const optionValues = await roleSelect.locator('option').evaluateAll((els: any[]) => els.map((el) => el.value));
+    expect(optionValues.sort((a, b) => a.localeCompare(b, 'en'))).toEqual([
+      'COACH',
+      'MEDICAL',
+      'OTHER',
+      'PHYSIO',
+      'TRAINER',
+    ]);
+
+    const collector = createMutationCollector(page);
+    await roleSelect.selectOption('MEDICAL');
+    await drawer.getByText('Save', { exact: true }).click();
+
+    // Assert the dispatched params, not just the redraw: the badge could update from a stale local
+    // refresh while the mutation carried the wrong role.
+    const entry = await collector.waitForMethod('modifyParticipant', 8_000);
+    const params = entry.methods.find((m) => m.method === 'modifyParticipant')?.params as Record<string, any>;
+    expect(params.participant.participantRole).toEqual('MEDICAL');
+    expect(params.participant.participantName).toEqual(NEUTRAL_GROUP);
+    collector.detach();
+
+    // ...and the table reflects it, which is the whole point of the badge.
+    await expect(groupRow(page, NEUTRAL_GROUP).locator('.tmx-role-badge')).toHaveText('MEDICAL', { timeout: 8_000 });
+
+    // The other group is untouched — a role edit must not smear across rows.
+    await expect(groupRow(page, COACH_GROUP).locator('.tmx-role-badge')).toHaveText('COACH');
+  });
+});

--- a/src/components/popovers/participantActions.ts
+++ b/src/components/popovers/participantActions.ts
@@ -30,6 +30,7 @@ export const participantActions =
     const { participantId, participantType } = data;
 
     const isTeam = participantType === 'TEAM';
+    const isGroup = participantType === 'GROUP';
     const isIndividual = participantType === 'INDIVIDUAL';
 
     const individualParticipant = isIndividual
@@ -67,6 +68,29 @@ export const participantActions =
               participant,
               refresh: replaceTableData,
               title: 'Rename team',
+            });
+          }
+        },
+      },
+      {
+        // GROUPs had no edit affordance at all — the row's only action was Delete. That left
+        // `editGroupingParticipant`'s role select reachable solely at creation time, and its
+        // `updateParticipant` role branch unreachable entirely, contradicting its own premise that a
+        // TD discovers a relationship at least as often after creating the group as before.
+        // `participantType: GROUP` is required: it is what makes the role select render (the TEAM
+        // default suppresses it, since a TEAM is pinned to COMPETITOR).
+        hide: !isGroup,
+        text: "<i class='fas fa-users'></i> Edit group",
+        onClick: () => {
+          const participant = tournamentEngine.getParticipants({
+            participantFilters: { participantIds: [participantId] },
+          }).participants?.[0];
+          if (participant) {
+            editGroupingParticipant({
+              participantType: 'GROUP',
+              refresh: replaceTableData,
+              title: 'Edit group',
+              participant,
             });
           }
         },

--- a/src/pages/tournament/tabs/participantTab/mapTeamParticipant.test.ts
+++ b/src/pages/tournament/tabs/participantTab/mapTeamParticipant.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The groupings table renders a GROUP's role badge from `field: 'participantRole'`, so the mapper is
+ * the load-bearing link between the record and the badge. It originally dropped the field, and the
+ * badge silently rendered nothing for every group — the column was visible, the record carried COACH,
+ * and the cell was empty. Nothing failed, because nothing asserted the row shape.
+ *
+ * This is a row-shape contract test, not a formatter test: it fails if the field stops surviving the
+ * mapping, which is the failure mode that actually happened.
+ */
+import { mapTeamParticipant } from './mapTeamParticipant';
+import { describe, expect, it } from 'vitest';
+
+const makeGroup = (overrides: any = {}) => ({
+  participantId: 'g1',
+  participantName: 'Coaching Group',
+  participantType: 'GROUP',
+  participantRole: 'COACH',
+  individualParticipantIds: ['i1', 'i2'],
+  individualParticipants: [],
+  events: [{ eventId: 'e1' }],
+  ...overrides,
+});
+
+describe('mapTeamParticipant', () => {
+  it('carries participantRole onto the row so the badge column can read it', () => {
+    let result: any = mapTeamParticipant(makeGroup(), {});
+    expect(result.participantRole).toBe('COACH');
+  });
+
+  it('leaves participantRole undefined when the record has none, rather than inventing one', () => {
+    let result: any = mapTeamParticipant(makeGroup({ participantRole: undefined }), {});
+    expect(result.participantRole).toBeUndefined();
+  });
+
+  it('still maps the fields the table already depended on', () => {
+    let result: any = mapTeamParticipant(makeGroup(), {});
+    expect(result.participantId).toBe('g1');
+    expect(result.participantName).toBe('Coaching Group');
+    expect(result.participantType).toBe('GROUP');
+    expect(result.membersCount).toBe(2);
+    expect(result.searchText).toBe('coaching group');
+  });
+});

--- a/src/pages/tournament/tabs/participantTab/mapTeamParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/mapTeamParticipant.ts
@@ -6,6 +6,7 @@ export function mapTeamParticipant(participant: any, derivedEventInfo: any): any
     individualParticipants,
     participantName,
     participantType,
+    participantRole,
     participantId,
     representing,
   } = participant;
@@ -20,6 +21,9 @@ export function mapTeamParticipant(participant: any, derivedEventInfo: any): any
     individualParticipants,
     participantName,
     participantType,
+    // The groupings table's role column reads `field: 'participantRole'`. Without it here the cell
+    // resolves to undefined and the badge silently never renders, whatever the record actually says.
+    participantRole,
     participantId,
     membersCount,
   };


### PR DESCRIPTION
Started as Playwright coverage for the officiating conflict surface (the follow-up logged in the 2026-08-16 session log). Writing it turned up two defects in the shipped GROUP `participantRole` work — both invisible to the unit tests that already covered the surface, so both are fixed here rather than encoded as expected behaviour.

## The badge could never render

`mapTeamParticipant` builds every groupings row and did not carry `participantRole`. The badge column reads `field: 'participantRole'`, so `cell.getValue()` was `undefined` on every row.

Probed in a real browser before believing it:

| check | result |
|---|---|
| role column visible in GROUP view | **yes** |
| engine record for the group | `{ name: 'Probe Coaching Group', role: 'COACH' }` |
| rendered cell | **empty** |
| `.tmx-role-badge` nodes | **0** |

Nothing asserted the row shape, so nothing failed.

## A group's role was create-only

The GROUP row's three-dot menu contained exactly one item: `Delete participant`. The edit item is gated `hide: !isTeam`, and that call omits `participantType`, so it defaults to `TEAM` — which would suppress the role select even if the item were shown.

That makes `editGroupingParticipant`'s `updateParticipant` role branch unreachable, contradicting its own comment: *"A TD discovers a relationship at least as often AFTER creating the group as before, so the role must be editable, not create-only."* `editGroupingParticipant.test.ts` calls the editor directly, which is exactly why it proved the select worked while nothing in the UI could open it.

Both fixes are repairs to stated intent: carry `participantRole` onto the mapped row, and give GROUP rows an **Edit group** action that passes `participantType: GROUP`.

## Coverage

TMX vitest is node-env by design, so Playwright is the only layer where any of this is observable.

- **Journey 94 — official picker conflict states.** none / warn / blocked annotation; a blocked row is not selectable and prompts nothing; declining the warn confirm dispatches nothing; an accepted assignment dispatches `addMatchUpOfficial` **carrying `policyDefinitions`**. That last assertion is the point — the UI is an affordance and the factory gate is the check, which only holds if the mutation actually carries the policy. Each conflicted official is grouped with a *different* side, so a bug attributing a conflict to the wrong participant cannot accidentally produce the expected badge.
- **Journey 95 — GROUP role badge + edit.** Badge renders `COACH`, stays blank for the neutral `OTHER` (absence of a badge, not absence of text — a badge reading "OTHER" would be the regression); the edit round-trip dispatches `modifyParticipant` with the new role and the badge follows; the other group is untouched.
- **`mapTeamParticipant.test.ts`** — a row-shape contract test, so this data-path regression is caught in node rather than only in a browser.

## Falsification

Every guard was broken on purpose against the real source and restored:

| break | assertion that fired |
|---|---|
| remove the BLOCK gate on click | blocked row dispatched `addMatchUpOfficial` |
| drop `policyDefinitions` from the dispatch | `params.policyDefinitions` |
| stop setting `data-conflict` | annotation assertions |
| remove the WARN confirm | declined-confirm dispatched nothing |
| revert the mapper fix | badge assertions **and** the unit test |
| hide the Edit group item | affordance assertion |
| omit `participantType` on the edit call | role-select visibility |

The last one reproduces the original defect exactly, which is the one a looser test would have missed.

## Checks

`pnpm lint` · `pnpm format:check` · `pnpm attr-audit --ci` · `pnpm check-types` · `pnpm test --run` (107 files / 1078 tests) · full `pnpm test:e2e` (**337 passed, 1 skipped**) — the whole suite, not just the new specs, because `participantActions` is shared with the individuals and teams tables.