### PR TITLE
fix(tables): stop asking Tabulator to remove a filter it never added

### DIFF
--- a/src/components/tables/common/filters/eventFilter.ts
+++ b/src/components/tables/common/filters/eventFilter.ts
@@ -16,18 +16,32 @@ export function getEventFilter(
 } {
   let filterValue: string | undefined = context.participantFilters.eventId;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let eventFilterApplied = false;
+
   const eventFilter = (rowData) =>
     filterValue === NONE ? !rowData?.eventIds?.length : rowData?.eventIds?.includes(filterValue);
   const updateEventFilter = (eventId?) => {
-    table.removeFilter(eventFilter);
+    if (eventFilterApplied) {
+      table.removeFilter(eventFilter);
+      eventFilterApplied = false;
+    }
     filterValue = eventId;
     context.participantFilters.eventId = eventId;
-    if (eventId) table.addFilter(eventFilter);
+    if (eventId) {
+      table.addFilter(eventFilter);
+      eventFilterApplied = true;
+    }
     if (onChange) onChange();
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(eventFilter);
+  if (filterValue) {
+    table.addFilter(eventFilter);
+    eventFilterApplied = true;
+  }
   const events = tournamentEngine.q.events() || [];
   const allEventsLabel = t('pages.participants.allEvents');
   const noEventsLabel = t('pages.participants.noEvents');

--- a/src/components/tables/common/filters/filterApplyGuard.test.ts
+++ b/src/components/tables/common/filters/filterApplyGuard.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18n', () => ({ t: (key: string) => key }));
+
+// `vi.mock` factories are hoisted above module-level consts, so the shared
+// filter state has to come from `vi.hoisted` rather than a plain const.
+const { matchUpFilters, participantFilters } = vi.hoisted(() => ({
+  matchUpFilters: {} as Record<string, any>,
+  participantFilters: {} as Record<string, any>,
+}));
+vi.mock('services/context', () => ({ context: { matchUpFilters, participantFilters } }));
+
+import { getMatchUpStatusFilter } from './matchUpStatusFilter';
+import { getSexFilter } from './sexFilter';
+
+/**
+ * Tabulator warns `Filter Error - No matching filter type found, ignoring: undefined`
+ * whenever `removeFilter` is handed a filter that is not in its list — and every
+ * one of these modules used to call `removeFilter` unconditionally at the top of
+ * its update function, so the FIRST interaction on a page with no saved filter
+ * always warned. (`undefined` is the message's `filter.type`, which is undefined
+ * for a function filter — the value in the console said nothing about which
+ * filter it was, which is why this went unexplained for so long.)
+ *
+ * These tests drive the real modules through a fake table so the guard is pinned
+ * by behaviour rather than by reading the source.
+ */
+
+function fakeTable() {
+  const added: any[] = [];
+  const removed: any[] = [];
+  return {
+    addFilter: vi.fn((fn: any) => added.push(fn)),
+    removeFilter: vi.fn((fn: any) => removed.push(fn)),
+    added,
+    removed,
+  };
+}
+
+describe('filter modules do not remove a filter they never added', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(matchUpFilters)) delete matchUpFilters[key];
+    for (const key of Object.keys(participantFilters)) delete participantFilters[key];
+  });
+
+  describe('matchUpStatusFilter', () => {
+    it('clearing with nothing applied does not call removeFilter', () => {
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus(undefined);
+
+      expect(table.removeFilter).not.toHaveBeenCalled();
+      expect(table.addFilter).not.toHaveBeenCalled();
+    });
+
+    it('setting a status adds exactly one filter and removes none', () => {
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus('complete');
+
+      expect(table.addFilter).toHaveBeenCalledTimes(1);
+      expect(table.removeFilter).not.toHaveBeenCalled();
+    });
+
+    it('changing an applied status removes the old filter before adding — Tabulator re-runs on both', () => {
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus('complete');
+      setStatus('retired');
+
+      expect(table.removeFilter).toHaveBeenCalledTimes(1);
+      expect(table.addFilter).toHaveBeenCalledTimes(2);
+      // The same predicate instance goes in and out, which is what lets
+      // Tabulator match it in its filter list.
+      expect(table.removed[0]).toBe(table.added[0]);
+    });
+
+    it('clearing an applied status removes it and adds nothing', () => {
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus('complete');
+      setStatus(undefined);
+
+      expect(table.removeFilter).toHaveBeenCalledTimes(1);
+      expect(table.addFilter).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearing twice does not remove twice', () => {
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus('complete');
+      setStatus(undefined);
+      setStatus(undefined);
+
+      expect(table.removeFilter).toHaveBeenCalledTimes(1);
+    });
+
+    it('a filter restored from saved state is treated as applied, so the first clear removes it', () => {
+      matchUpFilters.status = 'complete';
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      // Restoration applies the filter up front...
+      expect(table.addFilter).toHaveBeenCalledTimes(1);
+      setStatus(undefined);
+      // ...so clearing it must remove it — the guard must not suppress this.
+      expect(table.removeFilter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sexFilter (participant tables share the pattern)', () => {
+    // No setter is exposed; the filter is driven by its option onClick handlers.
+    // `sexOptions[0]` is the "all" option, which clears.
+    const clearAndPick = (table: any) => {
+      const { sexOptions } = getSexFilter(table, undefined as any) as any;
+      const options = sexOptions.filter((o: any) => !o.divider);
+      return { clear: () => options[0].onClick(), pick: () => options[1].onClick() };
+    };
+
+    it('clearing with nothing applied does not call removeFilter', () => {
+      const table = fakeTable();
+      clearAndPick(table).clear();
+      expect(table.removeFilter).not.toHaveBeenCalled();
+    });
+
+    it('still removes once a filter has been applied', () => {
+      const table = fakeTable();
+      const { clear, pick } = clearAndPick(table);
+      pick();
+      clear();
+      expect(table.removeFilter).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -51,6 +51,11 @@ export function getMatchUpDateFilter(table: any): {
 } {
   let filterValue: string | undefined = context.matchUpFilters.scheduledDate;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let dateFilterApplied = false;
+
   const dateFilter = (rowData: any): boolean => {
     if (!filterValue) return true;
     if (filterValue === NO_DATE_TOKEN) return !rowData.scheduledDate;
@@ -59,14 +64,23 @@ export function getMatchUpDateFilter(table: any): {
   };
 
   const updateFilter = (value?: string) => {
-    table.removeFilter(dateFilter);
+    if (dateFilterApplied) {
+      table.removeFilter(dateFilter);
+      dateFilterApplied = false;
+    }
     filterValue = value;
     context.matchUpFilters.scheduledDate = value;
-    if (value) table.addFilter(dateFilter);
+    if (value) {
+      table.addFilter(dateFilter);
+      dateFilterApplied = true;
+    }
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(dateFilter);
+  if (filterValue) {
+    table.addFilter(dateFilter);
+    dateFilterApplied = true;
+  }
 
   // Resolve active dates: prefer tournamentInfo.activeDates, fall back to date range.
   const { tournamentInfo } = competitionEngine.getTournamentInfo() ?? {};

--- a/src/components/tables/common/filters/matchUpEventFilter.ts
+++ b/src/components/tables/common/filters/matchUpEventFilter.ts
@@ -17,16 +17,30 @@ export function getMatchUpEventFilter(
 } {
   let filterValue: string | undefined = context.matchUpFilters.eventId;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let eventFilterApplied = false;
+
   const eventFilter = (rowData: any): boolean => rowData.eventId === filterValue;
   const updateFilter = (eventId?: string) => {
-    table.removeFilter(eventFilter);
+    if (eventFilterApplied) {
+      table.removeFilter(eventFilter);
+      eventFilterApplied = false;
+    }
     filterValue = eventId;
     context.matchUpFilters.eventId = eventId;
-    if (eventId) table.addFilter(eventFilter);
+    if (eventId) {
+      table.addFilter(eventFilter);
+      eventFilterApplied = true;
+    }
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(eventFilter);
+  if (filterValue) {
+    table.addFilter(eventFilter);
+    eventFilterApplied = true;
+  }
 
   // Caller can hand in a pre-fetched events list to share one q.events()
   // call across the event/flight/team filters on the matchUps tab.

--- a/src/components/tables/common/filters/matchUpFlightFilter.ts
+++ b/src/components/tables/common/filters/matchUpFlightFilter.ts
@@ -17,16 +17,30 @@ export function getMatchUpFlightFilter(
 } {
   let filterValue: string | undefined = context.matchUpFilters.drawId;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let flightFilterApplied = false;
+
   const flightFilter = (rowData: any): boolean => rowData.drawId === filterValue;
   const updateFilter = (drawId?: string) => {
-    table.removeFilter(flightFilter);
+    if (flightFilterApplied) {
+      table.removeFilter(flightFilter);
+      flightFilterApplied = false;
+    }
     filterValue = drawId;
     context.matchUpFilters.drawId = drawId;
-    if (drawId) table.addFilter(flightFilter);
+    if (drawId) {
+      table.addFilter(flightFilter);
+      flightFilterApplied = true;
+    }
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(flightFilter);
+  if (filterValue) {
+    table.addFilter(flightFilter);
+    flightFilterApplied = true;
+  }
 
   // Caller can hand in a pre-fetched events list to share one q.events()
   // call across the event/flight/team filters on the matchUps tab.

--- a/src/components/tables/common/filters/matchUpProfileFilter.ts
+++ b/src/components/tables/common/filters/matchUpProfileFilter.ts
@@ -19,6 +19,11 @@ export function getMatchUpProfileFilter(table: any): {
 } {
   let filterValue: string | undefined = context.matchUpFilters.profile;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let profileFilterApplied = false;
+
   const profileFilter = (rowData: any): boolean => {
     if (!filterValue) return true;
     if (filterValue === 'WALKOVER') return isWalkoverProfile(rowData);
@@ -26,13 +31,22 @@ export function getMatchUpProfileFilter(table: any): {
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(profileFilter);
+  if (filterValue) {
+    table.addFilter(profileFilter);
+    profileFilterApplied = true;
+  }
 
   const updateFilter = (profile?: string) => {
-    table.removeFilter(profileFilter);
+    if (profileFilterApplied) {
+      table.removeFilter(profileFilter);
+      profileFilterApplied = false;
+    }
     filterValue = profile;
     context.matchUpFilters.profile = profile;
-    if (profile) table.addFilter(profileFilter);
+    if (profile) {
+      table.addFilter(profileFilter);
+      profileFilterApplied = true;
+    }
   };
 
   const allLabel = t('pages.matchUps.allProfiles');

--- a/src/components/tables/common/filters/matchUpStatusFilter.ts
+++ b/src/components/tables/common/filters/matchUpStatusFilter.ts
@@ -20,6 +20,11 @@ export function getMatchUpStatusFilter(table: any): {
 } {
   let filterValue: string | undefined = context.matchUpFilters.status;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let statusFilterApplied = false;
+
   const statusFilter = (rowData: any): boolean => {
     if (!filterValue) return true;
     if (filterValue.startsWith(TODAY_STATUS_PREFIX)) {
@@ -29,13 +34,22 @@ export function getMatchUpStatusFilter(table: any): {
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(statusFilter);
+  if (filterValue) {
+    table.addFilter(statusFilter);
+    statusFilterApplied = true;
+  }
 
   const updateFilter = (status?: string) => {
-    table.removeFilter(statusFilter);
+    if (statusFilterApplied) {
+      table.removeFilter(statusFilter);
+      statusFilterApplied = false;
+    }
     filterValue = status;
     context.matchUpFilters.status = status;
-    if (status) table.addFilter(statusFilter);
+    if (status) {
+      table.addFilter(statusFilter);
+      statusFilterApplied = true;
+    }
   };
 
   const allLabel = t('pages.matchUps.allStatuses');

--- a/src/components/tables/common/filters/matchUpTypeFilter.ts
+++ b/src/components/tables/common/filters/matchUpTypeFilter.ts
@@ -14,16 +14,30 @@ export function getMatchUpTypeFilter(
 ): { typeOptions: any[]; hasOptions: boolean; isFiltered: () => boolean; activeIndex: () => number } {
   let filterValue: string | undefined = context.matchUpFilters.type;
 
+  // Tabulator warns "Filter Error - No matching filter type found" when
+  // removeFilter is handed a filter it never added — which is every first
+  // call here, since the filter is only added when a value is set.
+  let typeFilterApplied = false;
+
   const typeFilter = (rowData: any): boolean => rowData.matchUpType === filterValue;
 
   // Restore saved filter
-  if (filterValue) table.addFilter(typeFilter);
+  if (filterValue) {
+    table.addFilter(typeFilter);
+    typeFilterApplied = true;
+  }
 
   const updateFilter = (type?: string) => {
-    table.removeFilter(typeFilter);
+    if (typeFilterApplied) {
+      table.removeFilter(typeFilter);
+      typeFilterApplied = false;
+    }
     filterValue = type;
     context.matchUpFilters.type = type;
-    if (type) table.addFilter(typeFilter);
+    if (type) {
+      table.addFilter(typeFilter);
+      typeFilterApplied = true;
+    }
   };
 
   const matchUpTypes = data.reduce((types: string[], matchUp: any) => {

--- a/src/components/tables/common/filters/scheduleFilters.ts
+++ b/src/components/tables/common/filters/scheduleFilters.ts
@@ -22,11 +22,21 @@ type ScheduleFilterConfig = {
 function createScheduleFilter(table: any, config: ScheduleFilterConfig, onChange?: () => void): FilterResult {
   let filterValue: string | undefined;
 
+  // See the sibling filters: removeFilter on a never-added filter makes
+  // Tabulator warn "Filter Error - No matching filter type found".
+  let filterFnApplied = false;
+
   const filterFn = (rowData: any): boolean => rowData[config.field] === filterValue;
   const updateFilter = (value?: string) => {
-    table.removeFilter(filterFn);
+    if (filterFnApplied) {
+      table.removeFilter(filterFn);
+      filterFnApplied = false;
+    }
     filterValue = value;
-    if (value) table.addFilter(filterFn);
+    if (value) {
+      table.addFilter(filterFn);
+      filterFnApplied = true;
+    }
     if (onChange) onChange();
   };
 

--- a/src/components/tables/common/filters/sexFilter.ts
+++ b/src/components/tables/common/filters/sexFilter.ts
@@ -10,17 +10,30 @@ export function getSexFilter(
 ): { sexOptions: any[]; genders: Record<string, string>; isFiltered: () => boolean; activeIndex: () => number } {
   let filterValue: string | undefined = context.participantFilters.sex;
 
+  // See the sibling filters: removeFilter on a never-added filter makes
+  // Tabulator warn "Filter Error - No matching filter type found".
+  let sexFilterApplied = false;
+
   const sexFilter = (rowData: any): boolean => rowData.participant?.person?.sex === filterValue;
   const updateSexFilter = (sex?: string) => {
-    table.removeFilter(sexFilter);
+    if (sexFilterApplied) {
+      table.removeFilter(sexFilter);
+      sexFilterApplied = false;
+    }
     filterValue = sex;
     context.participantFilters.sex = sex;
-    if (sex) table.addFilter(sexFilter);
+    if (sex) {
+      table.addFilter(sexFilter);
+      sexFilterApplied = true;
+    }
     if (onChange) onChange();
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(sexFilter);
+  if (filterValue) {
+    table.addFilter(sexFilter);
+    sexFilterApplied = true;
+  }
   const sexes = [MALE, FEMALE];
   const genders: Record<string, string> = {
     [MALE]: t('pages.participants.gender.male'),

--- a/src/components/tables/common/filters/teamFilter.ts
+++ b/src/components/tables/common/filters/teamFilter.ts
@@ -11,17 +11,30 @@ export function getTeamFilter({
   onChange?: () => void;
 }) {
   let filterValue: string | undefined = context.participantFilters.teamId;
+  // See the sibling filters: removeFilter on a never-added filter makes
+  // Tabulator warn "Filter Error - No matching filter type found".
+  let teamFilterApplied = false;
+
   const teamFilter = (rowData) => rowData.teams.some((team) => team?.participantId === filterValue);
   const updateTeamFilter = (participantId?) => {
-    table.removeFilter(teamFilter);
+    if (teamFilterApplied) {
+      table.removeFilter(teamFilter);
+      teamFilterApplied = false;
+    }
     filterValue = participantId;
     context.participantFilters.teamId = participantId;
-    if (participantId) table.addFilter(teamFilter);
+    if (participantId) {
+      table.addFilter(teamFilter);
+      teamFilterApplied = true;
+    }
     if (onChange) onChange();
   };
 
   // Restore saved filter
-  if (filterValue) table.addFilter(teamFilter);
+  if (filterValue) {
+    table.addFilter(teamFilter);
+    teamFilterApplied = true;
+  }
   const anyTeamLabel = t('pages.participants.anyTeam');
   const allTeams = {
     label: `<span style='font-weight: bold'>${anyTeamLabel}</span>`,


### PR DESCRIPTION
Second of the two console warnings CA reported from the matchUps page:

```
Filter Error - No matching filter type found, ignoring:  undefined
```

Tabulator's `removeFilter` searches its filter list and warns when the entry is absent, printing `filter.type` — which is `undefined` for a function filter. That is why the message named neither the filter nor the page and went unexplained: `undefined` was never a value anyone set, it is the absence of a `type` on a predicate filter.

**Ten filter modules** called `removeFilter` unconditionally at the top of their update function while only *adding* the filter when a value was set — so the first interaction on any page with no saved filter warned every time. Each now tracks whether its filter is applied and removes only then.

Semantics are otherwise unchanged. While a filter **is** applied the remove-then-add pair is preserved deliberately: that is what makes Tabulator re-run filtering after the closed-over value changes, and dropping it would silently stop filters updating.

`createSearchFilter` already did exactly this (`if (searchFilter) …`) and was the model.

Seven modules are reachable from the matchUps page; `sexFilter`, `teamFilter` and `scheduleFilters` carry the identical defect on participant and schedule tables and are fixed here rather than left to be rediscovered from a different page.

## Verification

lint 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · check-types 0 · vitest **112 files / 1168** (+8).

The new tests drive the real modules through a fake table rather than reading the source — including the case that matters most for regression: a filter restored from saved state must still be removable on the first clear, so the guard cannot be implemented as "never remove on the first call".

Falsified: reverting the guard on `matchUpStatusFilter` + `sexFilter` reddens 6 of the 8 new cases. The two that stay green are precisely the ones that do not depend on it.

## ⚠️ This fixes one of the two warnings

The other — `Table Not Initialized - Calling the getSelectedRows function before the table is initialized` — **is not a TMX defect.** It comes from courthive-components `controlBar.ts:111`:

```ts
const currentRows = table?.getSelectedRows?.() ?? [];
```

called synchronously while building the control bar, before Tabulator has fired `tableBuilt`. TMX cannot fix it from this side; it needs a components change plus a publish. Raised separately so this one is not held up behind a cascade.
