### PR TITLE
fix(venues): pre-fill the Time zone field from the saved zone

### DIFF
--- a/e2e/journeys/98-overview-edit-dates-timezone.spec.ts
+++ b/e2e/journeys/98-overview-edit-dates-timezone.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, waitForAppReady } from '../helpers/dev-bridge';
+
+/**
+ * Journey 98 — overview Edit Dates modal pre-fills the tournament's time zone.
+ *
+ * The dates stat card right-justifies `localTimeZone` and click-throughs to the
+ * Edit Dates modal. The modal's Time zone field must open showing the zone that
+ * is already set — otherwise the TD sees an empty picker next to a card that
+ * plainly displays a zone, and a blind [Save] reads as "clear the zone".
+ *
+ * The regression this guards: the field was wired only through the typeAhead's
+ * `currentValue`, which resolves a stored code to its display label by looking
+ * for `{ value, label }` entries in the list. The zone list is plain strings,
+ * so the lookup never matched and the input rendered empty for every tournament
+ * that had a zone set.
+ */
+
+const TIME_ZONE = 'Europe/Paris';
+const TZ_INPUT = 'input[placeholder="e.g. America/New_York"]';
+
+test.describe('Journey 98 — Edit Dates modal time zone pre-fill', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+  });
+
+  test('an existing localTimeZone pre-fills the modal Time zone field', async ({ page }) => {
+    const tournamentId = await page.evaluate(async (timeZone) => {
+      const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        tournamentName: 'E2E Time Zone Prefill',
+        nonRandom: 1,
+      });
+      // Set the zone on the record before load — `setTournamentLocalTimeZone`
+      // is a server-gated mutation and this spec is only about how the modal
+      // READS an already-set zone.
+      tournamentRecord.localTimeZone = timeZone;
+      dev.factory.tournamentEngine.setState(tournamentRecord);
+      await dev.load(tournamentRecord);
+      return tournamentRecord.tournamentId as string;
+    }, TIME_ZONE);
+
+    await page.goto(`/#/tournament/${tournamentId}/overview`);
+
+    // Control: the dates card itself surfaces the zone. If this fails the
+    // record never carried the zone and the modal assertion below would be
+    // vacuously "empty field, empty record".
+    const datesCard = page.locator('.dash-stats .dash-panel').first();
+    await expect(datesCard).toContainText(TIME_ZONE, { timeout: 15_000 });
+
+    await datesCard.click();
+
+    const tzInput = page.locator(TZ_INPUT);
+    await expect(tzInput).toBeVisible({ timeout: 10_000 });
+    await expect(tzInput).toHaveValue(TIME_ZONE);
+  });
+});

--- a/src/components/drawers/editTournamentDrawer.ts
+++ b/src/components/drawers/editTournamentDrawer.ts
@@ -96,13 +96,14 @@ export function editTournament({
       language: i18next.language,
     },
     {
+      // See the note in `editDatesModal` — the zone list is plain strings, so
+      // the typeAhead's `currentValue` label lookup never matches. `value` is
+      // what actually pre-fills the input.
+      value: values.localTimeZone,
       label: t('drawers.editTournament.timeZoneLabel'),
       placeholder: t('drawers.editTournament.timeZonePlaceholder'),
       field: 'localTimeZone',
-      typeAhead: {
-        list: supportedTimeZones,
-        currentValue: values.localTimeZone,
-      },
+      typeAhead: { list: supportedTimeZones },
     },
     // Tournament tier — the federation-specific competitive prestige
     // classification. When the provider config declares

--- a/src/pages/tournament/tabs/overviewTab/editDatesModal.ts
+++ b/src/pages/tournament/tabs/overviewTab/editDatesModal.ts
@@ -103,13 +103,17 @@ export function openEditDatesModal({ onSave }: { onSave: () => void }): void {
     // drawer. Empty value === "clear" so TDs can unset back to the
     // host-local fallback.
     {
+      // `value` — not the typeAhead's `currentValue` — is what pre-fills this
+      // field. `currentValue` resolves a stored code to its display label by
+      // looking for `{ value, label }` entries in the list; the zone list is
+      // plain strings, so that lookup always misses and the input renders
+      // empty. `renderField` assigns `item.value` after the typeAhead is
+      // attached, so the pre-fill survives.
+      value: existingTimeZone || detectedTimeZone,
       label: t('drawers.editTournament.timeZoneLabel'),
       placeholder: t('drawers.editTournament.timeZonePlaceholder'),
       field: 'localTimeZone',
-      typeAhead: {
-        list: supportedTimeZones,
-        currentValue: existingTimeZone || detectedTimeZone,
-      },
+      typeAhead: { list: supportedTimeZones },
     },
   ];
 


### PR DESCRIPTION
The overview tab's Edit Dates modal opened with an empty Time zone picker even for a tournament whose dates card plainly displayed its zone — so a blind [Save] read as "clear the zone".

## Root cause

`courthive-components` `src/helpers/createTypeAhead.ts`:

```js
const currentLabel = list.find((item) => item.value === currentValue)?.label;
if (currentLabel) element.value = currentLabel;
```

`currentValue` resolves a stored *code* to its *display label* by looking for `{ value, label }` entries. That is how the IOC / country / nationality typeaheads work — `editIndividualParticipant.ts:141` documents it explicitly. But `getSupportedTimeZones()` returns **plain strings**, so `item.value` is `undefined`, the lookup always misses, and the input is never populated. The dates card reads the record directly, which is why the panel and the modal disagreed.

## Fix

Use `value:` instead — `renderField` assigns `item.value` *after* the typeahead is attached, so it wins.

- `src/pages/tournament/tabs/overviewTab/editDatesModal.ts` — the reported modal
- `src/components/drawers/editTournamentDrawer.ts` — identical defect on the same field, fixed with it

The upstream `createTypeAhead` string-list gap is **not** fixed here — that needs a courthive-components publish plus a consumer bump cascade. It remains a latent trap for the next plain-string typeahead.

## Verification

`e2e/journeys/98-overview-edit-dates-timezone.spec.ts`, falsified rather than merely run: with the fix reverted the *same* spec goes red, while its control assertion (the dates card shows the zone) passes in both runs — so the probe isolates the modal field rather than the seed.

Local: `pnpm lint` 0 · `check-types` 0 · `pnpm test --run` 113 files / 1193 tests · `format:check` clean · `attr-audit --ci` and `i18n-audit --ci` exit 0.