### PR TITLE
fix(deps): update tods-competition-factory to 6.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.27.0",
+    "tods-competition-factory": "6.28.1",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Ecosystem fan-out of factory **6.28.1**. Manifest-only: TMX overrides `tods-competition-factory` to `link:../factory`, so the lockfile records the link rather than a version and there is nothing to re-resolve. CI strips the override and installs the pin, which is what this changes.

Direct push to `main` was declined by branch protection, hence a PR — the other ten consumers took the bump directly.

## What is in 6.28.1

Notice-attribution fixes. No API or behaviour change for TMX; these populate identity fields on notices that were previously `undefined`:

- **#4647** — `MODIFY_MATCHUP` carries a populated `structureId`
- **#4649** — `eventId` reaches notices for **propagated** matchUps (advancement paths were dropping `event`)
- **#4651** — the `eventId` fallback is applied to the draw notice too, not only the matchUp payload

Consumed server-side by CFS for per-entity cache eviction. TMX is unaffected at runtime; this keeps the pin in step with the rest of the ecosystem.

Additive only — no existing notice shape changes.