### PR TITLE
ci: type-check src and run the unit suite on TMX pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,21 @@ jobs:
       # finding.
       - name: i18n-audit
         run: pnpm i18n-audit --ci
+
+      # Type-checks src/ against the PUBLISHED factory, because the link:
+      # overrides are stripped above. This is the only gate that can catch a
+      # call into sibling work that exists locally but has not been published —
+      # previously nothing did: `build + smoke` type-checks electron only, and
+      # `pnpm build` (tsc + vite) runs solely in deploy-pages.yml, after merge.
+      #
+      # A TMX change that needs unreleased factory work will fail here, and that
+      # is the point: it fails at the PR instead of at runtime in a deployed
+      # client. The remedy is to publish the dependency, not to skip this.
+      - name: check-types
+        run: pnpm check-types
+
+      # Local `pnpm test --run` used to be the only test evidence a reviewer
+      # ever saw. The suite is a few seconds; there is no reason for CI not to
+      # be the one running it.
+      - name: test
+        run: pnpm test --run


### PR DESCRIPTION
**Draft deliberately — this cannot merge until factory 6.27.0 publishes.** See the blocker below; its failure is the feature working.

## The gap

TMX PR CI checks neither types nor tests:

| job | steps |
| --- | --- |
| `build + smoke` | `check-types` for **electron only**, then `electron-vite build`, smoke, packaging |
| `lint` | `pnpm lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci` |

`pnpm build` (`rimraf dist && tsc && vite build`) runs **only in `deploy-pages.yml`, after merge**. `pnpm test` appears only in `release-please.yml` and `electron.yml`. So a green TMX PR has never been evidence that the app compiles or that its tests pass — local runs were the only signal, and only if the author mentioned them.

## Why `check-types` here specifically

This job strips the `link:` overrides and installs the **published** dependency. That makes it the only gate that can catch a call into sibling work which exists locally but has not been published. Today that class of mistake surfaces at runtime in a deployed client, with nothing in between.

## The blocker, which is also the proof

TMX `main` right now calls `scheduleGovernor.matchUpScheduleLocked` (from factory #4638, merged but unpublished). Type-checking that call against the published package:

```
probe.ts(2,40): error TS2551: Property 'matchUpScheduleLocked' does not exist on
type 'typeof index$d'. Did you mean 'matchUpScheduleChange'?
```

Verified by unpacking the 6.26.0 tarball and compiling a two-line probe against it, rather than reasoning from the source tree.

So **this PR's own CI will fail**, on exactly the defect the gate is designed to catch. That is the demonstration, not a reason to weaken it. The remedy is to publish factory 6.27.0 — which also unblocks schedule locks functionally — and merge this in the same window.

## Sequencing

1. factory 6.27.0 publishes (release-please #4618)
2. TMX bumps its factory pin
3. mark this ready → CI should pass → merge

If CI still fails after step 2, that is a real finding and worth reading closely.