### PR TITLE
feat(schedule): matchUp Inspector on both catalog views, toggleable, with readiness

### DIFF
--- a/attr-audit.config.json
+++ b/attr-audit.config.json
@@ -55,6 +55,7 @@
     "attribute",
     "WITHDRAW",
     "registrationIds",
-    "baseURI"
+    "baseURI",
+    "participantNames"
   ]
 }

--- a/e2e/journeys/97-schedule2-inspector-readiness.spec.ts
+++ b/e2e/journeys/97-schedule2-inspector-readiness.spec.ts
@@ -1,0 +1,298 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 97 — Schedule2 Inspector: both catalog views, toggleable, readiness.
+ *
+ * Before this workstream the Inspector existed only on the **Unscheduled** tab,
+ * not by design but because `injectSidebarControls` captured every sidebar child
+ * — the Inspector among them — as "catalog content" and hid the lot when the
+ * Scheduled tab was shown. This journey pins the three things that changed:
+ *
+ *  1. The Inspector survives the tab switch.
+ *
+ *     ⚠️ **What actually makes this pass is the courthive-components side**, not
+ *     the TMX `[data-panel="inspector"]` filter in `setTab`. The layout writes
+ *     `inspectorVisible` onto the panel on EVERY render, so a store tick after
+ *     the tab switch resets a `display:none` that `setTab` had applied. Verified
+ *     by falsification: with the TMX filter removed this test still passes, and a
+ *     DOM probe after the switch reads `catalog inline="none"` but
+ *     `inspector inline=""`. The filter is kept because two owners of one
+ *     element's `display` is a latent flash, but **this assertion does not
+ *     discriminate between having it and not** — do not read a green run here as
+ *     coverage of that filter.
+ *  2. A Scheduled-panel card is selectable, and the Inspector reports it as
+ *     **Scheduled: Yes** — the regression guard for the `isScheduled: false`
+ *     forgery in `scheduledMatchUpToCatalogItem`, which exists so the cards stay
+ *     draggable. Selecting that object directly would read "No".
+ *  3. The toggle hides/shows the Inspector globally (both tabs) and the choice
+ *     survives a reload via `schedule2:inspector-visible`.
+ *
+ * Readiness is asserted against a **seeded violation** rather than merely
+ * checking that a heading renders: two R1 matchUps 30 minutes apart share a
+ * participant, so the second cannot be ready at its scheduled time. A control
+ * case (a lone matchUp with nothing else that day) must report no issues — a
+ * readiness panel that always warns would pass a one-sided test.
+ */
+
+const SCHEDULE_DATE = todayLocal();
+
+const INSPECTOR = '[data-panel="inspector"]';
+const CATALOG_PANEL = '[data-panel="catalog"]';
+const SCHEDULED_PANEL = '[data-sidebar-panel="scheduled"]';
+const SCHEDULED_TAB = 'button[data-sidebar-tab="scheduled"]';
+const UNSCHEDULED_TAB = 'button[data-sidebar-tab="unscheduled"]';
+const INSPECTOR_TOGGLE = 'button[data-inspector-toggle="true"]';
+const SCHEDULED_CARD = `${SCHEDULED_PANEL} .spl-matchup-card`;
+const READINESS = '.tmx-readiness';
+const READINESS_FINDING = '.tmx-readiness-finding';
+const READINESS_OK = '.tmx-readiness-ok';
+const KV_ROW = `${INSPECTOR} .sp-kv`;
+
+type Seed = { tournamentId: string; clashingMatchUpId: string };
+
+/**
+ * `clash` mode: two singles events drawn from ONE participant pool, so some
+ * player necessarily appears in both draws. The seed then *searches* for a
+ * cross-event pair of R1 matchUps that genuinely share an individual and
+ * schedules them 30 minutes apart — the later one cannot be ready, because the
+ * shared player is still on court.
+ *
+ * It **throws** when no such pair exists rather than scheduling an arbitrary
+ * pair, so a seed that stops producing a clash fails loudly instead of leaving
+ * the readiness assertion to pass vacuously against an empty panel.
+ *
+ * (An earlier version rewrote `positionAssignments` directly to force the shared
+ * participant. It did not survive into the hydrated matchUps, and produced
+ * exactly that vacuous pass — no findings, and nothing to say why.)
+ *
+ * `clean` mode schedules a single matchUp with nothing else that day.
+ */
+async function seedInspector(page: import('@playwright/test').Page, mode: 'clash' | 'clean'): Promise<Seed> {
+  return page.evaluate(
+    async ({ date, mode }) => {
+      try {
+        await dev.tmx2db.initDB();
+
+        const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
+          setState: true,
+          tournamentName: 'E2E Inspector Readiness',
+          tournamentAttributes: {
+            tournamentId: `e2e-inspector-${mode}`,
+            startDate: date,
+            endDate: date,
+          },
+          participantsProfile: { scaledParticipantsCount: 16 },
+          drawProfiles:
+            mode === 'clean'
+              ? [{ eventName: 'Singles', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' }]
+              : [
+                  { eventName: 'Singles A', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' },
+                  { eventName: 'Singles B', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' },
+                ],
+          venueProfiles: [{ courtsCount: 2, venueName: 'Inspector Venue' }],
+        });
+
+        const r1 = (dev.factory.competitionEngine.allTournamentMatchUps({}).matchUps || []).filter(
+          (m: any) => m.matchUpStatus !== 'BYE' && m.roundNumber === 1,
+        );
+
+        const schedule = (matchUp: any, scheduledTime: string) =>
+          dev.factory.tournamentEngine.addMatchUpScheduleItems({
+            matchUpId: matchUp.matchUpId,
+            drawId: matchUp.drawId,
+            schedule: { scheduledDate: date, scheduledTime },
+          });
+
+        const idsOf = (matchUp: any): string[] =>
+          (matchUp.sides || [])
+            .flatMap((s: any) => [s.participantId, ...(s.participant?.individualParticipantIds || [])])
+            .filter(Boolean);
+
+        let clashingMatchUpId = r1[0].matchUpId;
+
+        if (mode === 'clean') {
+          schedule(r1[0], '10:00');
+        } else {
+          // Find a cross-event pair sharing an individual participant.
+          let pair: any[] | undefined;
+          for (const a of r1) {
+            const aIds = new Set(idsOf(a));
+            pair = [a, r1.find((b: any) => b.eventId !== a.eventId && idsOf(b).some((id) => aIds.has(id)))].filter(
+              Boolean,
+            );
+            if (pair.length === 2) break;
+            pair = undefined;
+          }
+          if (!pair) {
+            throw new Error(
+              'seed produced no cross-event matchUp pair sharing a participant — the clash assertion would pass vacuously',
+            );
+          }
+          // 09:30 then 10:00: 30 minutes apart, so the shared player is still on
+          // court (90 min average) when the second matchUp is due to start.
+          schedule(pair[0], '09:30');
+          schedule(pair[1], '10:00');
+          clashingMatchUpId = pair[1].matchUpId;
+        }
+
+        const mutated = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+        await dev.tmx2db.addTournament(mutated);
+
+        return { tournamentId: tournamentRecord.tournamentId as string, clashingMatchUpId };
+      } catch (err: any) {
+        throw new Error(
+          `${err?.name || 'Error'}: ${err?.message || String(err)} | stack: ${err?.stack?.split('\n').slice(0, 3).join(' || ')}`,
+        );
+      }
+    },
+    { date: SCHEDULE_DATE, mode },
+  );
+}
+
+async function openScheduling(page: import('@playwright/test').Page, tournamentId: string): Promise<void> {
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  await tournament.navigateToScheduling();
+}
+
+async function openScheduledTab(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator(SCHEDULED_TAB).click();
+  await page.locator(SCHEDULED_PANEL).waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+/**
+ * Explicit, because the sidebar does NOT reliably open on Unscheduled:
+ * `resolveInitialTab` lands on **Scheduled** whenever the selected date already
+ * has scheduled-but-unplaced matchUps — which every seed here creates.
+ */
+async function openUnscheduledTab(page: import('@playwright/test').Page): Promise<void> {
+  await page.locator(UNSCHEDULED_TAB).click();
+  await page.locator(CATALOG_PANEL).waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+test.describe('Journey 97 — Schedule2 Inspector readiness', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('Inspector is present on BOTH the Unscheduled and Scheduled tabs', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+
+    // Unscheduled side: the Inspector has always been here.
+    await openUnscheduledTab(page);
+    await expect(page.locator(INSPECTOR)).toBeVisible();
+    await expect(page.locator(CATALOG_PANEL)).toBeVisible();
+
+    await openScheduledTab(page);
+
+    // The regression this workstream fixes: the catalog is hidden, the
+    // Inspector is NOT.
+    await expect(page.locator(CATALOG_PANEL)).toBeHidden();
+    await expect(page.locator(INSPECTOR)).toBeVisible();
+  });
+
+  test('selecting a Scheduled card populates the Inspector and reports Scheduled: Yes', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+    await openScheduledTab(page);
+
+    // Empty state first — nothing selected yet.
+    await expect(page.locator(`${INSPECTOR} .sp-small`)).toBeVisible();
+
+    await page.locator(SCHEDULED_CARD).first().click();
+
+    await expect(page.locator(KV_ROW).first()).toBeVisible();
+    // `scheduledMatchUpToCatalogItem` forges `isScheduled: false` so the cards
+    // stay draggable; selection resolves the real catalog item instead, so this
+    // must read Yes. Reading "No" means the forgery reached the store.
+    await expect(page.locator(INSPECTOR)).toContainText('Scheduled');
+    await expect(page.locator(INSPECTOR)).toContainText('Yes');
+    await expect(page.locator(SCHEDULED_CARD).first()).toHaveClass(/selected/);
+  });
+
+  test('readiness flags a participant who cannot be ready at the scheduled time', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+    await openScheduledTab(page);
+
+    // The later of the two clashing matchUps is the second card (sorted by time).
+    await page.locator(SCHEDULED_CARD).nth(1).click();
+
+    await expect(page.locator(READINESS)).toBeVisible();
+    await expect(page.locator(READINESS_FINDING).first()).toBeVisible();
+    // Either kind is a correct answer for this seed depending on how the
+    // engine resolves the average for the format; both mean "not ready".
+    await expect(
+      page.locator(`${READINESS_FINDING}[data-kind="overlap"], ${READINESS_FINDING}[data-kind="recovery"]`),
+    ).not.toHaveCount(0);
+  });
+
+  test('readiness reports no issues for a matchUp with nothing else that day', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clean');
+    await openScheduling(page, tournamentId);
+    await openScheduledTab(page);
+
+    await page.locator(SCHEDULED_CARD).first().click();
+
+    // The control: a readiness panel that always warns would have passed the
+    // test above on its own.
+    await expect(page.locator(READINESS_OK)).toBeVisible();
+    await expect(page.locator(READINESS_FINDING)).toHaveCount(0);
+  });
+
+  test('the toggle hides the Inspector on both tabs and the choice survives a reload', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+    await openUnscheduledTab(page);
+
+    await expect(page.locator(INSPECTOR)).toBeVisible();
+    await expect(page.locator(INSPECTOR_TOGGLE)).toHaveAttribute('aria-pressed', 'true');
+
+    await page.locator(INSPECTOR_TOGGLE).click();
+    await expect(page.locator(INSPECTOR)).toBeHidden();
+    await expect(page.locator(INSPECTOR_TOGGLE)).toHaveAttribute('aria-pressed', 'false');
+
+    // Global to the catalog: still hidden after switching tabs.
+    await openScheduledTab(page);
+    await expect(page.locator(INSPECTOR)).toBeHidden();
+
+    // Persisted.
+    expect(await page.evaluate(() => localStorage.getItem('schedule2:inspector-visible'))).toBe('false');
+
+    await page.reload();
+    await waitForAppReady(page);
+    await openScheduling(page, tournamentId);
+    await expect(page.locator(INSPECTOR)).toBeHidden();
+
+    // And back again — the toggle is not one-way.
+    await page.locator(INSPECTOR_TOGGLE).click();
+    await expect(page.locator(INSPECTOR)).toBeVisible();
+    expect(await page.evaluate(() => localStorage.getItem('schedule2:inspector-visible'))).toBeNull();
+  });
+
+  test('selection while hidden does not auto-open the Inspector', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+    await page.locator(INSPECTOR_TOGGLE).click();
+    await openScheduledTab(page);
+    await expect(page.locator(INSPECTOR)).toBeHidden();
+
+    await page.locator(SCHEDULED_CARD).first().click();
+
+    // A persisted operator choice is not overridden by selecting a card
+    // (decision recorded in the workstream plan). Revealing it afterwards shows
+    // the selection that was made while hidden.
+    await expect(page.locator(INSPECTOR)).toBeHidden();
+    await page.locator(INSPECTOR_TOGGLE).click();
+    await expect(page.locator(KV_ROW).first()).toBeVisible();
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -952,7 +952,29 @@
     "startOnDropTitle": "Start match on drop?",
     "startOnDropPrompt": "You dropped a match onto the Now strip. Start matches automatically whenever they are dropped onto Now from now on? You can change this any time with the start-on-drop toggle in the schedule header.",
     "unscheduleAllTitle": "Unschedule all?",
-    "unscheduleAllConfirm": "Remove the date, time and court for {{count}} match(es)? They return to the unscheduled catalog; their results are untouched."
+    "unscheduleAllConfirm": "Remove the date, time and court for {{count}} match(es)? They return to the unscheduled catalog; their results are untouched.",
+    "inspector": {
+      "show": "Show inspector",
+      "hide": "Hide inspector",
+      "readiness": {
+        "heading": "Readiness",
+        "ready": "No readiness issues for this time.",
+        "overlap": "{{names}} is due on court in {{labels}} at this time",
+        "recovery": "{{names}} needs recovery time",
+        "recoveryNotBefore": "{{names}} needs recovery time — not before {{time}}",
+        "dependencyNotBefore": "Waiting on {{labels}} — not before {{time}}",
+        "dependencyUnscheduled": "Waiting on {{labels}}, which is not scheduled",
+        "undetermined": "Participants not yet determined — waiting on {{labels}}",
+        "skip": {
+          "generic": "Readiness cannot be evaluated for this matchUp.",
+          "bye": "A BYE has no readiness to check.",
+          "completed": "Already complete — nothing left to be ready for.",
+          "notScheduled": "Not scheduled yet, so there is no time to check against.",
+          "noTime": "No scheduled time, so readiness cannot be projected.",
+          "unknownMatchUp": "This matchUp is no longer in the tournament."
+        }
+      }
+    }
   },
   "penalties": {
     "fail2signout": "Failed to Sign Out",

--- a/src/pages/tournament/tabs/scheduleViews/gridDropMethods.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridDropMethods.ts
@@ -104,7 +104,13 @@ export function buildGridDropMethods(params: BuildGridDropMethodsParams): Schedu
   const matchUp = payload.matchUp;
 
   // Dropped onto its own cell — nothing to do.
-  if (occupant && occupant.matchUpId === matchUp.matchUpId) return [];
+  //
+  // The leading `matchUp.matchUpId &&` is load-bearing, not redundant: with no
+  // occupant, `occupant?.matchUpId` is undefined, so a bare optional-chain
+  // comparison would return true for a payload whose own matchUpId is missing
+  // and silently swallow the drop. The call site casts through
+  // `as unknown as GridDropPayload`, so the type does not rule that out.
+  if (matchUp.matchUpId && occupant?.matchUpId === matchUp.matchUpId) return [];
 
   // Stamped onto EVERY method the drop produces: a swap moves two matchUps, and
   // a confirmation that covers only one of them would half-apply the swap.
@@ -114,7 +120,10 @@ export function buildGridDropMethods(params: BuildGridDropMethodsParams): Schedu
       : methods;
 
   const source = payload.type === 'GRID_MATCHUP' ? payload.source : null;
-  const canSwap = !!(occupant && source && source.courtId && source.courtOrder != null);
+  // `source?.courtOrder != null` is false when `source` is absent (loose `!=`
+  // treats undefined as null), so the optional chain covers the null-source case
+  // without a separate `source &&`.
+  const canSwap = !!(occupant && source?.courtId && source.courtOrder != null);
 
   if (canSwap && occupant && source) {
     // Swap: the two matchUps trade court + courtOrder, but each KEEPS ITS OWN

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -271,8 +271,11 @@ import {
   writeScheduledGroupBy,
   readScheduledFilters,
   writeScheduledFilters,
+  readInspectorVisible,
+  writeInspectorVisible,
   type SidebarTab,
 } from './gridViewStorage';
+import { renderReadinessSection } from './inspectorReadiness';
 
 /** Distinct, sorted, locale-aware values of an accessor across catalog items.
  *  Mirrors the helper inside courthive-components' `matchUpCatalog.ts`. */
@@ -398,6 +401,14 @@ export function renderGridView(
     // dispatches a real state change (default-true store + false-localStorage
     // otherwise causes a no-op on first toggle).
     activeStripVisible: options?.activeStripVisible ?? true,
+    // Same reason as activeStripVisible: seed from localStorage so the first
+    // click on the toggle dispatches a real change rather than a no-op against
+    // the store's default-true.
+    inspectorVisible: readInspectorVisible(),
+    // Consumer-supplied Inspector detail: readiness for the selected matchUp.
+    // A render hook rather than an external append — the Inspector rebuilds its
+    // body on every store tick and would wipe anything appended from outside.
+    renderInspectorExtra: (matchUp) => renderReadinessSection(matchUp.matchUpId),
     // Restore catalog filter state captured from a previous mount within
     // this tournament session. Cleared on tournament load (see loadTournament).
     initialCatalogState: context.scheduleCatalogState,
@@ -494,9 +505,9 @@ export function renderGridView(
     },
 
     onMatchUpSelected: () => {
-      // Selection is a UI-only concern in the schedule page right now —
-      // no global state update needed. Keep the hook so the catalog can
-      // surface selection later (e.g. via an inspector panel).
+      // Selection is store-local: the Inspector reads `state.selectedMatchUp`
+      // and re-renders itself. Nothing global to update — the hook stays so a
+      // future consumer (deep link, cross-panel highlight) has a seam.
     },
   };
 
@@ -653,10 +664,38 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   const sidebar = layout.firstElementChild as HTMLElement;
   if (!sidebar) return;
 
-  // Build control bar (tab switcher: Unscheduled / Scheduled)
+  // Build control bar (inspector toggle + tab switcher: Unscheduled / Scheduled)
   const controlBar = document.createElement('div');
   controlBar.style.cssText =
     'display: flex; align-items: center; gap: 4px; padding: 6px 8px; flex-shrink: 0; border-bottom: 1px solid var(--sp-border, var(--tmx-border-primary));';
+
+  // Inspector show/hide, left of the tabs. Global to the catalog: one flag for
+  // BOTH views, because the Inspector describes the selected matchUp rather than
+  // either tab's contents. Persisted, and NOT auto-revealed on selection — a
+  // deliberate operator choice is not overridden (see the workstream plan).
+  const inspectorToggle = document.createElement('button');
+  inspectorToggle.className = 'tmx-inspector-toggle';
+  inspectorToggle.dataset.inspectorToggle = 'true';
+  inspectorToggle.innerHTML =
+    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="15" x2="21" y2="15"/></svg>';
+
+  const syncInspectorToggle = (visible: boolean) => {
+    inspectorToggle.setAttribute('aria-pressed', String(visible));
+    inspectorToggle.title = visible ? t('schedule.inspector.hide') : t('schedule.inspector.show');
+    inspectorToggle.setAttribute('aria-label', inspectorToggle.title);
+  };
+  syncInspectorToggle(activeControl?.getStore().getState().inspectorVisible ?? readInspectorVisible());
+
+  inspectorToggle.addEventListener('click', () => {
+    const store = activeControl?.getStore();
+    if (!store) return;
+    const next = !store.getState().inspectorVisible;
+    store.setInspectorVisible(next);
+    writeInspectorVisible(next);
+    syncInspectorToggle(next);
+  });
+
+  controlBar.appendChild(inspectorToggle);
 
   const unschedTab = document.createElement('button');
   unschedTab.dataset.sidebarTab = 'unscheduled';
@@ -961,7 +1000,13 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   });
 
   // The component's existing catalog content (everything after the control bar)
-  const catalogContent = Array.from(sidebar.children);
+  // The component's existing catalog content, EXCLUDING the Inspector panel.
+  // The Inspector is a sibling of the catalog in the layout's sidebar, so a naive
+  // `Array.from(sidebar.children)` sweeps it into "catalog content" and hides it
+  // whenever the Scheduled tab is shown — which is precisely why the Scheduled
+  // view had no Inspector. It is identified by the `data-panel` hook rather than
+  // by sibling order (both panels carry the same `sp-panel` class).
+  const catalogContent = Array.from(sidebar.children).filter((el) => (el as HTMLElement).dataset.panel !== 'inspector');
 
   // Insert control bar at top
   sidebar.insertBefore(controlBar, sidebar.firstChild);
@@ -1092,8 +1137,18 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
         // visual priority stays stable while the operator searches.
         const base = baseRoundByEvent.get(item.eventId);
         const roundOffset = base === undefined ? undefined : Math.max(0, item.roundNumber - base);
-        const card = buildMatchUpCard(item, {}, { prominentTime: true, roundOffset });
+        const card = buildMatchUpCard(
+          item,
+          { onClick: (m) => selectFromScheduledPanel(m.matchUpId) },
+          {
+            prominentTime: true,
+            roundOffset,
+          },
+        );
         if (!item.scheduledTime) card.classList.add('no-time');
+        if (activeControl?.getStore().getState().selectedMatchUp?.matchUpId === item.matchUpId) {
+          card.classList.add('selected');
+        }
         gb.appendChild(card);
       }
 
@@ -1101,6 +1156,28 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
       groupEl.appendChild(gb);
       scheduledCardsContainer.appendChild(groupEl);
     }
+  }
+
+  /**
+   * Select a Scheduled-panel card into the Inspector.
+   *
+   * ⚠️ Resolves the item out of `state.matchUpCatalog` rather than passing the
+   * card's own item. `scheduledMatchUpToCatalogItem` forces `isScheduled: false`
+   * so `buildMatchUpCard` attaches its dragstart listener; handing that object to
+   * the store would make the Inspector report "Scheduled: No" for a matchUp that
+   * plainly is. `buildCatalog(currentDate)` includes scheduled-on-this-date
+   * matchUps, so the lookup hits — and because the id IS in the catalog, the
+   * store's "clear selection when it leaves the catalog" guard cannot wrongly
+   * clear it either. The card's item is only a fallback.
+   */
+  function selectFromScheduledPanel(matchUpId: string): void {
+    const store = activeControl?.getStore();
+    if (!store) return;
+    const fromCatalog = store.getState().matchUpCatalog.find((m) => m.matchUpId === matchUpId);
+    const fallback = buildCatalog(currentDate).find((m) => m.matchUpId === matchUpId);
+    const resolved = fromCatalog ?? fallback;
+    if (resolved) store.selectMatchUp(resolved);
+    updateScheduledPanel();
   }
 
   // The default tab reflects the selected date's schedule state; the operator's

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -2375,7 +2375,9 @@ function extractParticipantIds(matchUp: any): string[] {
       continue;
     }
     if (participant.individualParticipantIds?.length) {
-      for (const id of participant.individualParticipantIds) ids.push(id);
+      // Single variadic push rather than one per id — SonarJS flags repeated
+      // `Array#push()` at the same scope.
+      ids.push(...participant.individualParticipantIds);
     } else if (participant.participantId) {
       ids.push(participant.participantId);
     }
@@ -2742,11 +2744,13 @@ function makeSpacerInteractive(stripEl: HTMLElement): void {
 function handleStripCellClick(event: MouseEvent, cellRoot: HTMLElement, refresh: () => void): void {
   if (!latestStripSnapshot) return;
 
-  const courtId = cellRoot.getAttribute('data-court-id') ?? '';
+  const courtId = cellRoot.dataset.courtId ?? '';
   if (!courtId) return;
 
-  const rowAttr = cellRoot.getAttribute('data-row-index');
-  const rowIndex = rowAttr === null ? 0 : Number(rowAttr);
+  // `dataset` yields undefined where getAttribute yielded null — the absent case
+  // still means row 0, and an empty string still coerces to 0 as before.
+  const rowAttr = cellRoot.dataset.rowIndex;
+  const rowIndex = rowAttr === undefined ? 0 : Number(rowAttr);
 
   const courtIndex = latestStripSnapshot.courtsData.findIndex((c) => c.courtId === courtId);
   if (courtIndex < 0) return;
@@ -3140,7 +3144,9 @@ function checkBlockInterruption(matchUp: any, courtId: string): BlockInterruptio
   }
 
   // Otherwise: does an upcoming block start before this matchUp could complete?
-  let nextBlock: any | undefined;
+  // `any` already admits undefined; `any | undefined` collapses to `any` and
+  // SonarJS flags the redundant member.
+  let nextBlock: any;
   for (const block of blocks) {
     if (block?.type === 'SCHEDULED') continue;
     if (!block.start || block.court?.courtId !== courtId) continue;
@@ -3361,8 +3367,15 @@ function applyHeaderRowIssueIndicators(
     if (issue === SCHEDULE_WARNING) return 1;
     return 0;
   };
+  // Seeded with the first issue so the accumulator is a plain severity string.
+  // Both callers already guard `!issues?.length`, but a seedless reduce THROWS on
+  // an empty array — the seed makes this correct on its own terms rather than
+  // dependent on those guards staying in place. Equivalent for non-empty input.
   const topSeverity = (issues: any[]): string =>
-    issues.reduce((top, cur) => (severityRank(cur.issue) > severityRank(top.issue) ? cur : top)).issue;
+    issues.reduce(
+      (top, cur) => (severityRank(cur.issue) > severityRank(top) ? cur.issue : top),
+      issues[0]?.issue ?? '',
+    );
 
   const severityColor = (issue: string): string => {
     if (issue === SCHEDULE_ERROR || issue === SCHEDULE_CONFLICT) return 'var(--sp-err, #f43f5e)';

--- a/src/pages/tournament/tabs/scheduleViews/gridViewStorage.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridViewStorage.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  readInspectorVisible,
   readScheduledFilters,
   readScheduledGroupBy,
   readScheduledSearch,
   readSidebarTab,
+  writeInspectorVisible,
   writeScheduledFilters,
   writeScheduledGroupBy,
   writeScheduledSearch,
@@ -147,5 +149,51 @@ describe('scheduled filters', () => {
   it('returns an empty object when stored JSON is malformed', () => {
     localStorage.setItem(FILTERS_KEY, 'not-json');
     expect(readScheduledFilters()).toEqual({});
+  });
+});
+
+const INSPECTOR_KEY = 'schedule2:inspector-visible';
+
+describe('inspector visibility', () => {
+  beforeEach(installMemoryStorage);
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('defaults to visible when nothing is stored', () => {
+    expect(readInspectorVisible()).toBe(true);
+  });
+
+  it('round-trips hidden', () => {
+    writeInspectorVisible(false);
+    expect(readInspectorVisible()).toBe(false);
+  });
+
+  it('round-trips back to visible', () => {
+    writeInspectorVisible(false);
+    writeInspectorVisible(true);
+    expect(readInspectorVisible()).toBe(true);
+  });
+
+  it('stores nothing for the default — visible removes the key rather than writing "true"', () => {
+    writeInspectorVisible(false);
+    expect(localStorage.getItem(INSPECTOR_KEY)).toBe('false');
+    writeInspectorVisible(true);
+    expect(localStorage.getItem(INSPECTOR_KEY)).toBeNull();
+  });
+
+  it('treats any value other than "false" as visible, so malformed storage cannot hide the panel', () => {
+    localStorage.setItem(INSPECTOR_KEY, 'nonsense');
+    expect(readInspectorVisible()).toBe(true);
+    localStorage.setItem(INSPECTOR_KEY, 'FALSE');
+    expect(readInspectorVisible()).toBe(true);
+  });
+
+  it('falls back to visible when storage throws on read', () => {
+    installThrowingStorage();
+    expect(readInspectorVisible()).toBe(true);
+  });
+
+  it('does not throw when storage throws on write', () => {
+    installThrowingStorage();
+    expect(() => writeInspectorVisible(false)).not.toThrow();
   });
 });

--- a/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
@@ -1,13 +1,16 @@
 /**
- * `gridView.ts` persists four pieces of view state across page reloads via
+ * `gridView.ts` persists five pieces of view state across page reloads via
  * `localStorage`:
  *
  *   - which sidebar tab the operator was last on (Unscheduled / Scheduled)
  *   - the Scheduled-panel search query
  *   - the Scheduled-panel group-by axis (event / draw / round / structure)
  *   - the Scheduled-panel filter selections (a `CatalogFilters` shape)
+ *   - whether the Inspector panel is shown (global to the matchUp catalog —
+ *     one flag for BOTH the Unscheduled and Scheduled views, because it is a
+ *     property of the catalog surface rather than of either tab)
  *
- * All four read / write pairs share a common contract: writes wrap
+ * All five read / write pairs share a common contract: writes wrap
  * `localStorage` in a `try { … } catch {}` so a sandboxed iframe (or
  * Storage-blocked browser) silently no-ops; reads return a sane default on
  * the same exception path so the UI always boots into a valid state.
@@ -26,6 +29,7 @@ const SIDEBAR_TAB_KEY = 'schedule2:sidebar-tab';
 const SCHEDULED_SEARCH_KEY = 'schedule2:scheduled-search';
 const SCHEDULED_GROUPBY_KEY = 'schedule2:scheduled-groupby';
 const SCHEDULED_FILTERS_KEY = 'schedule2:scheduled-filters';
+const INSPECTOR_VISIBLE_KEY = 'schedule2:inspector-visible';
 
 const VALID_GROUPBY: MatchUpCatalogGroupBy[] = ['event', 'draw', 'round', 'structure', 'time'];
 
@@ -103,6 +107,32 @@ export function writeScheduledFilters(value: CatalogFilters): void {
     const isEmpty = !value.eventType && !value.eventName && !value.drawName && !value.gender && !value.roundName;
     if (isEmpty) localStorage.removeItem(SCHEDULED_FILTERS_KEY);
     else localStorage.setItem(SCHEDULED_FILTERS_KEY, JSON.stringify(value));
+  } catch {
+    // storage unavailable
+  }
+}
+
+// ── Inspector visibility ──
+
+/**
+ * Defaults to VISIBLE: the Inspector is the surface that explains a placement,
+ * so an operator who has never touched the toggle should see it. Only an
+ * explicit `'false'` hides it — any other value (absent, malformed, storage
+ * throwing) falls back to visible rather than silently removing a panel the
+ * operator never asked to lose.
+ */
+export function readInspectorVisible(): boolean {
+  try {
+    return localStorage.getItem(INSPECTOR_VISIBLE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export function writeInspectorVisible(visible: boolean): void {
+  try {
+    if (visible) localStorage.removeItem(INSPECTOR_VISIBLE_KEY);
+    else localStorage.setItem(INSPECTOR_VISIBLE_KEY, 'false');
   } catch {
     // storage unavailable
   }

--- a/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
@@ -1,0 +1,140 @@
+/**
+ * Schedule2 — Inspector readiness section.
+ *
+ * The impure half of the readiness feature: gathers factory data, resolves
+ * timing through the engine, and renders the result into the courthive-components
+ * Inspector via its `renderInspectorExtra` hook. All rules live in the pure
+ * `matchUpReadiness.ts`; this file decides nothing.
+ *
+ * Timing comes from `tournamentEngine.getMatchUpFormatTiming`, which is what the
+ * auto-scheduler itself resolves against (including its scheduling-policy
+ * fallback, so unpoliced tournaments still get per-format averages rather than a
+ * flat 90/0). Resolution is memoised per `matchUpFormat|matchUpType` for the life
+ * of one render pass — a tournament has a handful of distinct pairs, not one per
+ * matchUp.
+ */
+
+import { getCachedAllMatchUps } from './schedule2DataCache';
+import { analyzeMatchUpReadiness } from './matchUpReadiness';
+import { tournamentEngine } from 'services/factory/engine';
+import { t } from 'i18n';
+
+// constants and types
+import type { ReadinessFinding, ReadinessMatchUp, ReadinessResult, ReadinessTiming } from './matchUpReadiness';
+
+const FALLBACK_TIMING: ReadinessTiming = { averageMinutes: 90, recoveryMinutes: 0 };
+
+/** Engine-backed timing lookup, memoised per format + type. */
+function makeTimingResolver(): (matchUp: ReadinessMatchUp) => ReadinessTiming {
+  const cache = new Map<string, ReadinessTiming>();
+  return (matchUp: ReadinessMatchUp) => {
+    const matchUpFormat = matchUp.matchUpFormat ?? '';
+    const key = `${matchUpFormat}|${matchUp.matchUpType ?? ''}`;
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    // A missing format cannot be resolved; the flat fallback keeps the
+    // arithmetic running rather than dropping every finding silently.
+    let timing = FALLBACK_TIMING;
+    if (matchUpFormat) {
+      // `matchUpType` is a plain string on the hydrated matchUp but an
+      // `EventTypeUnion` on the engine signature; the engine validates it and
+      // falls back to SINGLES, so widen at the boundary rather than duplicating
+      // the union here.
+      const result: any = tournamentEngine.getMatchUpFormatTiming({
+        eventType: matchUp.matchUpType as any,
+        matchUpFormat,
+      });
+      if (!result?.error) {
+        timing = {
+          averageMinutes: result?.averageMinutes ?? FALLBACK_TIMING.averageMinutes,
+          recoveryMinutes: result?.recoveryMinutes ?? FALLBACK_TIMING.recoveryMinutes,
+        };
+      }
+    }
+    cache.set(key, timing);
+    return timing;
+  };
+}
+
+/** Readiness for one matchUp, resolved against current factory state. */
+export function evaluateReadiness(matchUpId: string): ReadinessResult {
+  const { matchUps } = getCachedAllMatchUps();
+  return analyzeMatchUpReadiness({
+    matchUpId,
+    matchUps: (matchUps ?? []) as ReadinessMatchUp[],
+    timingFor: makeTimingResolver(),
+  });
+}
+
+function line(text: string, className: string): HTMLElement {
+  const el = document.createElement('div');
+  el.className = className;
+  el.textContent = text;
+  return el;
+}
+
+/**
+ * One finding as a sentence. Phrasing tracks `scheduleResultsDescribe.ts` so the
+ * auto-scheduler's deferral reasons and the Inspector describe the same condition
+ * the same way.
+ */
+export function describeFinding(finding: ReadinessFinding): string {
+  const names = finding.participantNames?.join(', ') ?? '';
+  const labels = finding.matchUpLabels?.join(', ') ?? '';
+  const notBefore = finding.notBefore;
+
+  if (finding.kind === 'overlap') return t('schedule.inspector.readiness.overlap', { names, labels });
+  if (finding.kind === 'recovery') {
+    return notBefore
+      ? t('schedule.inspector.readiness.recoveryNotBefore', { names, time: notBefore })
+      : t('schedule.inspector.readiness.recovery', { names });
+  }
+  if (finding.kind === 'dependency') {
+    return notBefore
+      ? t('schedule.inspector.readiness.dependencyNotBefore', { labels, time: notBefore })
+      : t('schedule.inspector.readiness.dependencyUnscheduled', { labels });
+  }
+  return t('schedule.inspector.readiness.undetermined', { labels });
+}
+
+function skipMessage(reason: string): string {
+  const key = `schedule.inspector.readiness.skip.${reason}`;
+  const message = t(key);
+  // `t()` echoes the key when it resolves to nothing; fall back to the generic
+  // line rather than printing a dotted path at the operator.
+  return message === key ? t('schedule.inspector.readiness.skip.generic') : message;
+}
+
+/**
+ * The `renderInspectorExtra` implementation. Returns a fresh element per call —
+ * the Inspector rebuilds its body on every state change, so a cached node would
+ * be re-parented rather than reused.
+ */
+export function renderReadinessSection(matchUpId: string): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const result = evaluateReadiness(matchUpId);
+
+  const section = document.createElement('div');
+  section.className = 'tmx-readiness';
+  section.dataset.readiness = result.evaluated ? String(result.findings.length) : 'skipped';
+  section.appendChild(line(t('schedule.inspector.readiness.heading'), 'tmx-readiness-heading'));
+
+  if (!result.evaluated) {
+    section.appendChild(line(skipMessage(result.reason), 'tmx-readiness-skip'));
+    return section;
+  }
+
+  if (!result.findings.length) {
+    section.appendChild(line(t('schedule.inspector.readiness.ready'), 'tmx-readiness-ok'));
+    return section;
+  }
+
+  for (const finding of result.findings) {
+    const row = line(describeFinding(finding), `tmx-readiness-finding is-${finding.severity.toLowerCase()}`);
+    row.dataset.kind = finding.kind;
+    section.appendChild(row);
+  }
+  return section;
+}

--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeMatchUpReadiness, individualIds, minutesToClock } from './matchUpReadiness';
+
+// constants and types
+import type { ReadinessMatchUp, ReadinessTiming } from './matchUpReadiness';
+
+/**
+ * Every finding kind is asserted as a PAIR: once where it fires, and once where
+ * the same fixture minus the offending condition stays silent. A single green
+ * assertion would not show the rule is wired to anything.
+ */
+
+const DATE = '2026-06-15';
+const OTHER_DATE = '2026-06-16';
+
+const TIMING_90_30: ReadinessTiming = { averageMinutes: 90, recoveryMinutes: 30 };
+const timing =
+  (t: ReadinessTiming = TIMING_90_30) =>
+  () =>
+    t;
+
+function player(participantId: string, participantName: string) {
+  return { participantId, participantName };
+}
+
+function matchUp(overrides: Partial<ReadinessMatchUp> & { matchUpId: string }): ReadinessMatchUp {
+  return {
+    roundName: 'R16',
+    sides: [player('p1', 'Alice'), player('p2', 'Bob')],
+    ...overrides,
+  };
+}
+
+function scheduled(time: string, date = DATE) {
+  return { scheduledDate: date, scheduledTime: time };
+}
+
+const kinds = (result: any): string[] => result.findings.map((f: any) => f.kind);
+
+describe('minutesToClock', () => {
+  it('formats and zero-pads', () => {
+    expect(minutesToClock(540)).toBe('09:00');
+    expect(minutesToClock(605)).toBe('10:05');
+  });
+
+  it('wraps past midnight rather than emitting 25:xx', () => {
+    expect(minutesToClock(1500)).toBe('01:00');
+  });
+});
+
+describe('individualIds', () => {
+  it('expands a doubles side to its members and does not also count the pair', () => {
+    const ids = individualIds(
+      matchUp({
+        matchUpId: 'M',
+        sides: [
+          { participantId: 'pair1', participant: { participantId: 'pair1', individualParticipantIds: ['a', 'b'] } },
+          player('p2', 'Bob'),
+        ],
+      }),
+    );
+    expect(ids).toEqual(['a', 'b', 'p2']);
+    expect(ids).not.toContain('pair1');
+  });
+
+  it('falls back to the side participantId when members are unknown', () => {
+    const ids = individualIds(matchUp({ matchUpId: 'M', sides: [{ participantId: 'solo' }] }));
+    expect(ids).toEqual(['solo']);
+  });
+});
+
+describe('analyzeMatchUpReadiness — not evaluated', () => {
+  const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00') });
+
+  it('reports unknownMatchUp when the id is absent', () => {
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'nope', matchUps: [target], timingFor: timing() });
+    expect(result).toEqual({ evaluated: false, reason: 'unknownMatchUp' });
+  });
+
+  it('skips a BYE', () => {
+    const bye = matchUp({ matchUpId: 'T', matchUpStatus: 'BYE', schedule: scheduled('10:00') });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [bye], timingFor: timing() });
+    expect(result.reason).toBe('bye');
+  });
+
+  it('skips a completed matchUp — by status and by winningSide', () => {
+    const byStatus = matchUp({ matchUpId: 'T', matchUpStatus: 'COMPLETED', schedule: scheduled('10:00') });
+    const byWinner = matchUp({ matchUpId: 'T', winningSide: 1, schedule: scheduled('10:00') });
+    expect((analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [byStatus], timingFor: timing() }) as any).reason).toBe(
+      'completed',
+    );
+    expect((analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [byWinner], timingFor: timing() }) as any).reason).toBe(
+      'completed',
+    );
+  });
+
+  it('skips when unscheduled, and separately when scheduled with no time', () => {
+    const unscheduled = matchUp({ matchUpId: 'T' });
+    const dateOnly = matchUp({ matchUpId: 'T', schedule: { scheduledDate: DATE } });
+    expect(
+      (analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [unscheduled], timingFor: timing() }) as any).reason,
+    ).toBe('notScheduled');
+    expect((analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [dateOnly], timingFor: timing() }) as any).reason).toBe(
+      'noTime',
+    );
+  });
+
+  it('a clean matchUp is evaluated with no findings — not skipped', () => {
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target], timingFor: timing() });
+    expect(result.evaluated).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+});
+
+describe('analyzeMatchUpReadiness — overlap', () => {
+  const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00') });
+
+  it('fires when a shared participant is on court elsewhere at the start time', () => {
+    // Neighbour 09:30 + 90min average runs to 11:00, so 10:00 lands inside it.
+    const neighbour = matchUp({ matchUpId: 'N', schedule: scheduled('09:30'), sides: [player('p1', 'Alice')] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, neighbour],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toContain('overlap');
+    expect(result.findings[0].participantNames).toEqual(['Alice']);
+  });
+
+  it('stays silent when the same neighbour finishes before the start time', () => {
+    // 08:00 + 90 = 09:30, clear of 10:00. Recovery is 30min → free 10:00, not > 10:00.
+    const neighbour = matchUp({ matchUpId: 'N', schedule: scheduled('08:00'), sides: [player('p1', 'Alice')] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, neighbour],
+      timingFor: timing(),
+    });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('stays silent when the neighbour shares no participant', () => {
+    const neighbour = matchUp({
+      matchUpId: 'N',
+      schedule: scheduled('09:30'),
+      sides: [player('p9', 'Zoe'), player('p8', 'Yan')],
+    });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, neighbour],
+      timingFor: timing(),
+    });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('stays silent when the overlapping matchUp is on another date', () => {
+    const neighbour = matchUp({
+      matchUpId: 'N',
+      schedule: scheduled('09:30', OTHER_DATE),
+      sides: [player('p1', 'Alice')],
+    });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, neighbour],
+      timingFor: timing(),
+    });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('matches a doubles player against a singles neighbour via individualParticipantIds', () => {
+    const doubles = matchUp({
+      matchUpId: 'T',
+      schedule: scheduled('10:00'),
+      sides: [
+        { participantId: 'pair1', participant: { participantId: 'pair1', individualParticipantIds: ['a', 'b'] } },
+        { participantId: 'pair2', participant: { participantId: 'pair2', individualParticipantIds: ['c', 'd'] } },
+      ],
+    });
+    const neighbour = matchUp({ matchUpId: 'N', schedule: scheduled('09:30'), sides: [{ participantId: 'a' }] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [doubles, neighbour],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toContain('overlap');
+    expect(result.findings[0].participantIds).toEqual(['a']);
+  });
+});
+
+describe('analyzeMatchUpReadiness — recovery', () => {
+  const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00') });
+
+  it('fires when an earlier matchUp leaves the participant inside the recovery window', () => {
+    // 08:15 + 90 = 09:45, + 30 recovery = 10:15 > 10:00.
+    const earlier = matchUp({ matchUpId: 'E', schedule: scheduled('08:15'), sides: [player('p1', 'Alice')] });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target, earlier], timingFor: timing() });
+    expect(kinds(result)).toEqual(['recovery']);
+    expect(result.findings[0].notBefore).toBe('10:15');
+    expect(result.findings[0].participantNames).toEqual(['Alice']);
+  });
+
+  it('stays silent for the identical fixture when recoveryMinutes is 0', () => {
+    const earlier = matchUp({ matchUpId: 'E', schedule: scheduled('08:15'), sides: [player('p1', 'Alice')] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, earlier],
+      timingFor: timing({ averageMinutes: 90, recoveryMinutes: 0 }),
+    });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('prefers a real endTime over the projected average', () => {
+    // Finished early at 09:00 → free 09:30, clear of 10:00, so nothing fires.
+    const earlier = matchUp({
+      matchUpId: 'E',
+      matchUpStatus: 'COMPLETED',
+      winningSide: 1,
+      sides: [player('p1', 'Alice')],
+      schedule: { scheduledDate: DATE, scheduledTime: '08:15', endTime: '09:00' },
+    });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target, earlier], timingFor: timing() });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('overlap suppresses recovery for the same participant', () => {
+    // One neighbour overlaps 10:00; another would only trigger recovery for the
+    // same player. Only the stronger finding should mention Alice.
+    const overlapping = matchUp({ matchUpId: 'N', schedule: scheduled('09:30'), sides: [player('p1', 'Alice')] });
+    const recovering = matchUp({ matchUpId: 'E', schedule: scheduled('08:15'), sides: [player('p1', 'Alice')] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, overlapping, recovering],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toEqual(['overlap']);
+  });
+
+  it('still reports recovery for a DIFFERENT participant when one is overlapped', () => {
+    const overlapping = matchUp({ matchUpId: 'N', schedule: scheduled('09:30'), sides: [player('p1', 'Alice')] });
+    const recovering = matchUp({ matchUpId: 'E', schedule: scheduled('08:15'), sides: [player('p2', 'Bob')] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, overlapping, recovering],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toEqual(['overlap', 'recovery']);
+    expect(result.findings[1].participantNames).toEqual(['Bob']);
+  });
+});
+
+describe('analyzeMatchUpReadiness — dependency', () => {
+  // S feeds T: S.winnerMatchUpId === 'T'.
+  const source = (overrides: Partial<ReadinessMatchUp> = {}) =>
+    matchUp({ matchUpId: 'S', roundName: 'R32', winnerMatchUpId: 'T', sides: [player('p3', 'Cara')], ...overrides });
+  const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00'), sides: [player('p1', 'Alice'), {}] });
+
+  it('fires when an incomplete upstream matchUp projects to finish after the start time', () => {
+    // 09:00 + 90 = 10:30 > 10:00.
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source({ schedule: scheduled('09:00') })],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toContain('dependency');
+    const dependency = result.findings.find((f: any) => f.kind === 'dependency');
+    expect(dependency.notBefore).toBe('10:30');
+    expect(dependency.matchUpLabels).toEqual(['R32: Cara']);
+  });
+
+  it('stays silent for the identical fixture when the upstream finishes in time', () => {
+    // 08:00 + 90 = 09:30 <= 10:00.
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source({ schedule: scheduled('08:00') })],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).not.toContain('dependency');
+  });
+
+  it('fires with no notBefore when the upstream is not scheduled at all', () => {
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source()],
+      timingFor: timing(),
+    });
+    const dependency = result.findings.find((f: any) => f.kind === 'dependency');
+    expect(dependency).toBeTruthy();
+    expect(dependency.notBefore).toBeUndefined();
+  });
+
+  it('stays silent when the upstream is complete', () => {
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source({ winningSide: 1, matchUpStatus: 'COMPLETED' })],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).not.toContain('dependency');
+  });
+
+  it('walks transitively — a grandparent blocks too', () => {
+    const grandparent = matchUp({ matchUpId: 'G', roundName: 'R64', winnerMatchUpId: 'S', sides: [] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source({ schedule: scheduled('09:00') }), grandparent],
+      timingFor: timing(),
+    });
+    const ids = result.findings.filter((f: any) => f.kind === 'dependency').flatMap((f: any) => f.matchUpIds);
+    expect(ids).toContain('G');
+  });
+
+  it('stops the walk at a finished parent — its own parents cannot still be pending', () => {
+    const grandparent = matchUp({ matchUpId: 'G', winnerMatchUpId: 'S', sides: [] });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, source({ winningSide: 1 }), grandparent],
+      timingFor: timing(),
+    });
+    const ids = result.findings.flatMap((f: any) => f.matchUpIds ?? []);
+    expect(ids).not.toContain('G');
+  });
+
+  it('follows loserMatchUpId as well as winnerMatchUpId', () => {
+    const consolationSource = matchUp({
+      matchUpId: 'L',
+      roundName: 'R32',
+      loserMatchUpId: 'T',
+      sides: [player('p4', 'Dee')],
+    });
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [target, consolationSource],
+      timingFor: timing(),
+    });
+    expect(result.findings.flatMap((f: any) => f.matchUpIds ?? [])).toContain('L');
+  });
+});
+
+describe('analyzeMatchUpReadiness — undetermined', () => {
+  it('fires when a side has no participant and an upstream matchUp is incomplete', () => {
+    const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00'), sides: [player('p1', 'Alice'), {}] });
+    const source = matchUp({ matchUpId: 'S', winnerMatchUpId: 'T', schedule: scheduled('08:00'), sides: [] });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target, source], timingFor: timing() });
+    expect(kinds(result)).toEqual(['undetermined']);
+    expect(result.findings[0].severity).toBe('INFO');
+  });
+
+  it('stays silent for the identical fixture when both sides are known', () => {
+    const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00') });
+    const source = matchUp({ matchUpId: 'S', winnerMatchUpId: 'T', schedule: scheduled('08:00'), sides: [] });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target, source], timingFor: timing() });
+    expect(result.findings).toEqual([]);
+  });
+
+  it('stays silent when the side is unknown but nothing upstream is pending', () => {
+    const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00'), sides: [player('p1', 'Alice'), {}] });
+    let result: any = analyzeMatchUpReadiness({ matchUpId: 'T', matchUps: [target], timingFor: timing() });
+    expect(result.findings).toEqual([]);
+  });
+});
+
+describe('analyzeMatchUpReadiness — ordering', () => {
+  it('returns findings strongest-first', () => {
+    const target = matchUp({ matchUpId: 'T', schedule: scheduled('10:00'), sides: [player('p1', 'Alice'), {}] });
+    const overlapping = matchUp({ matchUpId: 'N', schedule: scheduled('09:30'), sides: [player('p1', 'Alice')] });
+    const recovering = matchUp({ matchUpId: 'E', schedule: scheduled('08:15'), sides: [player('p2', 'Bob')] });
+    const source = matchUp({ matchUpId: 'S', winnerMatchUpId: 'T', schedule: scheduled('09:00'), sides: [] });
+    const targetWithBob = { ...target, sides: [player('p1', 'Alice'), player('p2', 'Bob')] };
+
+    let result: any = analyzeMatchUpReadiness({
+      matchUpId: 'T',
+      matchUps: [targetWithBob, overlapping, recovering, source],
+      timingFor: timing(),
+    });
+    expect(kinds(result)).toEqual(['overlap', 'dependency', 'recovery']);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
@@ -1,0 +1,410 @@
+/**
+ * Schedule2 — matchUp readiness analysis (pure, DOM-free, engine-free).
+ *
+ * Answers, for one scheduled matchUp: *can this placement actually happen at the
+ * time it is scheduled for?* Four ways it cannot:
+ *
+ *   - `undetermined` — a side has no participant yet because an upstream matchUp
+ *     has not finished. Informational on its own; becomes a `dependency` finding
+ *     when that upstream also cannot finish in time.
+ *   - `dependency`   — an incomplete upstream matchUp projects to finish AFTER
+ *     this one is due to start (or is not scheduled at all).
+ *   - `recovery`     — a participant's earlier matchUp leaves them still in
+ *     their recovery window at this matchUp's start time.
+ *   - `overlap`      — a participant is due on court in another matchUp whose
+ *     playing window contains this start time. Strictly worse than `recovery`,
+ *     so it suppresses the recovery finding for the same participant.
+ *
+ * ── Why this lives in TMX, and behind an adapter ──
+ *
+ * The rules are domain rules and arguably belong in the factory, which already
+ * has `checkRecoveryTime` inside the scheduler. But that machinery is not
+ * exposed as a standalone query, and this surface needs an answer per selected
+ * matchUp rather than per scheduling run. So the arithmetic lives here, while
+ * every *domain value* it reasons about comes from the factory:
+ *
+ *   - upstream edges are inverted from hydrated `winnerMatchUpId` /
+ *     `loserMatchUpId` (`nextMatchUps: true`), not re-derived from draw shape;
+ *   - `averageMinutes` / `recoveryMinutes` arrive through the injected
+ *     `timingFor` callback, which the caller backs with the engine's
+ *     `getMatchUpFormatTiming` — the same resolution the auto-scheduler uses,
+ *     including its scheduling-policy fallback.
+ *
+ * `ReadinessInput` → `ReadinessResult` is therefore the seam: a future factory
+ * `getMatchUpReadiness` replaces this function's body and keeps the contract.
+ * Nothing above the seam knows which side of it the answer came from.
+ *
+ * Vocabulary deliberately matches `scheduleResultsDescribe.ts` ("needs recovery
+ * time", "not before HH:MM", "waiting on …") so the same condition does not read
+ * two different ways on the same page.
+ */
+
+import { parseClockMinutes } from './courtTimeOrderIssues';
+
+// constants and types
+
+export type ReadinessKind = 'undetermined' | 'dependency' | 'recovery' | 'overlap';
+export type ReadinessSeverity = 'WARN' | 'INFO';
+
+/** The shape readiness needs off a hydrated matchUp. Structural, so the caller can pass factory output directly. */
+export interface ReadinessMatchUp {
+  matchUpId: string;
+  matchUpStatus?: string;
+  matchUpFormat?: string;
+  matchUpType?: string;
+  eventId?: string;
+  roundName?: string;
+  roundNumber?: number;
+  winningSide?: number;
+  winnerMatchUpId?: string;
+  loserMatchUpId?: string;
+  sides?: ReadinessSide[];
+  schedule?: ReadinessSchedule | null;
+}
+
+export interface ReadinessSide {
+  participantId?: string;
+  participantName?: string;
+  participant?: {
+    participantId?: string;
+    participantName?: string;
+    individualParticipantIds?: string[];
+  };
+}
+
+export interface ReadinessSchedule {
+  scheduledDate?: string;
+  scheduledTime?: string;
+  courtId?: string;
+  endTime?: string;
+}
+
+export interface ReadinessTiming {
+  averageMinutes: number;
+  recoveryMinutes: number;
+}
+
+export interface ReadinessInput {
+  /** The matchUp being inspected. */
+  matchUpId: string;
+  /** Every matchUp in the tournament, hydrated `{ inContext: true, nextMatchUps: true }`. */
+  matchUps: ReadinessMatchUp[];
+  /** Engine-backed timing resolution. Returning zeroes disables the time arithmetic without breaking it. */
+  timingFor: (matchUp: ReadinessMatchUp) => ReadinessTiming;
+}
+
+export interface ReadinessFinding {
+  kind: ReadinessKind;
+  severity: ReadinessSeverity;
+  participantIds?: string[];
+  participantNames?: string[];
+  matchUpIds?: string[];
+  matchUpLabels?: string[];
+  /** Earliest clock time the blocker clears, `HH:MM`. Absent when it cannot be projected. */
+  notBefore?: string;
+}
+
+/** Why readiness could not be evaluated. Never reported as "ready" — an unevaluated matchUp is not a clean one. */
+export type ReadinessSkipReason = 'unknownMatchUp' | 'bye' | 'completed' | 'notScheduled' | 'noTime';
+
+export type ReadinessResult =
+  { evaluated: false; reason: ReadinessSkipReason } | { evaluated: true; findings: ReadinessFinding[] };
+
+const BYE = 'BYE';
+const COMPLETED_STATUSES = new Set([
+  'COMPLETED',
+  'RETIRED',
+  'WALKOVER',
+  'DEFAULTED',
+  'DOUBLE_WALKOVER',
+  'DOUBLE_DEFAULT',
+  'ABANDONED',
+]);
+
+/** True when a matchUp has a result and can no longer block anything. */
+export function isFinished(matchUp: ReadinessMatchUp): boolean {
+  return !!matchUp.winningSide || (!!matchUp.matchUpStatus && COMPLETED_STATUSES.has(matchUp.matchUpStatus));
+}
+
+/** `540` → `'09:00'`. Wraps past midnight rather than producing `25:xx`. */
+export function minutesToClock(minutes: number): string {
+  const wrapped = ((Math.round(minutes) % 1440) + 1440) % 1440;
+  const hh = Math.floor(wrapped / 60);
+  const mm = wrapped % 60;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+/** Individual participantIds on a matchUp — expands doubles/team sides to their members. */
+export function individualIds(matchUp: ReadinessMatchUp): string[] {
+  const ids = new Set<string>();
+  for (const side of matchUp.sides ?? []) {
+    for (const id of side.participant?.individualParticipantIds ?? []) ids.add(id);
+    const sideId = side.participantId ?? side.participant?.participantId;
+    // A side's own participantId is only a *substitute* for its members when the
+    // members are unknown — otherwise a doubles pair would be counted twice, as
+    // itself and as its players, and never match the individuals on another side.
+    if (sideId && !side.participant?.individualParticipantIds?.length) ids.add(sideId);
+  }
+  return [...ids];
+}
+
+function sideLabel(side: ReadinessSide): string {
+  return side.participant?.participantName ?? side.participantName ?? 'TBD';
+}
+
+/** "R16: Alice vs Bob" — the label vocabulary the issues panel already uses. */
+export function matchUpLabel(matchUp: ReadinessMatchUp): string {
+  const names = (matchUp.sides ?? []).map(sideLabel);
+  const players = names.length ? names.join(' vs ') : 'TBD vs TBD';
+  return matchUp.roundName ? `${matchUp.roundName}: ${players}` : players;
+}
+
+/** Direct upstream feeders, inverted from the forward `winner`/`loser` edges. */
+function buildFeederMap(matchUps: ReadinessMatchUp[]): Map<string, string[]> {
+  const feeders = new Map<string, string[]>();
+  const push = (target: string | undefined, source: string) => {
+    if (!target) return;
+    const list = feeders.get(target);
+    if (list) list.push(source);
+    else feeders.set(target, [source]);
+  };
+  for (const matchUp of matchUps) {
+    push(matchUp.winnerMatchUpId, matchUp.matchUpId);
+    push(matchUp.loserMatchUpId, matchUp.matchUpId);
+  }
+  return feeders;
+}
+
+/**
+ * Every incomplete matchUp upstream of `matchUpId`, transitively. A grandparent
+ * that has not been played blocks just as surely as a parent, and the walk stops
+ * at finished matchUps because nothing behind them can still be pending.
+ */
+function incompleteUpstream(
+  matchUpId: string,
+  feeders: Map<string, string[]>,
+  byId: Map<string, ReadinessMatchUp>,
+): ReadinessMatchUp[] {
+  const found: ReadinessMatchUp[] = [];
+  const seen = new Set<string>([matchUpId]);
+  const queue = [...(feeders.get(matchUpId) ?? [])];
+
+  while (queue.length) {
+    const id = queue.shift() as string;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const matchUp = byId.get(id);
+    if (!matchUp) continue;
+    if (isFinished(matchUp)) continue;
+    if (matchUp.matchUpStatus === BYE) continue;
+    found.push(matchUp);
+    queue.push(...(feeders.get(id) ?? []));
+  }
+  return found;
+}
+
+/** When an incomplete matchUp is projected to finish, in minutes. `null` when it cannot be projected. */
+function projectedFinish(matchUp: ReadinessMatchUp, timing: ReadinessTiming): number | null {
+  const start = parseClockMinutes(matchUp.schedule?.scheduledTime);
+  if (start === null) return null;
+  return start + timing.averageMinutes;
+}
+
+/** When a participant coming out of `matchUp` is next available, in minutes. `null` when unprojectable. */
+function freeAfter(matchUp: ReadinessMatchUp, timing: ReadinessTiming): number | null {
+  const end = parseClockMinutes(matchUp.schedule?.endTime);
+  if (end !== null) return end + timing.recoveryMinutes;
+  const start = parseClockMinutes(matchUp.schedule?.scheduledTime);
+  if (start === null) return null;
+  return start + timing.averageMinutes + timing.recoveryMinutes;
+}
+
+function skip(reason: ReadinessSkipReason): ReadinessResult {
+  return { evaluated: false, reason };
+}
+
+/** Why the target cannot be evaluated, or undefined when it can. */
+function skipReasonFor(target: ReadinessMatchUp): ReadinessSkipReason | undefined {
+  if (target.matchUpStatus === BYE) return 'bye';
+  if (isFinished(target)) return 'completed';
+  if (!target.schedule?.scheduledDate) return 'notScheduled';
+  if (parseClockMinutes(target.schedule?.scheduledTime) === null) return 'noTime';
+  return undefined;
+}
+
+function undeterminedFinding(target: ReadinessMatchUp, upstream: ReadinessMatchUp[]): ReadinessFinding | undefined {
+  const hasUnknownSide = (target.sides ?? []).some((side) => !(side.participantId ?? side.participant?.participantId));
+  if (!hasUnknownSide || !upstream.length) return undefined;
+  return {
+    kind: 'undetermined',
+    severity: 'INFO',
+    matchUpIds: upstream.map((m) => m.matchUpId),
+    matchUpLabels: upstream.map(matchUpLabel),
+  };
+}
+
+function dependencyFindings(
+  upstream: ReadinessMatchUp[],
+  startMinutes: number,
+  timingFor: ReadinessInput['timingFor'],
+): ReadinessFinding[] {
+  const findings: ReadinessFinding[] = [];
+  for (const source of upstream) {
+    const finish = projectedFinish(source, timingFor(source));
+    // Unscheduled upstream: cannot be projected, and therefore cannot be
+    // promised to finish in time — reported without a `notBefore`.
+    if (finish === null) {
+      findings.push({
+        kind: 'dependency',
+        severity: 'WARN',
+        matchUpIds: [source.matchUpId],
+        matchUpLabels: [matchUpLabel(source)],
+      });
+      continue;
+    }
+    if (finish > startMinutes) {
+      findings.push({
+        kind: 'dependency',
+        severity: 'WARN',
+        matchUpIds: [source.matchUpId],
+        matchUpLabels: [matchUpLabel(source)],
+        notBefore: minutesToClock(finish),
+      });
+    }
+  }
+  return findings;
+}
+
+type ParticipantClash = {
+  participantId: string;
+  participantName: string;
+  matchUp: ReadinessMatchUp;
+  notBefore?: string;
+};
+
+/** Name for a participantId, taken from whichever matchUp side carries it. */
+function nameFor(participantId: string, matchUps: ReadinessMatchUp[]): string {
+  for (const matchUp of matchUps) {
+    for (const side of matchUp.sides ?? []) {
+      if ((side.participantId ?? side.participant?.participantId) === participantId) return sideLabel(side);
+      if (side.participant?.individualParticipantIds?.includes(participantId)) return sideLabel(side);
+    }
+  }
+  return participantId;
+}
+
+/** Other same-day matchUps that share an individual with the target. */
+function sameDayNeighbours(target: ReadinessMatchUp, matchUps: ReadinessMatchUp[]): ReadinessMatchUp[] {
+  const date = target.schedule?.scheduledDate;
+  const targetIndividuals = new Set(individualIds(target));
+  if (!targetIndividuals.size) return [];
+  return matchUps.filter((matchUp) => {
+    if (matchUp.matchUpId === target.matchUpId) return false;
+    if (matchUp.matchUpStatus === BYE) return false;
+    if (matchUp.schedule?.scheduledDate !== date) return false;
+    return individualIds(matchUp).some((id) => targetIndividuals.has(id));
+  });
+}
+
+/** Shared individuals between two matchUps, as clash rows. */
+function clashesBetween(
+  target: ReadinessMatchUp,
+  neighbour: ReadinessMatchUp,
+  matchUps: ReadinessMatchUp[],
+): ParticipantClash[] {
+  const targetIndividuals = new Set(individualIds(target));
+  return individualIds(neighbour)
+    .filter((id) => targetIndividuals.has(id))
+    .map((participantId) => ({
+      participantId,
+      participantName: nameFor(participantId, matchUps),
+      matchUp: neighbour,
+    }));
+}
+
+function toFinding(kind: ReadinessKind, clashes: ParticipantClash[]): ReadinessFinding {
+  const notBefore = clashes.map((c) => c.notBefore).find(Boolean);
+  return {
+    kind,
+    severity: 'WARN',
+    participantIds: clashes.map((c) => c.participantId),
+    participantNames: [...new Set(clashes.map((c) => c.participantName))],
+    matchUpIds: [...new Set(clashes.map((c) => c.matchUp.matchUpId))],
+    matchUpLabels: [...new Set(clashes.map((c) => matchUpLabel(c.matchUp)))],
+    ...(notBefore && { notBefore }),
+  };
+}
+
+/**
+ * Overlap and recovery in one pass, because they are the same question asked at
+ * two strengths and must not both fire for one participant: overlap means the
+ * participant is *on court elsewhere* at this start time, which already implies
+ * the recovery window is violated.
+ */
+function clashFindings(
+  target: ReadinessMatchUp,
+  startMinutes: number,
+  matchUps: ReadinessMatchUp[],
+  timingFor: ReadinessInput['timingFor'],
+): ReadinessFinding[] {
+  const overlapping: ParticipantClash[] = [];
+  const recovering: ParticipantClash[] = [];
+  const overlappedIds = new Set<string>();
+
+  for (const neighbour of sameDayNeighbours(target, matchUps)) {
+    const timing = timingFor(neighbour);
+    const neighbourStart = parseClockMinutes(neighbour.schedule?.scheduledTime);
+    const clashes = clashesBetween(target, neighbour, matchUps);
+    if (!clashes.length) continue;
+
+    const isOverlap =
+      !isFinished(neighbour) &&
+      neighbourStart !== null &&
+      neighbourStart <= startMinutes &&
+      startMinutes < neighbourStart + Math.max(timing.averageMinutes, 1);
+
+    if (isOverlap) {
+      overlapping.push(...clashes);
+      for (const clash of clashes) overlappedIds.add(clash.participantId);
+      continue;
+    }
+
+    const free = freeAfter(neighbour, timing);
+    if (free === null || free <= startMinutes) continue;
+    recovering.push(...clashes.map((clash) => ({ ...clash, notBefore: minutesToClock(free) })));
+  }
+
+  const stillRecovering = recovering.filter((clash) => !overlappedIds.has(clash.participantId));
+  const findings: ReadinessFinding[] = [];
+  if (overlapping.length) findings.push(toFinding('overlap', overlapping));
+  if (stillRecovering.length) findings.push(toFinding('recovery', stillRecovering));
+  return findings;
+}
+
+/**
+ * Readiness for one scheduled matchUp. Findings are ordered strongest-first
+ * (`overlap` → `dependency` → `recovery` → `undetermined`) so a renderer can
+ * take the head as the headline without re-deciding severity.
+ */
+export function analyzeMatchUpReadiness(input: ReadinessInput): ReadinessResult {
+  const byId = new Map(input.matchUps.map((matchUp) => [matchUp.matchUpId, matchUp]));
+  const target = byId.get(input.matchUpId);
+  if (!target) return skip('unknownMatchUp');
+
+  const reason = skipReasonFor(target);
+  if (reason) return skip(reason);
+
+  const startMinutes = parseClockMinutes(target.schedule?.scheduledTime) as number;
+  const upstream = incompleteUpstream(target.matchUpId, buildFeederMap(input.matchUps), byId);
+
+  const findings: ReadinessFinding[] = [
+    ...clashFindings(target, startMinutes, input.matchUps, input.timingFor),
+    ...dependencyFindings(upstream, startMinutes, input.timingFor),
+  ];
+
+  const undetermined = undeterminedFinding(target, upstream);
+  if (undetermined) findings.push(undetermined);
+
+  const order: ReadinessKind[] = ['overlap', 'dependency', 'recovery', 'undetermined'];
+  return { evaluated: true, findings: findings.toSorted((a, b) => order.indexOf(a.kind) - order.indexOf(b.kind)) };
+}

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -253,3 +253,77 @@
   background-color: var(--tmx-panel-red-bg);
   border-color: var(--tmx-accent-red) !important;
 }
+
+/* ── Schedule2 Inspector: readiness section ──
+   Rendered into the courthive-components Inspector body (`.sp-inspector`) via
+   its `renderInspectorExtra` hook. Colours come from theme tokens so the block
+   reads correctly in both light and dark; severity is carried on the row class
+   rather than inline, so a re-theme needs no JS change. */
+
+.tmx-readiness {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--tmx-border-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tmx-readiness-heading {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--tmx-text-secondary);
+}
+
+.tmx-readiness-ok {
+  font-size: 0.75rem;
+  color: var(--tmx-accent-green);
+}
+
+.tmx-readiness-skip {
+  font-size: 0.75rem;
+  color: var(--tmx-text-secondary);
+  font-style: italic;
+}
+
+.tmx-readiness-finding {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  padding-left: 8px;
+  border-left: 3px solid var(--tmx-accent-orange);
+  color: var(--tmx-text-primary);
+}
+
+.tmx-readiness-finding.is-warn {
+  border-left-color: var(--tmx-accent-red);
+}
+
+.tmx-readiness-finding.is-info {
+  border-left-color: var(--tmx-accent-blue);
+  color: var(--tmx-text-secondary);
+}
+
+/* Inspector show/hide toggle in the sidebar control bar. */
+.tmx-inspector-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 5px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+  color: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.tmx-inspector-toggle:hover {
+  border-color: var(--tmx-border-primary);
+}
+
+.tmx-inspector-toggle[aria-pressed='true'] {
+  background: var(--tmx-fill-accent, #2563eb);
+  color: #fff;
+}


### PR DESCRIPTION
Closes the **Schedule MatchUp Inspector** workstream ([plan](https://github.com/CourtHive/Mentat/blob/main/planning/SCHEDULE_MATCHUP_INSPECTOR.md)). Consumes the extension points published in courthive-components **3.14.0** (already pinned on `main`).

## What changes for a tournament director

| before | after |
|---|---|
| Inspector on the Unscheduled tab only | Inspector on **both** tabs |
| No way to reclaim the vertical space | Toggle icon left of the tabs, persisted |
| Scheduled cards inert | Click to select; Inspector describes it |
| Inspector = static detail | **Readiness**: can this placement actually happen? |

## Readiness

`matchUpReadiness.ts` — pure, DOM-free, engine-free — behind a `ReadinessInput → ReadinessResult` adapter, so a future factory `getMatchUpReadiness` replaces the body without touching the Inspector.

| kind | fires when |
|---|---|
| `overlap` | a participant is on court elsewhere at this start time |
| `dependency` | an incomplete upstream matchUp projects to finish after this start (or isn't scheduled) |
| `recovery` | an earlier matchUp leaves the participant inside their recovery window |
| `undetermined` | a side has no participant yet and something upstream is pending |

Ordered strongest-first, and `overlap` suppresses `recovery` for the same participant — the same question at two strengths should not report twice. Unevaluated cases (BYE, complete, unscheduled, no time) say *why*; an unevaluated matchUp is never shown as clean.

**No factory change was needed.** Upstream edges invert the hydrated `winnerMatchUpId` / `loserMatchUpId` already in the cache; `averageMinutes` / `recoveryMinutes` come from the engine's `getMatchUpFormatTiming`, which is what the auto-scheduler resolves against (policy fallback included), so no timing rule is re-implemented here. Wording tracks `scheduleResultsDescribe.ts`.

> The plan's data-path assumption was slightly wrong and worth recording: `allTournamentMatchUps({ afterRecoveryTimes: true })` does **not** hydrate `timeAfterRecovery` on its own — `getMatchUpScheduleDetails` only computes it when `scheduleTiming` is *also* passed, and that param is not auto-resolved. `getMatchUpFormatTiming` is the primitive that actually resolves per event + format.

## Two traps handled

- **`isScheduled` forgery.** `scheduledMatchUpToCatalogItem` forces `isScheduled: false` so the cards stay draggable. Selection resolves the real item out of `state.matchUpCatalog`; passing the card's own item made the Inspector read "Scheduled: **No**" for a scheduled matchUp. Pinned by an e2e assertion.
- **No auto-open.** Selecting while hidden leaves it hidden — a persisted operator choice is not silently overridden.

## Verification

| gate | result |
|---|---|
| `pnpm lint` · `format:check` · `attr-audit --ci` · `i18n-audit --ci` · `check-types` | all 0 |
| `pnpm test --run` | 111 files / **1160** tests (+37) |
| e2e journeys 97 / 38 / 47 / 59 / 96 | **19 passed** |

Every readiness kind has a firing case **and** a silent control on the same fixture minus the offending condition. Journey 97 seeds a real cross-event participant clash and **throws if the seed stops producing one**, so the assertion cannot pass against an empty panel. Falsified: disabling clash detection reddens exactly the clash case and leaves the control green.

⚠️ **One assertion does not discriminate, and the commit says so.** Journey 97's "Inspector on both tabs" case passes with the `setTab` filter removed, because the components layout rewrites `inspectorVisible` onto the panel on every render and a store tick undoes `setTab`'s `display:none` regardless. Confirmed by a DOM probe after the switch: `catalog inline="none"`, `inspector inline=""`. The filter is kept — two owners of one element's `display` is a latent flash — but it is belt-and-braces, not the mechanism. Don't read that green as coverage of the filter.

`attr-audit`: `participantNames` is **allow-listed, not renamed**. It collides with the TODS `participantName` on frequency ratio alone and both names are real.
