### PR TITLE
fix(deps): update courthive-components to 3.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.13.2",
+    "courthive-components": "3.14.0",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.4",


### PR DESCRIPTION
Consumer fan-out for **courthive-components 3.14.0** (published today; carries the schedule-page inspector extension points from [components #511](https://github.com/CourtHive/courthive-components/pull/511)).

Ran via `Mentat/scripts/bump-components-consumers.sh 3.14.0`, which bumped and pushed `courthive-public`, `epixodic` and `courthive-ams` directly to their default branches. **TMX needs a PR instead**, because `main` now requires the `lint` status check — a direct consequence of [#1288](https://github.com/CourtHive/TMX/pull/1288) landing real CI here. The script's push was rejected (`GH006 … Required status check "lint" is expected`), so its commit is carried onto this branch unchanged; `main` was reset to `origin/main` so the shared checkout is not left ahead.

Lockfile is unchanged, as expected: `pnpm-workspace.yaml` overrides components to `link:../courthive-components`, so the pin is inert locally. `pnpm install --lockfile-only` confirmed the lockfile already satisfies the supply-chain policy (verified 1d ago) and had nothing to rewrite.

## Verification

- `pnpm check-types` green as part of the script's consumer gate (it also passed for the other three consumers).
- The published 3.14.0 tarball was checked directly rather than trusting git ancestry: `renderInspectorExtra`, `inspectorVisible`, `setInspectorVisible`, `toggleInspector` and the `data-panel` hooks are all present in `dist/*.js`, and all four are declared in the nested `dist/**/*.d.ts` — so this pin type-checks against real published types, not just the local symlink.
- CI on this PR is the real gate now: `lint`, `format:check`, `attr-audit`, `i18n-audit`, `check-types`, `test --run`, all after `link:` overrides are stripped.
