### PR TITLE
chore(deps): bump tods-competition-factory to 6.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.26.0",
+    "tods-competition-factory": "6.27.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
6.27.0 published. This bumps TMX's pin to it.

## Why it matters beyond routine housekeeping

**TMX `main` has not compiled against its own published pin since #1286.** The schedule-lock UI calls `scheduleGovernor.matchUpScheduleLocked` and `setMatchUpScheduleLock`, neither of which existed in 6.26.0. Nothing caught it, because TMX PR CI type-checks electron only (see #1288).

Verified against the published tarballs rather than the source tree:

| | 6.26.0 | 6.27.0 |
| --- | --- | --- |
| probe compiling `scheduleGovernor.matchUpScheduleLocked` | `TS2551: Property … does not exist` | clean |

6.27.0 carries `setMatchUpScheduleLock` (#4633), the `isScheduleLocked` query + `matchUpScheduleLocked` (#4638), and the `allocatedCourts` alias (#4642) — all confirmed present in the published `.d.ts` and runtime bundle.

## No lockfile change, deliberately

`pnpm-workspace.yaml` overrides the dependency to `link:../factory`, so `pnpm-lock.yaml` records `specifier: link:../factory` rather than the version. `pnpm install --lockfile-only` produces no diff, and that is correct rather than a forgotten step — the pin still matters because CI strips the overrides and installs the published package.

## Verification

`pnpm test --run` 1118 passed · `pnpm lint` clean · `pnpm check-types` clean.

Scope note: this bumps **TMX only**. The ecosystem fan-out across the other ten `link:` consumers is `Mentat/scripts/bump-factory-consumers.sh`, which is a deploy-shaped action and left for CA — its preflight currently also reports `courthive-components` on a feature branch.