### PR TITLE
feat(i18n): fail CI on t() keys that resolve to nothing

### DIFF
--- a/scripts/i18n-audit.mjs
+++ b/scripts/i18n-audit.mjs
@@ -116,6 +116,62 @@ export function looksLikeProse(raw) {
   return /^[A-Z][a-z]/.test(value);
 }
 
+// ------------------------------------------------- unresolved-key resolution
+//
+// The mirror image of the hardcoded-string check. A hardcoded string is visibly
+// English; a MISTYPED KEY is worse, because i18next returns the key itself on a
+// miss — so `t('pages.participants.actions.editGroup')` renders that dotted path
+// on screen as if it were copy. Nothing else catches it: it is valid TypeScript,
+// lint-clean, and no test exercises most of these paths.
+//
+// Two exemptions, both load-bearing (without them this check is pure noise):
+//
+//   1. `defaultValue` — `t('x.y', { defaultValue: 'Dismiss' })` renders the
+//      default on a miss, by design. 11 of 14 initial hits were this. Flagging
+//      them would push people to add keys duplicating the inline defaults.
+//   2. Plural suffixes — `t('x.count', { count })` resolves through
+//      `x.count_one` / `x.count_other`, and the bare key often does not exist.
+//
+// Dynamic keys (`t(\`participantRoles.${role}\`)`, `t(someVar)`) are skipped:
+// not statically knowable. That is a real blind spot, not a solved problem.
+
+const PLURAL_SUFFIXES = ['', '_one', '_other', '_zero', '_two', '_few', '_many'];
+
+let enBundle;
+function loadEn() {
+  enBundle ??= JSON.parse(fs.readFileSync(path.join(ROOT, 'src', 'i18n', 'locales', 'en.json'), 'utf8'));
+  return enBundle;
+}
+
+function lookup(dotted) {
+  let node = loadEn();
+  for (const part of dotted.split('.')) {
+    if (!node || typeof node !== 'object' || !(part in node)) return undefined;
+    node = node[part];
+  }
+  return node;
+}
+
+/** Does this key resolve to a string, allowing for i18next plural suffixes? */
+export function keyResolves(key) {
+  return PLURAL_SUFFIXES.some((suffix) => typeof lookup(key + suffix) === 'string');
+}
+
+/** `t(key, { defaultValue: … })` — renders the default rather than the key. */
+function hasDefaultValue(call) {
+  const options = call.arguments[1];
+  if (!options || !ts.isObjectLiteralExpression(options)) return false;
+  return options.properties.some((p) => p.name && ts.isIdentifier(p.name) && p.name.text === 'defaultValue');
+}
+
+/** A call to `t(...)` or `something.t(...)`. */
+function isTranslateCall(call) {
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return callee.text === 't';
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text === 't';
+  return false;
+}
+
 // ---------------------------------------------------------------- AST walk
 
 function stringValueOf(node) {
@@ -125,7 +181,7 @@ function stringValueOf(node) {
   return undefined; // calls (t(...)), identifiers, templates with substitution, …
 }
 
-function collectFromFile(file, findings) {
+function collectFromFile(file, findings, unresolved) {
   const source = ts.createSourceFile(file, fs.readFileSync(file, 'utf8'), ts.ScriptTarget.Latest, true);
   const rel = path.relative(ROOT, file);
 
@@ -135,6 +191,15 @@ function collectFromFile(file, findings) {
   };
 
   const visit = (node) => {
+    // 0. t('some.key') that resolves to nothing — renders the key on screen.
+    if (ts.isCallExpression(node) && isTranslateCall(node) && node.arguments.length) {
+      const key = stringValueOf(node.arguments[0]);
+      if (key !== undefined && !hasDefaultValue(node) && !keyResolves(key)) {
+        const { line } = source.getLineAndCharacterOfPosition(node.getStart(source));
+        unresolved.push({ file: rel, line: line + 1, key });
+      }
+    }
+
     // 1. { label: 'Cancel' }
     if (ts.isPropertyAssignment(node)) {
       const name = ts.isIdentifier(node.name) || ts.isStringLiteral(node.name) ? node.name.text : undefined;
@@ -219,11 +284,13 @@ function main() {
   }
 
   const findings = [];
-  for (const file of walk(SRC, [])) collectFromFile(file, findings);
+  const unresolved = [];
+  for (const file of walk(SRC, [])) collectFromFile(file, findings, unresolved);
   findings.sort((a, b) => a.file.localeCompare(b.file, 'en') || a.line - b.line);
+  unresolved.sort((a, b) => a.file.localeCompare(b.file, 'en') || a.line - b.line);
 
   if (jsonAt !== -1 && argv[jsonAt + 1]) {
-    fs.writeFileSync(argv[jsonAt + 1], `${JSON.stringify(findings, null, 2)}\n`, 'utf8');
+    fs.writeFileSync(argv[jsonAt + 1], `${JSON.stringify({ findings, unresolved }, null, 2)}\n`, 'utf8');
   }
 
   if (update) {
@@ -250,8 +317,27 @@ function main() {
     // Without --ci this exits 0 even with new findings, which is easy to read as
     // a pass. Say so, rather than relying on the reader noticing the count.
     if (!ci && fresh.length) {
-      console.log(`\ni18n-audit: exiting 0 — this mode only reports. Use --ci to fail on the ${fresh.length} new string(s).`);
+      console.log(
+        `\ni18n-audit: exiting 0 — this mode only reports. Use --ci to fail on the ${fresh.length} new string(s).`,
+      );
     }
+  }
+
+  // Unresolved keys are NOT baselined. Unlike hardcoded strings there is no
+  // legacy backlog to ratchet down — the tree starts clean, so any hit is a new
+  // defect that renders a dotted key path on screen.
+  if (!quiet && unresolved.length) {
+    console.log(`\ni18n-audit: ${unresolved.length} t() key(s) resolve to NOTHING — these render the key itself:`);
+    for (const u of unresolved) console.log(`  ${u.file}:${u.line}  t('${u.key}')`);
+  }
+
+  if (ci && unresolved.length) {
+    console.error(
+      `\ni18n-audit: ${unresolved.length} unresolved t() key(s). i18next returns the key on a miss, so each of ` +
+        `these renders its own dotted path to the user. Add the key to src/i18n/locales/en.json, fix the typo, ` +
+        `or pass an explicit { defaultValue }.`,
+    );
+    return 1;
   }
 
   if (ci && fresh.length) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -345,7 +345,8 @@
     "confirmRemoveUser": "Remove User",
     "removeUserConfirm": "Are you sure you want to remove",
     "searchProviders": "Search providers...",
-    "lastAccess": "Last Access"
+    "lastAccess": "Last Access",
+    "inviteFailed": "Could not send the invitation. Please try again."
   },
   "round_names": {
     "F": "Final",

--- a/src/pages/tournament/formatWizardPage.ts
+++ b/src/pages/tournament/formatWizardPage.ts
@@ -134,7 +134,7 @@ function buildPageHeader(): HTMLElement {
   back.id = FORMAT_WIZARD_BACK;
   back.type = 'button';
   back.style.cssText = BACK_BUTTON_STYLE;
-  back.innerHTML = `<i class="fa fa-chevron-left"></i> ${t('back')}`;
+  back.innerHTML = `<i class="fa fa-chevron-left"></i> ${t('common.back')}`;
   back.addEventListener('click', () => navigateToOverview());
   header.appendChild(back);
 


### PR DESCRIPTION
The mirror image of the hardcoded-string check, and the worse failure of the two.

A hardcoded string is at least visibly English. **A mistyped key is invisible until it reaches a user** — i18next returns the key itself on a miss, so `t('pages.participants.actions.editGroup')` renders that dotted path on screen as if it were copy. It is valid TypeScript, lint-clean, and most of these paths have no test.

I hit exactly this in #1282: four keys pointing at a pre-rename namespace, caught only because I happened to write a throwaway resolver script. A peer session hit the same class independently and guarded it with a per-module assertion in their own test file. **Both approaches depend on someone remembering to write the assertion for their own module.** This one doesn't.

## No baseline

Unlike hardcoded strings there is no legacy backlog to ratchet down — the tree starts clean, so any hit is a new defect.

## Two exemptions, both load-bearing

Without these the check is pure noise:

| exemption | why |
|---|---|
| `defaultValue` | `t('x.y', { defaultValue: 'Dismiss' })` renders the default by design. **11 of the 14 initial hits were this.** Flagging them would have pushed people to add keys duplicating the inline defaults. |
| plural suffixes | `t('x.count', { count })` resolves via `x.count_one` / `x.count_other`; the bare key often doesn't exist. |

The plural exemption is verified load-bearing, not theoretical: disabling it false-positives on a **real** call site, `crowdTrackersModalLogic.ts:70`.

Dynamic keys (`t(\`participantRoles.${role}\`)`, `t(someVar)`) are skipped — not statically knowable. That's a genuine blind spot, stated in the header rather than papered over.

## Three real defects found and fixed

| where | what a user saw |
|---|---|
| `formatWizardPage.ts:137` | the literal lowercase `back` as the button label — the key is `common.back` |
| `inviteUser.ts:188` and `:196` | the toast `system.inviteFailed` when an invite failed without a server message |

`system.inviteFailed` was genuinely missing; wording matched to the sibling failure strings ("Could not set your password. Please try again.").

## Falsification

Four directions, each restored after:

| probe | expected | got |
|---|---|---|
| bogus key, no default | fires | exit 1 |
| same key **with** `defaultValue` | silent | exit 0 |
| dynamic template key | silent | exit 0 |
| plural-only key (`crowd.activeTrackers`) | silent | exit 0 |
| …same probe, plural handling removed | fires | exit 1 |

That last pair matters: my first plural test was **vacuous** — I picked a key that also had a bare form, so it would have passed with or without the feature. Re-done against a genuinely plural-only key.

## Checks

`pnpm lint` · `format:check` · `check-types` · `attr-audit --ci` · `i18n-audit --ci` · `pnpm test --run` (108 files / 1090 tests) — all green.

## Coordination

`src/i18n/locales/en.json` is still claimed by the Today-view session. Their uncommitted `"called": "Called"` line was **deliberately excluded** — staged my hunk only, leaving theirs in the working tree.