### PR TITLE
fix(socket): reconnect after a back-forward-cache freeze, not just on navigation

### DIFF
--- a/src/initialState.ts
+++ b/src/initialState.ts
@@ -10,6 +10,7 @@ import { hydrateConfigFromStorage } from 'services/settings/settingsStorage';
 import { factoryConstants, globalState } from 'tods-competition-factory';
 import { initTheme, initThemeToggle } from 'services/theme/themeService';
 import { loadUserCompositions } from 'pages/templates/compositionBridge';
+import { startConnectionLifecycle } from 'services/messaging/connectionLifecycle';
 import { initStalenessGuard } from 'services/staleness/stalenessGuard';
 import { initSessionGuard } from 'services/session/sessionGuard';
 import { initTmxVersionCheck } from 'services/version/checkTmxVersion';
@@ -172,6 +173,10 @@ function tmxReady(): void {
   initStalenessGuard();
   initSessionGuard();
   initTmxVersionCheck();
+  // Recover the /tmx + relay sockets on bfcache restore / tab return / network
+  // return. Must be paired with initStalenessGuard: that one re-fetches data on
+  // return, this one restores the live connection that keeps it fresh afterwards.
+  startConnectionLifecycle();
   // Populate the user-composition cache so resolveCompositionByName() can
   // find custom compositions on the first draw render. Fire-and-forget;
   // early renders fall through to builtin compositions until the load

--- a/src/services/messaging/connectionLifecycle.test.ts
+++ b/src/services/messaging/connectionLifecycle.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ensureConnected = vi.fn(() => false);
+const ensureRelayConnected = vi.fn(() => false);
+
+vi.mock('./socketIo', () => ({ ensureConnected: () => ensureConnected() }));
+vi.mock('./scoreRelay', () => ({ ensureRelayConnected: () => ensureRelayConnected() }));
+vi.mock('config/debugConfig', () => ({ debugConfig: { get: () => ({ socketLog: false }) } }));
+
+import {
+  isConnectionLifecycleActive,
+  startConnectionLifecycle,
+  stopConnectionLifecycle,
+  recoverConnections,
+} from './connectionLifecycle';
+
+/**
+ * The bug this module exists for: after a back-forward-cache restore both sockets
+ * are dead and nothing asks them to reconnect while the operator stays on the
+ * page. `pageshow(persisted)` is the event guaranteed to fire on that restore, so
+ * it is the primary path here — with a NON-persisted `pageshow` (an ordinary
+ * load) as the control that must not trigger recovery.
+ *
+ * ── What these tests do and do not cover ──
+ *
+ * Vitest runs in the `node` environment, which has no `window`/`document`, and
+ * the ecosystem rule is that DOM behaviour belongs to Playwright rather than
+ * happy-dom. So registration is stubbed: the harness captures the handlers this
+ * module registers and invokes them, which verifies the event→recovery mapping
+ * and the throttle.
+ *
+ * It does NOT verify that a real browser fires `pageshow(persisted)` on a bfcache
+ * restore, nor that a real frozen socket recovers. That is a browser behaviour;
+ * stating it plainly is better than a test that appears to cover it.
+ */
+
+type Listener = (event?: any) => void;
+
+const windowListeners = new Map<string, Set<Listener>>();
+const documentListeners = new Map<string, Set<Listener>>();
+let visibilityState: 'visible' | 'hidden' = 'visible';
+
+function register(map: Map<string, Set<Listener>>) {
+  return (name: string, fn: Listener) => {
+    const set = map.get(name) ?? new Set<Listener>();
+    set.add(fn);
+    map.set(name, set);
+  };
+}
+
+function unregister(map: Map<string, Set<Listener>>) {
+  return (name: string, fn: Listener) => map.get(name)?.delete(fn);
+}
+
+/** Invoke every handler registered for an event, as the browser would. */
+function fire(map: Map<string, Set<Listener>>, name: string, event?: any): void {
+  for (const fn of map.get(name) ?? []) fn(event);
+}
+
+const firePageShow = (persisted: boolean) => fire(windowListeners, 'pageshow', { persisted });
+const fireOnline = () => fire(windowListeners, 'online');
+const fireVisibility = (state: 'visible' | 'hidden') => {
+  visibilityState = state;
+  fire(documentListeners, 'visibilitychange');
+};
+
+const registeredWindowEvents = () => [...windowListeners.keys()].filter((k) => (windowListeners.get(k)?.size ?? 0) > 0);
+const handlerCount = (map: Map<string, Set<Listener>>, name: string) => map.get(name)?.size ?? 0;
+
+describe('connectionLifecycle', () => {
+  beforeEach(() => {
+    ensureConnected.mockReset().mockReturnValue(false);
+    ensureRelayConnected.mockReset().mockReturnValue(false);
+    windowListeners.clear();
+    documentListeners.clear();
+    visibilityState = 'visible';
+
+    vi.stubGlobal('addEventListener', register(windowListeners));
+    vi.stubGlobal('removeEventListener', unregister(windowListeners));
+    vi.stubGlobal('document', {
+      addEventListener: register(documentListeners),
+      removeEventListener: unregister(documentListeners),
+      get visibilityState() {
+        return visibilityState;
+      },
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'));
+    stopConnectionLifecycle();
+  });
+
+  afterEach(() => {
+    stopConnectionLifecycle();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  describe('registration', () => {
+    it('is inactive until started', () => {
+      expect(isConnectionLifecycleActive()).toBe(false);
+      expect(registeredWindowEvents()).toEqual([]);
+    });
+
+    it('registers exactly pageshow + online on window and visibilitychange on document', () => {
+      startConnectionLifecycle();
+      expect(isConnectionLifecycleActive()).toBe(true);
+      expect(registeredWindowEvents().toSorted((a, b) => a.localeCompare(b))).toEqual(['online', 'pageshow']);
+      expect(handlerCount(documentListeners, 'visibilitychange')).toBe(1);
+    });
+
+    it('removes every listener on stop', () => {
+      startConnectionLifecycle();
+      stopConnectionLifecycle();
+      expect(isConnectionLifecycleActive()).toBe(false);
+      expect(handlerCount(windowListeners, 'pageshow')).toBe(0);
+      expect(handlerCount(windowListeners, 'online')).toBe(0);
+      expect(handlerCount(documentListeners, 'visibilitychange')).toBe(0);
+    });
+
+    it('is idempotent — a second start does not add a second handler set', () => {
+      startConnectionLifecycle();
+      startConnectionLifecycle();
+      expect(handlerCount(windowListeners, 'pageshow')).toBe(1);
+      expect(handlerCount(documentListeners, 'visibilitychange')).toBe(1);
+    });
+
+    it('does not recover after stop', () => {
+      startConnectionLifecycle();
+      stopConnectionLifecycle();
+      firePageShow(true);
+      expect(ensureConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bfcache restore — the reported bug', () => {
+    it('recovers both sockets on pageshow(persisted)', () => {
+      startConnectionLifecycle();
+      firePageShow(true);
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+      expect(ensureRelayConnected).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT recover on a non-persisted pageshow (ordinary load)', () => {
+      startConnectionLifecycle();
+      firePageShow(false);
+      expect(ensureConnected).not.toHaveBeenCalled();
+      expect(ensureRelayConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('other triggers', () => {
+    it('recovers when the tab becomes visible', () => {
+      startConnectionLifecycle();
+      fireVisibility('visible');
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not recover when the tab becomes hidden', () => {
+      startConnectionLifecycle();
+      fireVisibility('hidden');
+      expect(ensureConnected).not.toHaveBeenCalled();
+    });
+
+    it('recovers when the network returns', () => {
+      startConnectionLifecycle();
+      fireOnline();
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('throttle', () => {
+    it('collapses a burst of events into one sweep', () => {
+      startConnectionLifecycle();
+      firePageShow(true);
+      fireVisibility('visible');
+      fireOnline();
+      // A single tab return can fire all three; one handshake attempt, not three.
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows another sweep once the window has passed', () => {
+      startConnectionLifecycle();
+      firePageShow(true);
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(2001);
+      firePageShow(true);
+      expect(ensureConnected).toHaveBeenCalledTimes(2);
+    });
+
+    it('still suppresses one millisecond before the window closes', () => {
+      startConnectionLifecycle();
+      firePageShow(true);
+      vi.advanceTimersByTime(1999);
+      firePageShow(true);
+      // Pins the 2000ms floor — shortening it breaks this case.
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the two sockets are independent', () => {
+    it('reports each outcome separately', () => {
+      ensureConnected.mockReturnValue(false);
+      ensureRelayConnected.mockReturnValue(true);
+      expect(recoverConnections('test')).toEqual({ socket: false, relay: true });
+
+      ensureConnected.mockReturnValue(true);
+      ensureRelayConnected.mockReturnValue(false);
+      expect(recoverConnections('test')).toEqual({ socket: true, relay: false });
+    });
+
+    it('attempts the socket BEFORE the relay, so a throwing relay cannot mask it', () => {
+      ensureRelayConnected.mockImplementation(() => {
+        throw new Error('relay boom');
+      });
+      expect(() => recoverConnections('test')).toThrow('relay boom');
+      expect(ensureConnected).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/messaging/connectionLifecycle.ts
+++ b/src/services/messaging/connectionLifecycle.ts
@@ -1,0 +1,118 @@
+/**
+ * Page-lifecycle → socket recovery.
+ *
+ * The missing half of TMX's reconnection story. `ensureConnected()` (the `/tmx`
+ * socket) and `ensureRelayConnected()` (score-relay) both knew how to recover,
+ * but the only thing calling either was the router — so recovery happened on
+ * navigation and at no other time. An operator who left the tab, came back, and
+ * simply *sat* on the page stayed disconnected indefinitely.
+ *
+ * ── Why the back-forward cache is the trigger that matters ──
+ *
+ * Chrome and Safari freeze a page when the operator navigates away, keeping it
+ * in the back-forward cache so a return is instant. A frozen page cannot hold an
+ * open socket, so the browser closes both of ours — visible in the console as:
+ *
+ *     WebSocket connection to 'wss://…/socket.io/…' failed:
+ *     Page entered Back-Forward Cache.
+ *
+ * On restore the page resumes with its JS heap intact and its sockets dead. No
+ * `visibilitychange` fires for a bfcache restore in every engine, so the one
+ * event that is guaranteed is `pageshow` with `event.persisted === true`. That is
+ * the primary hook here.
+ *
+ * Three events, because each covers a case the others miss:
+ *
+ *   - `pageshow` (persisted) — bfcache restore. The reported bug.
+ *   - `visibilitychange` → visible — tab switch, window refocus, phone unlock;
+ *     these do not always involve bfcache but can still outlive a socket timeout.
+ *   - `online` — the network came back; the OS knows before socket.io's next
+ *     scheduled retry does.
+ *
+ * Deliberately additive: existing `visibilitychange` listeners
+ * (`stalenessGuard`, `checkTmxVersion`, `schedulingTab`) check *data* and version
+ * freshness and never socket health. `stalenessGuard` in particular re-fetches
+ * the tournament on return while leaving the socket dead, which is why the
+ * symptom read as intermittent — one fresh snapshot, then silence.
+ */
+
+import { ensureRelayConnected } from './scoreRelay';
+import { ensureConnected } from './socketIo';
+import { debugConfig } from 'config/debugConfig';
+
+const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
+
+/**
+ * Minimum gap between recovery sweeps. A tab switch can fire `visibilitychange`
+ * and `pageshow` back to back, and `online` may arrive alongside both; without a
+ * floor, one return could trigger three handshakes.
+ */
+const SWEEP_THROTTLE_MS = 2000;
+
+let lastSweep = 0;
+let listening = false;
+
+/** Exposed for tests: the recovery sweep, ignoring the throttle. */
+export function recoverConnections(reason: string): { socket: boolean; relay: boolean } {
+  // Both are attempted independently — the /tmx socket and the relay fail and
+  // recover separately, and a dead relay must not mask a dead socket.
+  const socket = ensureConnected();
+  const relay = ensureRelayConnected();
+  if (socket || relay) {
+    slog('[lifecycle] recovery after %s — socket=%s relay=%s', reason, socket, relay);
+  }
+  return { socket, relay };
+}
+
+function throttledRecover(reason: string): void {
+  const now = Date.now();
+  if (now - lastSweep < SWEEP_THROTTLE_MS) {
+    slog('[lifecycle] %s within throttle window — skipping', reason);
+    return;
+  }
+  lastSweep = now;
+  recoverConnections(reason);
+}
+
+function onPageShow(event: Event): void {
+  // A non-persisted pageshow is an ordinary load, which already connects through
+  // the normal boot path; only a bfcache restore needs recovery.
+  if (!(event as PageTransitionEvent).persisted) return;
+  throttledRecover('pageshow(persisted)');
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState !== 'visible') return;
+  throttledRecover('visibilitychange(visible)');
+}
+
+function onOnline(): void {
+  throttledRecover('online');
+}
+
+/**
+ * Start listening. Idempotent — a second call is a no-op rather than a second
+ * set of listeners, so a re-entrant boot cannot double the handshakes.
+ */
+export function startConnectionLifecycle(): void {
+  if (listening) return;
+  listening = true;
+  globalThis.addEventListener('pageshow', onPageShow);
+  globalThis.addEventListener('online', onOnline);
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  slog('[lifecycle] connection lifecycle listeners registered');
+}
+
+export function stopConnectionLifecycle(): void {
+  if (!listening) return;
+  listening = false;
+  globalThis.removeEventListener('pageshow', onPageShow);
+  globalThis.removeEventListener('online', onOnline);
+  document.removeEventListener('visibilitychange', onVisibilityChange);
+  lastSweep = 0;
+}
+
+/** Exposed for tests. */
+export function isConnectionLifecycleActive(): boolean {
+  return listening;
+}

--- a/src/services/messaging/scoreRelay.test.ts
+++ b/src/services/messaging/scoreRelay.test.ts
@@ -16,6 +16,14 @@ const mockSocket = {
     handlers.set(event, handler);
   }),
   emit: vi.fn(),
+  // Re-opens a manager that a disconnect stopped — what `ensureRelayConnected`
+  // calls to recover a transport the browser killed while the page was frozen.
+  // Fires `connect` like a real socket would: without that, a test could invoke
+  // the connect handler by hand and pass even with recovery removed.
+  connect: vi.fn(() => {
+    mockSocket.connected = true;
+    handlers.get('connect')?.();
+  }),
   disconnect: vi.fn(() => {
     mockSocket.connected = false;
   }),
@@ -53,6 +61,9 @@ vi.mock('config/debugConfig', () => ({
 
 const DEV_SOCKET_PATH = 'http://localhost:8383';
 
+// Relay-specific wire event; no factory constant exists for it.
+const SUBSCRIBE_TOURNAMENT = 'subscribe:tournament';
+
 // Import after mocks are set up
 import {
   connectRelay,
@@ -60,6 +71,7 @@ import {
   onTournamentScore,
   subscribeToMatchUp,
   unsubscribeFromMatchUp,
+  ensureRelayConnected,
 } from './scoreRelay';
 
 /** Simulate the relay server emitting 'connect' to our socket. */
@@ -136,7 +148,7 @@ describe('TMX scoreRelay client', () => {
     connectRelay('tid-002');
     triggerConnect();
 
-    expect(mockSocket.emit).toHaveBeenCalledWith('subscribe:tournament', 'tid-002');
+    expect(mockSocket.emit).toHaveBeenCalledWith(SUBSCRIBE_TOURNAMENT, 'tid-002');
   });
 
   it('dispatches tournament-level score handler on score event', () => {
@@ -234,8 +246,72 @@ describe('TMX scoreRelay client', () => {
     triggerConnect();
 
     // On reconnect, tournament subscription is re-emitted
-    expect(mockSocket.emit).toHaveBeenCalledWith('subscribe:tournament', 'tid-008');
+    expect(mockSocket.emit).toHaveBeenCalledWith(SUBSCRIBE_TOURNAMENT, 'tid-008');
     // Active matchUp subscriptions are also re-emitted
     expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', 'mu-persist');
+  });
+
+  describe('ensureRelayConnected — recovery after a frozen/dropped transport', () => {
+    it('re-opens the existing socket when the transport died', () => {
+      connectRelay('tid-recover');
+      triggerConnect();
+
+      // What a back-forward-cache freeze leaves behind: the socket object is
+      // still there, its transport is not.
+      mockSocket.connected = false;
+      vi.clearAllMocks();
+
+      expect(ensureRelayConnected()).toBe(true);
+      expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-issues the tournament AND matchUp subscriptions once the reconnect lands', () => {
+      connectRelay('tid-resub');
+      triggerConnect();
+      subscribeToMatchUp('mu-resub', vi.fn());
+
+      mockSocket.connected = false;
+      vi.clearAllMocks();
+      // No manual triggerConnect here — the mock's connect() fires `connect`, so
+      // these assertions fail if recovery does not actually reconnect.
+      ensureRelayConnected();
+
+      expect(mockSocket.emit).toHaveBeenCalledWith(SUBSCRIBE_TOURNAMENT, 'tid-resub');
+      expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', 'mu-resub');
+    });
+
+    it('is a no-op while the relay is connected', () => {
+      connectRelay('tid-live');
+      triggerConnect();
+      mockSocket.connected = true;
+      vi.clearAllMocks();
+
+      expect(ensureRelayConnected()).toBe(false);
+      expect(mockSocket.connect).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no tournament subscription is active', () => {
+      disconnectRelay();
+      vi.clearAllMocks();
+
+      expect(ensureRelayConnected()).toBe(false);
+      expect(mockSocket.connect).not.toHaveBeenCalled();
+    });
+
+    it('does NOT route through connectRelay — that would clear matchUpCallbacks', () => {
+      connectRelay('tid-nowipe');
+      triggerConnect();
+      const callback = vi.fn();
+      subscribeToMatchUp('mu-nowipe', callback);
+
+      mockSocket.connected = false;
+      ensureRelayConnected();
+
+      // If recovery had gone through connectRelay (which begins with
+      // disconnectRelay, clearing matchUpCallbacks), this score would reach
+      // nobody and the scoring dialog would silently stop updating.
+      triggerScore({ matchUpId: 'mu-nowipe', score: '6-4' });
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/services/messaging/scoreRelay.ts
+++ b/src/services/messaging/scoreRelay.ts
@@ -121,3 +121,34 @@ export function unsubscribeFromMatchUp(matchUpId: string): void {
 export function relayConnected(): boolean {
   return !!relaySocket?.connected;
 }
+
+/**
+ * Reconnect the relay if a tournament subscription is active but the connection
+ * is down. Returns true if a reconnect was initiated.
+ *
+ * Mirrors `ensureConnected()` for the `/tmx` socket, and exists for the same
+ * reason: after a back-forward-cache restore the transport is dead, and nothing
+ * in the app was asking the relay to come back. `connect()` re-arms the existing
+ * manager, and the `connect` handler re-issues the tournament subscription plus
+ * every active matchUp subscription.
+ *
+ * ⚠️ Deliberately does NOT fall back to `connectRelay()` when the socket is
+ * missing. `connectRelay` begins with `disconnectRelay()`, which clears
+ * `matchUpCallbacks` — so rebuilding that way would silently drop the scoring
+ * dialog's per-matchUp subscription. That state is also unreachable in practice:
+ * `relaySocket` and `currentTournamentId` are set together in `connectRelay` and
+ * cleared together in `disconnectRelay`, so no socket means no active
+ * subscription and the guard above has already returned.
+ */
+export function ensureRelayConnected(): boolean {
+  if (!currentTournamentId) return false;
+  if (!relaySocket) {
+    slog('[relay] ensureRelayConnected — tournamentId set with no socket (unexpected); leaving alone');
+    return false;
+  }
+  if (relaySocket.connected) return false;
+
+  slog('[relay] ensureRelayConnected — re-opening existing socket');
+  relaySocket.connect();
+  return true;
+}

--- a/src/services/messaging/socketIo.ts
+++ b/src/services/messaging/socketIo.ts
@@ -139,7 +139,10 @@ export function connectSocket(callback?: () => void): void {
     transportOptions: { polling: { extraHeaders: getAuthorization() } },
     'force new connection': true,
     reconnectionDelay: 1000,
-    reconnectionAttempts: 'Infinity',
+    // A NUMBER, not the string 'Infinity'. socket.io compares
+    // `attempts >= reconnectionAttempts`; against a string that comparison is
+    // always false, so the old value never gave up only by accident.
+    reconnectionAttempts: Infinity,
     timeout: 20000,
   };
   if (oi.socket) {
@@ -189,13 +192,53 @@ export function connectSocket(callback?: () => void): void {
     oi.socket.on('timestamp', (data: any) => (oi.timestampOffset = Date.now() - data.timestamp));
     oi.socket.on('connect_error', (data: any) => {
       slog('[socket] connect_error:', data?.message ?? data);
-      tmxToast({ message: t('toasts.connectionError'), intent: 'is-danger' });
-      disconnectSocket();
+      // DO NOT tear the socket down here.
+      //
+      // This handler used to call `disconnectSocket()`. In socket.io-client an
+      // explicit `disconnect()` CANCELS automatic reconnection — the manager
+      // will not retry after it — and `disconnectSocket` then deletes the
+      // socket object outright. So a single transient `connect_error`
+      // permanently disarmed reconnection, which is exactly what happens on a
+      // back-forward-cache restore: the browser kills the transport while the
+      // page is frozen, the first reconnect attempt errors, and the client then
+      // sat dead for as long as the operator stayed on the page.
+      //
+      // A connect_error is transient by definition — socket.io is already
+      // scheduling the next attempt. Auth rejections do NOT arrive here; the
+      // server's SocketGuard emits `exception`, handled above.
+      notifyConnectionTrouble();
     });
   }
 }
 
+/**
+ * A `connect_error` fires once per retry attempt, and socket.io retries every
+ * second — so toasting per event produced a wall of identical danger toasts.
+ * One toast per trouble window, re-armed by the next successful connect.
+ */
+let connectionTroubleNotified = false;
+
+function notifyConnectionTrouble(): void {
+  if (connectionTroubleNotified) return;
+  connectionTroubleNotified = true;
+  tmxToast({ message: t('toasts.connectionError'), intent: 'is-danger' });
+}
+
+/**
+ * True only when there is a LIVE connection.
+ *
+ * Previously `!!oi.socket`, which is truthy for a socket object that exists and
+ * is disconnected — so the main menu offered "Disconnect" on a dead socket, the
+ * settings panel displayed "Connected", and `requestTournamentRecord` emitted
+ * into the void instead of telling the operator they are offline. All four
+ * callers want live connectivity.
+ */
 export function connected(): boolean {
+  return !!oi.socket?.connected;
+}
+
+/** True when a socket object exists at all, connected or not (internal lifecycle checks). */
+export function socketExists(): boolean {
   return !!oi.socket;
 }
 
@@ -222,14 +265,29 @@ export function reconnectSocket(): void {
 }
 
 /**
- * Reconnect the socket if the user is logged in but the socket is gone.
+ * Reconnect the socket if the user is logged in but the connection is down.
  * Returns true if a reconnect was initiated.
+ *
+ * ⚠️ Must reconnect the EXISTING socket when there is one. This used to call
+ * `connectSocket()` unconditionally — but `connectSocket` early-returns when
+ * `oi.socket` is truthy, so with a disconnected-but-not-deleted socket the whole
+ * call was a silent no-op. That made the one caller (the router) unreliable too:
+ * whether navigation recovered the connection depended on whether the socket
+ * object happened to have been deleted yet.
  */
 export function ensureConnected(): boolean {
   if (oi.socket?.connected) return false;
   const state = getLoginState();
   if (!state) return false;
-  slog('[socket] ensureConnected — reconnecting (was disconnected)');
+
+  if (oi.socket) {
+    slog('[socket] ensureConnected — re-opening existing socket (disconnected)');
+    // Re-arms a manager that an explicit disconnect had stopped.
+    oi.socket.connect();
+    return true;
+  }
+
+  slog('[socket] ensureConnected — no socket, connecting fresh');
   connectSocket();
   return true;
 }
@@ -290,6 +348,8 @@ function socketEmit(msg: string, data: any): void {
 
 function connectionEvent(callback?: () => void): void {
   slog('[socket] connected — id:', oi.socket?.id);
+  // Re-arm the trouble toast so the NEXT outage is announced once more.
+  connectionTroubleNotified = false;
   // Capture before anything clears the flag: true only when this `connect` is a
   // reconnect after a prior drop (the first connect leaves the flag false).
   const reconnected = disconnectedSinceLastNav;


### PR DESCRIPTION
Fixes the reconnection failure CA reported from a prod console (TMX 8.17.1): after the page sits in the back-forward cache, **neither socket ever reconnects while you stay on the page.**

The browser told us why — `WebSocket connection to 'wss://courthive.net/socket.io/…' failed: Page entered Back-Forward Cache` — and TMX had reconnection logic that could not act on it. **Four defects**, each independently sufficient to produce the symptom.

### 1. `connect_error` disarmed reconnection

```ts
oi.socket.on('connect_error', (data) => { …; disconnectSocket(); });
```

`disconnectSocket()` calls `socket.disconnect()` — and in socket.io-client an explicit disconnect **cancels automatic reconnection** — then deletes the socket. bfcache restore reliably raises `connect_error` (the transport died while frozen), so the *first* one disarmed retries permanently. `reconnectionAttempts` never got a chance.

Now it logs and notifies without tearing down. A connect_error is transient by definition; socket.io is already scheduling the next attempt. Auth rejections don't arrive here — the server's SocketGuard emits `exception`, handled separately.

### 2. `ensureConnected()` could not reconnect an existing socket

It called `connectSocket()`, which **early-returns when `oi.socket` is truthy** — so with a disconnected-but-not-deleted socket, the whole call was a silent no-op. Now it calls `connect()` on the existing socket and constructs only when there is none. This also means the router path was unreliable: whether navigation recovered depended on whether the socket object had been deleted yet.

### 3. Nothing asked for recovery unless you navigated

`ensureConnected()` had exactly one caller: `router.ts`. New `connectionLifecycle.ts` wires `pageshow(persisted)` — the event guaranteed on a bfcache restore — plus `visibilitychange→visible` and `online`, throttled to one sweep per 2s so a tab return firing all three produces one handshake.

Additive by design: `stalenessGuard`, `checkTmxVersion` and `schedulingTab` already listen to `visibilitychange` but check *data* and version freshness, never socket health. `stalenessGuard` in particular re-fetches the tournament on return while leaving the socket dead — which is exactly why this read as intermittent: one fresh snapshot, then silence.

### 4. The relay had no recovery entry point at all

New `ensureRelayConnected()` re-opens the existing socket; the `connect` handler already re-issues the tournament and matchUp subscriptions. It deliberately does **not** route through `connectRelay()`, which begins with `disconnectRelay()` and would clear `matchUpCallbacks` — silently dropping the scoring dialog's subscription. There's a test for that specific mistake.

### Also found

- **`connected()` was `!!oi.socket`** — truthy for a dead socket. The main menu offered "Disconnect" on a dead connection, settings displayed "Connected", and `requestTournamentRecord` emitted into the void instead of telling the operator they're offline. Now `!!oi.socket?.connected`; all four callers want live connectivity.
- **`reconnectionAttempts: 'Infinity'` was a string.** socket.io compares `attempts >= reconnectionAttempts`; against a string that's always false, so it never gave up *by accident*. Now a number.
- The trouble toast fired once per retry (i.e. every second). Now once per outage, re-armed on the next successful connect.

## Verification

lint 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · check-types 0 · vitest **112 files / 1180 tests** (+20) · e2e journeys 97 / 48 / 64.

Falsified per defect, not in aggregate: removing the `persisted` check reddens exactly the ordinary-load control; removing the throttle reddens the burst + boundary cases; disabling relay recovery reddens two relay cases; routing relay recovery through `connectRelay` reddens the callback-preservation case.

**Two things I want to flag rather than bury:**

⚠️ **Not covered by any automated test:** that a real browser fires `pageshow(persisted)` on a bfcache restore, and that a real frozen socket recovers. Those are browser behaviours — the node test env has no DOM, and happy-dom isn't this ecosystem's DOM layer. The unit tests cover the event→recovery mapping and the throttle by capturing the registered handlers. **This wants one manual check in a deployed build:** navigate away, wait, come back, confirm the socket returns *without* navigating.

⚠️ **Two of my own new tests were vacuous at first** and I only caught it by falsifying: they called `triggerConnect()` by hand, so they passed with relay recovery removed. Fixed by making the mock socket's `connect()` fire `connect` as a real socket does; re-falsified, and the failure count went 1 → 3.

⚠️ **Reverted mid-change:** I had added a polling fallback to the relay transports. An existing test pins `transports: ['websocket']`, and the change was speculative — the evidence is that nothing *attempts* reconnection, not that attempts fail. The test was right to stop it, so the transports are untouched.

Prod runs 8.17.1, so this needs a deploy to reach the reporter.
