### PR TITLE
refactor(schedule): consolidate schedule2CellActions import; hoist listScheduledOrphans

### DIFF
--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -28,9 +28,13 @@ import {
   writeScheduleDisplayConfig,
 } from 'services/schedulePreferences/scheduleDisplayExtension';
 import { detectCourtTimeOrderIssues, CONFLICT_COURT_TIME_ORDER } from './courtTimeOrderIssues';
-import { handleActiveStripNowClick, handleSchedule2CellClick, handleSchedule2RowClick } from './schedule2CellActions';
-import { openShiftCourtsModal } from './schedule2CellActions';
-import type { Schedule2NowContext } from './schedule2CellActions';
+import {
+  handleActiveStripNowClick,
+  handleSchedule2CellClick,
+  handleSchedule2RowClick,
+  openShiftCourtsModal,
+  Schedule2NowContext,
+} from './schedule2CellActions';
 import { getActiveRegistrationNamesByCourtId } from './practiceRegistrationStrip';
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { printCourtMatchUpCards } from 'components/modals/printCourtCards';
@@ -968,40 +972,13 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   // when the selected date already has scheduled-but-unplaced matchUps.
   let activeTab: SidebarTab = readSidebarTab();
 
-  // Single source of truth for "scheduled but not placed" — used by both the
-  // panel renderer and the tab badge so they cannot drift. Sorted by
-  // scheduledTime ascending (no-time entries fall to the bottom) so that
-  // the list reflects the play order produced by the scheduler, with a
-  // stable tie-break on matchUpId.
-  // Orphans = scheduled-for-this-date, no court assigned, not BYE. Completion
-  // status is NOT filtered here — callers decide based on the operator's
-  // "Show completed" toggle. Splitting the call this way lets `updateBadge`
-  // compute both the visible count (respects toggle) and the absolute count
-  // (drives funnel visibility) from one factory call.
-  function listScheduledOrphans(): any[] {
-    const { matchUps } = getCachedAllMatchUps();
-    const filtered = (matchUps || []).filter((m: any) => {
-      if (m.matchUpStatus === BYE) return false;
-      if (m.schedule?.scheduledDate !== currentDate) return false;
-      if (m.schedule?.courtId) return false; // already on a court — don't show
-      return true; // date match is sufficient — time is optional
-    });
-    filtered.sort((a: any, b: any) => {
-      const am = scheduledTimeToMinutes(a.schedule?.scheduledTime);
-      const bm = scheduledTimeToMinutes(b.schedule?.scheduledTime);
-      if (am !== bm) return am - bm;
-      return String(a.matchUpId).localeCompare(String(b.matchUpId));
-    });
-    return filtered;
-  }
-
   function getScheduledNotPlacedOnCourt(): any[] {
     // Honors the shared "Show completed" store flag so a completed matchUp
     // whose court was cleared (manual unschedule or upstream sync wiping
     // courtId while preserving scheduledDate/scheduledTime) has a surface
     // to be re-assigned from — without the toggle, it had nowhere to live.
     const showCompleted = activeControl?.getStore().getState().showCompleted ?? false;
-    const all = listScheduledOrphans();
+    const all = listScheduledOrphans(currentDate);
     return showCompleted ? all : all.filter((m: any) => !isCompletedStatus(m.matchUpStatus));
   }
 
@@ -1010,7 +987,7 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
     // and absolute-count (gates funnel visibility). The funnel is hidden
     // when there's nothing for the popover to act on even with the toggle
     // on — otherwise opening it surfaces an empty Clear All / × husk.
-    const orphans = listScheduledOrphans();
+    const orphans = listScheduledOrphans(currentDate);
     const showCompleted = activeControl?.getStore().getState().showCompleted ?? false;
     const visibleCount = showCompleted
       ? orphans.length
@@ -3106,6 +3083,40 @@ function checkBlockInterruption(matchUp: any, courtId: string): BlockInterruptio
     averageMinutes,
     availableMinutes: Math.max(availableMinutes, 0),
   };
+}
+
+/**
+ * Single source of truth for "scheduled but not placed" — used by both the
+ * Scheduled-panel renderer and the tab badge so they cannot drift. Sorted by
+ * scheduledTime ascending (no-time entries fall to the bottom) so that the list
+ * reflects the play order produced by the scheduler, with a stable tie-break on
+ * matchUpId.
+ *
+ * Orphans = scheduled-for-this-date, no court assigned, not BYE. Completion
+ * status is NOT filtered here — callers decide based on the operator's
+ * "Show completed" toggle. Splitting the call this way lets `updateBadge`
+ * compute both the visible count (respects the toggle) and the absolute count
+ * (drives funnel visibility) from one factory call.
+ *
+ * Takes `scheduledDate` explicitly rather than reading the module-level
+ * `currentDate` it used to close over: pure given its input, so it is
+ * independently testable and is not re-created on every render pass.
+ */
+function listScheduledOrphans(scheduledDate: string): any[] {
+  const { matchUps } = getCachedAllMatchUps();
+  const filtered = (matchUps || []).filter((m: any) => {
+    if (m.matchUpStatus === BYE) return false;
+    if (m.schedule?.scheduledDate !== scheduledDate) return false;
+    if (m.schedule?.courtId) return false; // already on a court — don't show
+    return true; // date match is sufficient — time is optional
+  });
+  filtered.sort((a: any, b: any) => {
+    const am = scheduledTimeToMinutes(a.schedule?.scheduledTime);
+    const bm = scheduledTimeToMinutes(b.schedule?.scheduledTime);
+    if (am !== bm) return am - bm;
+    return String(a.matchUpId).localeCompare(String(b.matchUpId));
+  });
+  return filtered;
 }
 
 /**


### PR DESCRIPTION
Two SonarLint findings on `gridView.ts`, raised by another session in [`Mentat/in-flight/NOTE-2026-08-17-gridview-lint-findings.md`](https://github.com/CourtHive/Mentat/blob/main/in-flight/NOTE-2026-08-17-gridview-lint-findings.md) — the file is on my in-flight claim, so I took them rather than hand it over.

## 1. Three imports of one module → one

`./schedule2CellActions` was imported by three statements (values, one more value, a type). The type folds into the merged statement: the ecosystem does not use `import type`, and TMX has `isolatedModules` without `verbatimModuleSyntax`, so the interface elides cleanly. Written multi-line — matching the file's other consolidated imports — so the longest-first single-line ordering is untouched.

## 2. `listScheduledOrphans` hoisted to module scope

It was declared inside `injectSidebarControls`, re-created on every render pass. It turned out to close over **nothing** local — `currentDate` is a module-level binding, so the note's "closes over one binding" was slightly off — but rather than have it read that mutable singleton from module scope, it now takes `scheduledDate` as a parameter. That makes it pure given its input and independently testable, which the readiness work in this workstream wants. Both call sites pass `currentDate`, read at call time exactly as before.

Body is otherwise unchanged; the diff is a move plus one parameter rename.

## Verification

| check | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm format:check` (touched file) | clean |
| `pnpm check-types` | 0 (src + e2e + electron) |
| `pnpm test --run` | 110 files / 1123 tests passed — same as baseline |
| journeys 38 / 47 / 59 | **8/8 passed** |

No unit test imports `gridView.ts`, so the unit suite is a no-change control here — the real evidence is the three e2e journeys that exercise this function: Scheduled-tab listing, panel search, group-by re-partition, tab+groupBy reload persistence, completed-orphan toggle, funnel visibility, BYE exclusion from the date count, and date-badge recompute.

**Falsified rather than just run green:** making the hoisted function ignore its date argument (`!== 'FALSIFY-NO-SUCH-DATE'`) turns journey 38 red across all three of its affected tests plus retries; restoring it returns 8/8. So those passes exercise the moved code rather than passing incidentally.

## One correction to the note

Neither finding is reported by `pnpm lint`, which I verified rather than assumed: `eslint` on this file is exit 0 with no output, and the detector was falsified (an unused-var probe in the same directory does report). `eslint.config.mjs` registers only `@typescript-eslint` and `sonarjs`; the four `import/*` entries are `'off'` **and** have no plugin behind them, so `import/no-duplicates` cannot fire, and there is no `unicorn` plugin for `consistent-function-scoping`. Confirmed with CA: they come from **SonarLint in VS Code**. Worth fixing, gating nothing.
