### PR TITLE
fix(schedule): keep the Inspector in the same slot on both catalog tabs

### DIFF
--- a/e2e/journeys/97-schedule2-inspector-readiness.spec.ts
+++ b/e2e/journeys/97-schedule2-inspector-readiness.spec.ts
@@ -200,6 +200,31 @@ test.describe('Journey 97 — Schedule2 Inspector readiness', () => {
     await expect(page.locator(INSPECTOR)).toBeVisible();
   });
 
+  test('the Inspector occupies the SAME slot on both tabs', async ({ page }) => {
+    const { tournamentId } = await seedInspector(page, 'clash');
+    await openScheduling(page, tournamentId);
+
+    const topOf = async (selector: string) => {
+      const box = await page.locator(selector).boundingBox();
+      if (!box) throw new Error(`no bounding box for ${selector}`);
+      return box.y;
+    };
+
+    await openUnscheduledTab(page);
+    const unscheduledTop = await topOf(INSPECTOR);
+    expect(unscheduledTop).toBeGreaterThan(await topOf(CATALOG_PANEL));
+
+    await openScheduledTab(page);
+    const scheduledTop = await topOf(INSPECTOR);
+    // The Scheduled panel is inserted BEFORE the Inspector rather than appended
+    // to the sidebar; appending put the Inspector at the top of the Scheduled
+    // tab and the bottom of the Unscheduled one.
+    expect(scheduledTop).toBeGreaterThan(await topOf(SCHEDULED_PANEL));
+    // Below-the-list is not enough — it must land at the same height, which is
+    // what the Scheduled panel's `flex: 3` (matching the catalog) buys.
+    expect(Math.abs(scheduledTop - unscheduledTop)).toBeLessThan(2);
+  });
+
   test('selecting a Scheduled card populates the Inspector and reports Scheduled: Yes', async ({ page }) => {
     const { tournamentId } = await seedInspector(page, 'clash');
     await openScheduling(page, tournamentId);

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -744,7 +744,10 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
   // sibling surfaces rather than two different designs.
   const scheduledPanel = document.createElement('div');
   scheduledPanel.dataset.sidebarPanel = 'scheduled';
-  scheduledPanel.style.cssText = 'display: none; flex: 1; min-height: 0; flex-direction: column;';
+  // `flex: 3` matches the unscheduled catalog panel's flex in the component's
+  // sidebar layout, so the Inspector below it gets the identical share of the
+  // sidebar on both tabs.
+  scheduledPanel.style.cssText = 'display: none; flex: 3; min-height: 0; flex-direction: column;';
 
   let scheduledSearchQuery = readScheduledSearch();
   let scheduledGroupBy: MatchUpCatalogGroupBy = readScheduledGroupBy();
@@ -1010,7 +1013,14 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
 
   // Insert control bar at top
   sidebar.insertBefore(controlBar, sidebar.firstChild);
-  sidebar.appendChild(scheduledPanel);
+  // The Scheduled panel stands in for the catalog, so it takes the catalog's
+  // slot — ABOVE the Inspector. Appending it to the sidebar instead leaves it
+  // after the Inspector, which puts the Inspector at the TOP on the Scheduled
+  // tab and at the BOTTOM on the Unscheduled tab: the panel jumps as soon as
+  // you switch views. `insertBefore(_, null)` degrades to append if the
+  // Inspector is ever absent.
+  const inspectorEl = sidebar.querySelector(':scope > [data-panel="inspector"]');
+  sidebar.insertBefore(scheduledPanel, inspectorEl);
 
   // Default sidebar tab is resolved after the scheduled-orphan helpers are
   // declared (see `resolveInitialTab` below), so we can land on "Scheduled"


### PR DESCRIPTION
The Inspector rendered **above** the list on the Scheduled tab and **below** it on Unscheduled, so switching tabs made the panel jump.

Two causes, both in `injectSidebarControls` (`gridView.ts`):

- `sidebar.appendChild(scheduledPanel)` placed the Scheduled panel *after* the Inspector. The component layout builds the sidebar as `catalog → inspector`, so the Scheduled panel has to take the catalog's slot, not a slot below the Inspector. Now inserted before `[data-panel="inspector"]` — `insertBefore(_, null)` degrades to append if it is ever absent.
- `scheduledPanel` was `flex: 1` against the catalog's `flex: 3`, so even with the order corrected the sidebar split 50/50 on one tab and 75/25 on the other, landing the Inspector at a different height.  Now `flex: 3`.

## Coverage

Journey 97 gains **"the Inspector occupies the SAME slot on both tabs"** — it asserts the Inspector is below the visible list on each tab *and* that its top edge lands within 2px across the switch.

Falsified both halves rather than assumed:
- restoring `appendChild` → fails `expect(scheduledTop).toBeGreaterThan(topOf(SCHEDULED_PANEL))` (Inspector top 154, above the panel)
- restoring `flex: 1` → fails the same-height assertion

Verified: journey 97 7/7, `pnpm lint` 0, `prettier --check` clean, `pnpm check-types` clean.