### PR TITLE
feat(matchUps): split called out of readyToScore in the Today bar

### DIFF
--- a/src/components/tables/common/filters/matchUpStatusPredicates.test.ts
+++ b/src/components/tables/common/filters/matchUpStatusPredicates.test.ts
@@ -18,6 +18,12 @@ const row = (over: any = {}) => ({
   ...over,
 });
 
+// A call stamped at 14:00 LOCAL on the given day, expressed as the ISO instant
+// the factory stores — keeps the expectations timezone-independent.
+const calledAtOn = (isoDate: string) => new Date(`${isoDate}T14:00:00`).toISOString();
+const DAY = '2026-08-16';
+const PRIOR_DAY = '2026-08-15';
+
 describe('classifyTodayBucket', () => {
   it('buckets a completed matchUp as complete', () => {
     expect(classifyTodayBucket(row({ matchUpStatus: 'COMPLETED', winningSide: 'side1', complete: true }))).toBe(
@@ -45,11 +51,41 @@ describe('classifyTodayBucket', () => {
     expect(classifyTodayBucket(row({ matchUpStatus: 'TO_BE_PLAYED', readyToScore: true }))).toBe('readyToScore');
   });
 
-  it('buckets an unready TO_BE_PLAYED as notReady', () => {
-    expect(classifyTodayBucket(row({ matchUpStatus: 'TO_BE_PLAYED' }))).toBe('notReady');
+  it('buckets a ready matchUp called on its scheduled day as called', () => {
+    const data = row({ calledAt: calledAtOn(DAY), scheduledDate: DAY, readyToScore: true });
+    expect(classifyTodayBucket(data)).toBe('called');
   });
 
-  it('always returns one of the five known buckets', () => {
+  it('ignores a calledAt stamp left over from an earlier day', () => {
+    const data = row({ calledAt: calledAtOn(PRIOR_DAY), scheduledDate: DAY, readyToScore: true });
+    expect(classifyTodayBucket(data)).toBe('readyToScore');
+  });
+
+  it('ignores an unparseable calledAt', () => {
+    const data = row({ scheduledDate: DAY, readyToScore: true, calledAt: 'not-a-date' });
+    expect(classifyTodayBucket(data)).toBe('readyToScore');
+  });
+
+  it('treats a call with no scheduledDate as called', () => {
+    const data = row({ calledAt: calledAtOn(DAY), readyToScore: true });
+    expect(classifyTodayBucket(data)).toBe('called');
+  });
+
+  it('keeps a called matchUp that has started in live, not called', () => {
+    const data = row({
+      matchUpStatus: 'IN_PROGRESS',
+      calledAt: calledAtOn(DAY),
+      scheduledDate: DAY,
+      readyToScore: true,
+    });
+    expect(classifyTodayBucket(data)).toBe('live');
+  });
+
+  it('buckets an unready matchUp as notReady even when called', () => {
+    expect(classifyTodayBucket(row({ calledAt: calledAtOn(DAY), scheduledDate: DAY }))).toBe('notReady');
+  });
+
+  it('always returns one of the known buckets', () => {
     const bucket = classifyTodayBucket(row({ matchUpStatus: 'RETIRED', complete: true }));
     expect(TODAY_BUCKETS).toContain(bucket);
   });

--- a/src/components/tables/common/filters/matchUpStatusPredicates.ts
+++ b/src/components/tables/common/filters/matchUpStatusPredicates.ts
@@ -17,7 +17,7 @@ const WALKOVER_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'DEFAULTED', '
 const COMPLETE_STATUSES = new Set(['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT', 'CANCELLED', 'ABANDONED']);
 
 // Today-view partition buckets (order defines the segment layout).
-export const TODAY_BUCKETS = ['complete', 'live', 'suspended', 'readyToScore', 'notReady'] as const;
+export const TODAY_BUCKETS = ['complete', 'live', 'suspended', 'called', 'readyToScore', 'notReady'] as const;
 export type TodayBucket = (typeof TODAY_BUCKETS)[number];
 
 /** Prefix distinguishing bar-driven status tokens from popover tokens. */
@@ -33,15 +33,38 @@ function isComplete(rowData: any): boolean {
 }
 
 /**
+ * True when the row carries a `calledAt` stamp belonging to the day it is
+ * scheduled on. `calledAt` is a full ISO instant and survives a reschedule as
+ * historical record (only an explicit unschedule clears it), so a stamp from an
+ * earlier day must not make a match look called for today. Compared in local
+ * wall-clock — the same convention the calledAt column and the Call Timing
+ * Variance report use, and on-site local time is venue time.
+ */
+function isCalledForScheduledDay(rowData: any): boolean {
+  const calledAt = rowData?.calledAt;
+  if (!calledAt) return false;
+  const called = new Date(calledAt);
+  if (Number.isNaN(called.getTime())) return false;
+  if (!rowData.scheduledDate) return true;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const localDate = `${called.getFullYear()}-${pad(called.getMonth() + 1)}-${pad(called.getDate())}`;
+  return localDate === rowData.scheduledDate;
+}
+
+/**
  * Mutually-exclusive classification of a matchUp into a Today-view bucket.
- * Precedence: complete → suspended → live → readyToScore → notReady.
+ * Precedence: complete → suspended → live → called → readyToScore → notReady.
+ *
+ * `called` splits the ready-to-score population: matches already sent on court
+ * (a `calledAt` stamp for their scheduled day) versus those still waiting to be
+ * called, which is the distinction a director scans the bar for.
  */
 export function classifyTodayBucket(rowData: any): TodayBucket {
   const status = statusOf(rowData);
   if (isComplete(rowData)) return 'complete';
   if (status === 'SUSPENDED') return 'suspended';
   if (status === 'IN_PROGRESS' || (rowData.score && !rowData.winningSide)) return 'live';
-  if (rowData.readyToScore) return 'readyToScore';
+  if (rowData.readyToScore) return isCalledForScheduledDay(rowData) ? 'called' : 'readyToScore';
   return 'notReady';
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1903,6 +1903,7 @@
       "noDate": "No date",
       "toBePlayed": "To be played",
       "suspended": "Suspended",
+      "called": "Called",
       "readyToScore": "Ready to score",
       "notReady": "Not ready",
       "live": "Live",

--- a/src/pages/tournament/tabs/matchUpsTab/todayView.test.ts
+++ b/src/pages/tournament/tabs/matchUpsTab/todayView.test.ts
@@ -1,0 +1,88 @@
+import { TODAY_BUCKETS } from 'components/tables/common/filters/matchUpStatusPredicates';
+import { aggregateToday, getTodaySegments, totalToday } from './todayView';
+import { describe, expect, it } from 'vitest';
+
+const DAY = '2026-08-16';
+const OTHER_DAY = '2026-08-17';
+
+// A call stamped at 14:00 LOCAL on the given day, expressed as the ISO instant
+// the factory stores — keeps the expectations timezone-independent.
+const calledAtOn = (isoDate: string) => new Date(`${isoDate}T14:00:00`).toISOString();
+
+const row = (over: any = {}) => ({
+  matchUpStatus: 'TO_BE_PLAYED',
+  scheduledDate: DAY,
+  readyToScore: false,
+  complete: false,
+  ...over,
+});
+
+describe('getTodaySegments', () => {
+  // Guard: buildSegmentedBar renders and totals only the keys it is handed, so a
+  // bucket added to the partition without a matching segment would vanish from
+  // the bar and be dropped from its total with no other symptom.
+  it('renders exactly one segment per Today bucket, in partition order', () => {
+    expect(getTodaySegments().map((s) => s.key)).toEqual([...TODAY_BUCKETS]);
+  });
+
+  it('labels every segment and gives each a distinct colour', () => {
+    const segments = getTodaySegments();
+    expect(segments.every((s) => !!s.label && !s.label.includes('pages.matchUps'))).toBe(true);
+    expect(new Set(segments.map((s) => s.color)).size).toBe(segments.length);
+  });
+});
+
+describe('aggregateToday', () => {
+  it('splits ready matchUps into called and readyToScore', () => {
+    const items = [
+      row({ readyToScore: true, calledAt: calledAtOn(DAY) }),
+      row({ readyToScore: true, calledAt: calledAtOn(DAY) }),
+      row({ readyToScore: true }),
+      row({ matchUpStatus: 'COMPLETED', winningSide: 'side1', complete: true }),
+      row({ matchUpStatus: 'IN_PROGRESS' }),
+      row(),
+    ];
+    expect(aggregateToday(items, DAY)).toEqual({
+      complete: 1,
+      live: 1,
+      suspended: 0,
+      called: 2,
+      readyToScore: 1,
+      notReady: 1,
+    });
+  });
+
+  it('counts only rows scheduled for the requested day', () => {
+    const items = [
+      row({ readyToScore: true, calledAt: calledAtOn(DAY) }),
+      row({ scheduledDate: OTHER_DAY, readyToScore: true, calledAt: calledAtOn(OTHER_DAY) }),
+      row({ scheduledDate: undefined, readyToScore: true }),
+    ];
+    const counts = aggregateToday(items, DAY);
+    expect(counts.called).toBe(1);
+    expect(totalToday(counts)).toBe(1);
+  });
+
+  it('reads Tabulator row objects as well as plain data', () => {
+    const data = row({ readyToScore: true, calledAt: calledAtOn(DAY) });
+    expect(aggregateToday([{ getData: () => data }], DAY).called).toBe(1);
+  });
+
+  it('returns zeroed counts for a non-array or empty input', () => {
+    const zeroed = { complete: 0, live: 0, suspended: 0, called: 0, readyToScore: 0, notReady: 0 };
+    expect(aggregateToday(undefined as any, DAY)).toEqual(zeroed);
+    expect(aggregateToday([], DAY)).toEqual(zeroed);
+    expect(totalToday(aggregateToday([], DAY))).toBe(0);
+  });
+});
+
+describe('totalToday', () => {
+  it('sums every bucket, including called', () => {
+    const items = [
+      row({ readyToScore: true, calledAt: calledAtOn(DAY) }),
+      row({ readyToScore: true }),
+      row({ matchUpStatus: 'SUSPENDED', score: '6-4 2-3' }),
+    ];
+    expect(totalToday(aggregateToday(items, DAY))).toBe(3);
+  });
+});

--- a/src/pages/tournament/tabs/matchUpsTab/todayView.ts
+++ b/src/pages/tournament/tabs/matchUpsTab/todayView.ts
@@ -1,7 +1,7 @@
 /**
  * Today-view aggregation for the matchUps-page segmented bar.
  *
- * Buckets a set of matchUp rows scheduled for a given ISO day into the five
+ * Buckets a set of matchUp rows scheduled for a given ISO day into the
  * day-of-play segments, using the shared classifier so the counts match what
  * clicking a segment filters to. The bar is scoped to `todayIso` and is
  * independent of the popover status filter, so it stays a stable dashboard of
@@ -23,18 +23,20 @@ export function getTodaySegments(): SegmentDef[] {
     { key: 'complete', label: t('pages.matchUps.complete'), color: 'var(--chc-status-success, #16a34a)' },
     { key: 'live', label: t('pages.matchUps.live'), color: 'var(--chc-status-info, #3b82f6)' },
     { key: 'suspended', label: t('pages.matchUps.suspended'), color: 'var(--chc-status-warning, #d97706)' },
+    // Called sits between suspended and ready: already sent on court, not yet started.
+    { key: 'called', label: t('pages.matchUps.called'), color: 'var(--chc-status-violet, #7c3aed)' },
     { key: 'readyToScore', label: t('pages.matchUps.readyToScore'), color: 'var(--chc-status-teal, #0d9488)' },
     { key: 'notReady', label: t('pages.matchUps.notReady'), color: 'var(--chc-text-muted, #6b7280)' },
   ];
 }
 
 function emptyCounts(): TodayCounts {
-  return { complete: 0, live: 0, suspended: 0, readyToScore: 0, notReady: 0 };
+  return { complete: 0, live: 0, suspended: 0, called: 0, readyToScore: 0, notReady: 0 };
 }
 
 /**
  * Aggregate rows (Tabulator row objects or plain data) scheduled for `todayIso`
- * into the five Today buckets.
+ * into the Today buckets.
  */
 export function aggregateToday(items: any[], todayIso: string): TodayCounts {
   const counts = emptyCounts();


### PR DESCRIPTION
On the matchUps page, the Today-view status bar lumped every ready-to-play matchUp into one `readyToScore` segment. A director could not see at a glance which of them had already been **called to court**, which is exactly the distinction they scan the bar for.

## What changed

`TODAY_BUCKETS` gains `called`, sitting between suspended and ready:

    complete → live → suspended → called → readyToScore → notReady

The bar and the `today:` status filter both run off `classifyTodayBucket`, so the count a segment shows still equals the rows you get when you click it — no second vocabulary was introduced.

| file | change |
| --- | --- |
| `matchUpStatusPredicates.ts` | `called` bucket; ready rows split on `calledAt` |
| `todayView.ts` | segment def (violet) + count key |
| `en.json` | `pages.matchUps.called` |
| `matchUpStatusPredicates.test.ts` | +5 cases |
| `todayView.test.ts` | **new**, 7 tests |

## The judgment call worth reviewing

`calledAt` **survives a reschedule** as historical record — only an explicit unschedule clears it (`gridView.ts:2826`). So a naive `!!calledAt` test would render a match called yesterday and pushed to today as "called". The predicate compares the stamp's *local* calendar day against the row's `scheduledDate` — the same convention `calledAtFormatter` and the Call Timing Variance report use, and on-site local time is venue time. A stale stamp falls back to `readyToScore`.

Precedence is unchanged above `called`: a called match that has started is still `live`, and a match that isn't ready stays `notReady` even if stamped.

## Coverage

`todayView.ts` had no tests at all. The new file closes a failure class the predicate tests can't see: `buildSegmentedBar` renders and totals **only the keys handed to it**, so a bucket added to `TODAY_BUCKETS` without a matching segment def would make those matchUps vanish from the bar and drop out of its total — no error, just a wrong number. The guard asserts segment keys equal the partition exactly, in order.

**Falsified**, not assumed: deleting the `called` segment fails that test alone (`expected […(3)] to deeply equal […(4)]`).

## Verification

- `pnpm test --run` **1090 passed** (108 files) · `pnpm lint` clean · `pnpm check-types` clean · prettier clean
- `pnpm i18n-audit --ci` — **606 baselined, 0 new, 0 unresolved keys**. Also falsified against the new unresolved-key gate from #1283: mistyping the key to `pages.matchUps.calledZZZ` fails CI as intended, so the key really is being checked.

## Not included

No Playwright journey. The click→filter wiring is shared with the five pre-existing buckets and untouched here, and there is currently no Today-view e2e at all — worth writing as its own spec covering the whole view rather than bolted onto this.