### PR TITLE
refactor(tables): clamp filter activeIndex with Math.max, use toSorted in teamFilter

### DIFF
--- a/src/components/tables/common/filters/eventFilter.ts
+++ b/src/components/tables/common/filters/eventFilter.ts
@@ -71,7 +71,9 @@ export function getEventFilter(
     if (!filterValue) return 0;
     const matchValue = filterValue === NONE ? '__NONE__' : filterValue;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === matchValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { eventOptions, events, isFiltered, activeIndex };

--- a/src/components/tables/common/filters/filterApplyGuard.test.ts
+++ b/src/components/tables/common/filters/filterApplyGuard.test.ts
@@ -11,6 +11,7 @@ const { matchUpFilters, participantFilters } = vi.hoisted(() => ({
 vi.mock('services/context', () => ({ context: { matchUpFilters, participantFilters } }));
 
 import { getMatchUpStatusFilter } from './matchUpStatusFilter';
+import { getTeamFilter } from './teamFilter';
 import { getSexFilter } from './sexFilter';
 
 /**
@@ -134,6 +135,62 @@ describe('filter modules do not remove a filter they never added', () => {
       pick();
       clear();
       expect(table.removeFilter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('activeIndex clamps a missing option to 0', () => {
+    // Was `idx >= 0 ? idx : 0`, now `Math.max(idx, 0)` — identical for every
+    // value `findIndex` can return (-1 or a valid index). Pinned so the clamp
+    // survives, since an unclamped -1 would index the popover out of bounds.
+    it('returns 0 when no filter is set', () => {
+      const table = fakeTable();
+      const { activeIndex } = getMatchUpStatusFilter(table as any);
+      expect(activeIndex()).toBe(0);
+    });
+
+    it('returns 0 when the saved filter matches no option', () => {
+      matchUpFilters.status = 'a-status-that-no-longer-exists';
+      const table = fakeTable();
+      const { activeIndex } = getMatchUpStatusFilter(table as any);
+      expect(activeIndex()).toBe(0);
+    });
+
+    it('returns the option index when the filter does match', () => {
+      const table = fakeTable();
+      const { statusOptions, setStatus, activeIndex } = getMatchUpStatusFilter(table as any);
+      const selectable = statusOptions.filter((o: any) => !o.divider);
+      // Pick a real option's own value so the lookup can succeed.
+      const target = selectable.find((o: any) => o.filterValue);
+      setStatus(target.filterValue);
+      expect(activeIndex()).toBe(selectable.indexOf(target));
+      expect(activeIndex()).toBeGreaterThan(0);
+    });
+  });
+
+  describe('teamFilter does not reorder the caller array', () => {
+    it('sorts for display without mutating the supplied teamParticipants', () => {
+      const table = fakeTable();
+      const teamParticipants = [
+        { participantId: 't2', participantName: 'Zebras' },
+        { participantId: 't1', participantName: 'Antelopes' },
+      ];
+      const original = teamParticipants.map((t) => t.participantId);
+
+      const { teamOptions } = getTeamFilter({ table: table as any, teamParticipants }) as any;
+
+      // `teamParticipants` is a caller-supplied parameter; `sort` used to
+      // reorder it in place, which is invisible here but corrupts whatever the
+      // caller does with the array next.
+      expect(teamParticipants.map((t) => t.participantId)).toEqual(original);
+      // ...while the rendered options ARE sorted.
+      const labels = teamOptions.filter((o: any) => !o.divider && o.filterValue).map((o: any) => o.filterValue);
+      expect(labels[0]).toBe('t1');
+    });
+
+    it('tolerates a participant with no name — the comparator must stay total', () => {
+      const table = fakeTable();
+      const teamParticipants = [{ participantId: 't1', participantName: 'Antelopes' }, { participantId: 't2' }];
+      expect(() => getTeamFilter({ table: table as any, teamParticipants })).not.toThrow();
     });
   });
 });

--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -131,7 +131,9 @@ export function getMatchUpDateFilter(table: any): {
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return {

--- a/src/components/tables/common/filters/matchUpEventFilter.ts
+++ b/src/components/tables/common/filters/matchUpEventFilter.ts
@@ -64,7 +64,9 @@ export function getMatchUpEventFilter(
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { eventOptions, hasOptions: events.length > 1, isFiltered: () => !!filterValue, activeIndex };

--- a/src/components/tables/common/filters/matchUpFlightFilter.ts
+++ b/src/components/tables/common/filters/matchUpFlightFilter.ts
@@ -69,7 +69,9 @@ export function getMatchUpFlightFilter(
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { flightOptions, hasOptions: flightOptions.length > 3, isFiltered: () => !!filterValue, activeIndex };

--- a/src/components/tables/common/filters/matchUpProfileFilter.ts
+++ b/src/components/tables/common/filters/matchUpProfileFilter.ts
@@ -83,7 +83,9 @@ export function getMatchUpProfileFilter(table: any): {
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return {

--- a/src/components/tables/common/filters/matchUpStatusFilter.ts
+++ b/src/components/tables/common/filters/matchUpStatusFilter.ts
@@ -117,7 +117,9 @@ export function getMatchUpStatusFilter(table: any): {
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return {

--- a/src/components/tables/common/filters/matchUpTeamFilter.ts
+++ b/src/components/tables/common/filters/matchUpTeamFilter.ts
@@ -99,7 +99,9 @@ export function getMatchUpTeamFilter(
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { teamOptions, hasOptions: teamParticipants.length > 0, isFiltered: () => !!filterValue, activeIndex };

--- a/src/components/tables/common/filters/matchUpTypeFilter.ts
+++ b/src/components/tables/common/filters/matchUpTypeFilter.ts
@@ -78,7 +78,9 @@ export function getMatchUpTypeFilter(
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { typeOptions, hasOptions: matchUpTypes.length > 1, isFiltered: () => !!filterValue, activeIndex };

--- a/src/components/tables/common/filters/scheduleFilters.ts
+++ b/src/components/tables/common/filters/scheduleFilters.ts
@@ -58,7 +58,9 @@ function createScheduleFilter(table: any, config: ScheduleFilterConfig, onChange
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { options, hasOptions: config.values.length > 1, isFiltered: () => !!filterValue, activeIndex };

--- a/src/components/tables/common/filters/sexFilter.ts
+++ b/src/components/tables/common/filters/sexFilter.ts
@@ -60,7 +60,9 @@ export function getSexFilter(
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { sexOptions, genders, isFiltered, activeIndex };

--- a/src/components/tables/common/filters/teamFilter.ts
+++ b/src/components/tables/common/filters/teamFilter.ts
@@ -45,7 +45,12 @@ export function getTeamFilter({
   // TODO: teamOptions => use element.options.replaceWith to update to only those teams with results
   const teamOptions = [allTeams, { divider: true }].concat(
     teamParticipants
-      .sort((a, b) => a?.participantName?.localeCompare(b?.participantName))
+      // `toSorted`, not `sort`: `teamParticipants` is a caller-supplied
+      // parameter, so sorting in place silently reordered the caller's array.
+      // The comparator is also made total — the old `a?.participantName?.…`
+      // returned `undefined` whenever a name was missing, which is not a valid
+      // comparator result and left ordering unspecified for those entries.
+      .toSorted((a, b) => (a?.participantName ?? '').localeCompare(b?.participantName ?? ''))
       .map((team) => ({
         onClick: () => updateTeamFilter(team.participantId),
         label: team.participantName,
@@ -60,7 +65,9 @@ export function getTeamFilter({
   const activeIndex = () => {
     if (!filterValue) return 0;
     const idx = selectableOptions.findIndex((opt: any) => opt.filterValue === filterValue);
-    return idx >= 0 ? idx : 0;
+    // `findIndex` yields -1 or a valid index, so clamping at 0 is exactly
+    // the old ternary. SonarJS prefers Math.max here.
+    return Math.max(idx, 0);
   };
 
   return { teamOptions, isFiltered, activeIndex };


### PR DESCRIPTION
SonarQube findings CA reported across the filter modules. **Both predate the filter-guard work** — those files were simply read closely for the first time in #1297.

## `Prefer Math.max() to simplify ternary expressions` — 11 modules

Each ended `activeIndex()` with `return idx >= 0 ? idx : 0;`. `findIndex` yields `-1` or a valid index, so `Math.max(idx, 0)` is exactly equivalent — it differs only for `NaN`, which `findIndex` cannot return.

eventFilter · matchUpDateFilter · matchUpEventFilter · matchUpFlightFilter · matchUpProfileFilter · matchUpStatusFilter · matchUpTypeFilter · matchUpTeamFilter · scheduleFilters · sexFilter · teamFilter

## `Move this array "sort" … or replace it with "toSorted"` — teamFilter

Not stylistic. `teamFilter` sorted `teamParticipants` **in place**, and that is a *caller-supplied parameter* — so building the dropdown silently reordered the caller's array. `toSorted` fixes a real side effect.

While there, the comparator was made total: `a?.participantName?.localeCompare(…)` returns `undefined` whenever a name is missing, which is not a valid comparator result and leaves ordering unspecified for those entries.

## Verification

lint 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · check-types 0 · vitest **113 files / 1193 tests** (+5).

Falsified per change: removing the clamp reddens only *"returns 0 when the saved filter matches no option"*; reverting `toSorted` to `sort` reddens only *"sorts for display without mutating the supplied teamParticipants"*. The non-mutation test is the one worth having — the old behaviour was invisible from inside this module.

## Deliberately not done

`numeric: true` on that comparator. The ecosystem standard prefers it for tournament metadata ("Team 2" before "Team 10"), but it changes visible ordering, which is beyond a Sonar cleanup. Happy to add it as its own change if you want that ordering.
