### PR TITLE
fix(deps): update courthive-components to 3.14.1 and pdf-factory to 0.8.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.17",
+    "pdf-factory": "0.8.18",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.14.0",
+    "courthive-components": "3.14.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.5",


### PR DESCRIPTION
Consumer fan-out for the two packages published today.

| package | from | to |
|---|---|---|
| courthive-components | 3.14.0 | **3.14.1** |
| pdf-factory | 0.8.17 | **0.8.18** |

**components 3.14.1 carries the `controlBar` fix** (courthive-components#515) for the first of the two Tabulator warnings CA reported on the matchUps page — `Table Not Initialized - Calling the getSelectedRows function before the table is initialized`. Without this bump a full prod deploy would still ship 3.14.0 and the warning would persist, even though both warnings are fixed in source.

`courthive-public`, `epixodic` and `courthive-ams` were bumped and pushed directly by `bump-components-consumers.sh 3.14.1`. **TMX needs a PR** because `main` requires the `lint` status check, so the script's push was rejected (`GH006 … Required status check "lint" is expected`) and its commit was left local. Carried onto this branch unchanged; `main` was reset to `origin/main` so the shared checkout is not left ahead.

The pdf-factory bump is hand-made: there is no `bump-pdf-factory-consumers.sh` alongside the factory/components/provider-config scripts, and TMX is pdf-factory's only consumer.

Lockfile is unchanged for both, which is expected rather than an omission — `pnpm-workspace.yaml` overrides both to `link:../…`, so the pins are inert locally and are what CI and prod install once the override is stripped. `pnpm install --lockfile-only` confirmed there was nothing to rewrite.

## Verification

`pnpm check-types` passed for all four consumers as part of the bump script's gate. CI here is the real check: it strips the `link:` overrides and installs the published pins before `check-types` and `test --run`, so a green run is evidence about **3.14.1 and 0.8.18 as published**, not about the local symlinks.

⚠️ The full e2e suite I ran earlier today (348 passed / 1 skipped / 0 failed) was against components **3.14.0**. 3.14.1 changes when `controlBar` reads table selection — immediately if the table is built, deferred to `tableBuilt` otherwise — so the table-heavy journeys are worth a re-run after this lands.
