### PR TITLE
fix(venues): re-read the venues table from the engine when a venue is added

### DIFF
--- a/e2e/journeys/99-venues-table-refresh-on-add.spec.ts
+++ b/e2e/journeys/99-venues-table-refresh-on-add.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 99 — the venues TABLE shows a venue the moment it is added, by either add path.
+ *
+ * Why this exists: `updateVenueRow` used to refresh only the tab header in table mode, on the
+ * assumption that the table "self-updates via dataChanged". Tabulator fires `dataChanged` only for
+ * data changed *through* the table (inline edit, `addRow`, `deleteRow`) — never for a factory
+ * mutation applied elsewhere — so nothing re-read the engine, the row never appeared, and the
+ * header reported the stale count. Grid mode was unaffected because it re-renders from the engine.
+ *
+ * Journey 92 covers the registry add but asserts only on the mutation payload and the tournament
+ * record, so it passed with the bug present. This file asserts on the rendered table.
+ *
+ * Both add paths are exercised deliberately. They pass different arguments to the same callback —
+ * `addVenue.ts` sends `{ ...result, venue }`, `addVenueFromRegistry.ts` sends a bare `result` — so
+ * a refresh that read the venue off the argument would work here for hand entry and silently no-op
+ * for the registry. Covering only one route would not catch that.
+ */
+
+const VENUES_TABLE = '#venuesTable';
+const NAME_CELL = `${VENUES_TABLE} .tabulator-cell[tabulator-field="venueName"]`;
+const HEADER = '.section:has(#venuesTable) .tabHeader';
+const VIEW_MODE_KEY = 'tmx_venues_view_mode';
+
+const AMS = '**/facilities/**';
+
+const CANDIDATES = {
+  results: [
+    { facilityId: 'fac-life', name: 'Life Time Peachtree', city: 'Atlanta', countryCode: 'USA', courtCount: 7 },
+  ],
+};
+
+const REGISTRY_VENUE = {
+  venueId: 'fac-life',
+  facilityId: 'fac-life',
+  venueName: 'Life Time Peachtree',
+  addresses: [{ city: 'Atlanta', countryCode: 'USA' }],
+  courts: [
+    { courtId: 'court-a', courtName: 'Court 1', courtOrder: 1 },
+    { courtId: 'court-b', courtName: 'Court 2', courtOrder: 2 },
+  ],
+};
+
+async function stubRegistry(page: Page) {
+  await page.route(AMS, (route) => {
+    const url = route.request().url();
+    if (url.includes('/facilities/search')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(CANDIDATES) });
+    }
+    if (url.includes('/venue')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(REGISTRY_VENUE) });
+    }
+    return route.continue();
+  });
+}
+
+/** The registry lookup button is gated on a signed-in session; an unsigned JWT with a future `exp` clears it. */
+async function stubSignedInSession(page: Page) {
+  await page.evaluate(() => {
+    const b64 = (o: any) => btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    localStorage.setItem('tmxToken', `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ exp, roles: [], provider: {} })}.`);
+  });
+}
+
+async function gotoVenues(page: Page, viewMode: 'table' | 'grid') {
+  const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+  await stubSignedInSession(page);
+  // Table is the default, but the bug is mode-specific — pin it rather than inherit it.
+  await page.evaluate(([key, mode]) => localStorage.setItem(key, mode), [VIEW_MODE_KEY, viewMode] as const);
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  await tournament.navigateToVenues();
+}
+
+/** Fill the hand-entry drawer and save. Fields carry no ids, so target them by their label. */
+async function addVenueByHand(page: Page, { name, abbreviation, courts }: Record<string, string>) {
+  await page.locator('#addVenue').click();
+  const field = (label: string) => page.locator(`.drawer .field:has(label.label:text-is("${label}")) input`).first();
+  await expect(field('Venue name')).toBeVisible({ timeout: 5_000 });
+  await field('Venue name').fill(name);
+  await field('Abbreviation').fill(abbreviation);
+  await field('Number of courts').fill(courts);
+  const save = page.locator('#addVenueButton');
+  await expect(save).toBeEnabled({ timeout: 5_000 });
+  await save.click();
+}
+
+async function addVenueFromRegistry(page: Page) {
+  await page.locator('#addVenue').click();
+  const lookup = page.locator('#facilityRegistryLookup');
+  await expect(lookup).toBeVisible({ timeout: 5_000 });
+  await lookup.click();
+  await page.getByPlaceholder('Search facilities by name').fill('life');
+  const candidate = page.locator('[data-facility-id="fac-life"]');
+  await expect(candidate).toBeVisible({ timeout: 5_000 });
+  await candidate.click();
+  await expect(page.locator('#facilityPreview')).toContainText('Court 1', { timeout: 5_000 });
+  await page.getByRole('button', { name: 'Add to tournament' }).click();
+}
+
+test.describe('Journey 99 — the venues table refreshes when a venue is added', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('hand entry adds the row to the table and updates the header count', async ({ page }) => {
+    await gotoVenues(page, 'table');
+    await expect(page.locator(HEADER)).toContainText('Venues (0)');
+
+    await addVenueByHand(page, { name: 'Greenwood Racquet Club', abbreviation: 'GRC', courts: '4' });
+
+    await expect(page.locator(NAME_CELL)).toContainText('Greenwood Racquet Club', { timeout: 8_000 });
+    await expect(page.locator(HEADER)).toContainText('Venues (1)');
+  });
+
+  test('a registry add lands the row too — the refresh cannot depend on the callback argument', async ({ page }) => {
+    await stubRegistry(page);
+    await gotoVenues(page, 'table');
+    await expect(page.locator(HEADER)).toContainText('Venues (0)');
+
+    await addVenueFromRegistry(page);
+
+    // The registry path passes no `venue` to the callback. Reading one off the argument would leave
+    // this assertion red while the hand-entry test above stayed green.
+    await expect(page.locator(NAME_CELL)).toContainText('Life Time Peachtree', { timeout: 8_000 });
+    await expect(page.locator(HEADER)).toContainText('Venues (1)');
+  });
+
+  test('grid mode is unaffected — the control that localises the fix to the table path', async ({ page }) => {
+    await gotoVenues(page, 'grid');
+
+    await addVenueByHand(page, { name: 'Greenwood Racquet Club', abbreviation: 'GRC', courts: '4' });
+
+    // Grid mode re-renders from the engine and was already correct. This assertion holds both with
+    // and without the table fix, so it proves the two table tests above isolate the table path
+    // rather than an unrelated failure to add the venue at all.
+    await expect(page.locator('.tmx-venues-grid')).toContainText('Greenwood Racquet Club', { timeout: 8_000 });
+  });
+});

--- a/src/pages/tournament/tabs/venuesTab/venuesTab.ts
+++ b/src/pages/tournament/tabs/venuesTab/venuesTab.ts
@@ -74,6 +74,7 @@ export function renderVenueTab({ venueView, venueId }: RenderVenueTabParams = {}
   // ─── List view (cards or table) ─────────────────────────────────────────
   let mode: VenuesViewMode = readVenuesViewMode();
   let table: any;
+  let replaceTableData: (() => void) | undefined;
   let gridInstance: AvailabilityGridInstance | undefined;
   let availabilityVisible = venueView === AVAILABILITY;
 
@@ -105,10 +106,22 @@ export function renderVenueTab({ venueView, venueId }: RenderVenueTabParams = {}
     context.router?.navigate(`/${TOURNAMENT}/${tournamentId}/${VENUE}/${vId}`);
   };
 
+  /**
+   * Re-read the venue list from the engine after a mutation applied elsewhere.
+   *
+   * Takes no arguments **by design**. The two add paths pass different shapes to this callback —
+   * `addVenue.ts` sends `{ ...result, venue }`, `addVenueFromRegistry.ts` sends a bare `result` —
+   * so anything read off the argument would work on one route and silently no-op on the other.
+   * Deriving from the engine makes both paths behave identically by construction.
+   */
   const updateVenueRow = () => {
     if (mode === 'table' && table) {
-      // Table mode self-updates via dataChanged; orchestrator refreshes header.
-      refreshHeader(table.getDataCount?.() ?? table.getData?.().length ?? 0);
+      // Tabulator's `dataChanged` fires only for data changed THROUGH the table (inline edit,
+      // addRow, deleteRow); a factory mutation elsewhere never reaches it, so the table has to be
+      // told to re-read. The count comes from the engine rather than `getDataCount()` because
+      // `replaceData` resolves asynchronously — reading the table here still returns the old one.
+      replaceTableData?.();
+      refreshHeader(readVenueCardData().length);
     } else if (mode === 'grid' && venuesAnchor) {
       const count = renderVenuesGrid(venuesAnchor, onCardClick);
       refreshHeader(count);
@@ -119,6 +132,7 @@ export function renderVenueTab({ venueView, venueId }: RenderVenueTabParams = {}
     if (!venuesAnchor) return;
     destroyTable({ anchorId: TOURNAMENT_VENUES });
     table = undefined;
+    replaceTableData = undefined;
     const count = renderVenuesGrid(venuesAnchor, onCardClick);
     refreshHeader(count);
   }
@@ -126,6 +140,7 @@ export function renderVenueTab({ venueView, venueId }: RenderVenueTabParams = {}
   function renderTable(): void {
     const result = createVenuesTable();
     table = result.table;
+    replaceTableData = result.replaceTableData;
     const initialCount = table?.getDataCount?.() ?? table?.getData?.().length ?? 0;
     refreshHeader(initialCount);
     table?.on?.('dataChanged', (rows: any[]) => refreshHeader(rows.length));


### PR DESCRIPTION
## The bug

Add a venue in the Venues tab and, in **table** mode, the row does not appear — and the header count is wrong too. The mutation itself is fine: reload the page and the venue is there. Reported on `dev.courthive.net/tmx` after a registry add, but it is not registry-specific; both add paths share the callback.

## Root cause

`venuesTab.ts` `updateVenueRow()` refreshed only the header in table mode:

```ts
// Table mode self-updates via dataChanged; orchestrator refreshes header.
refreshHeader(table.getDataCount?.() ?? table.getData?.().length ?? 0);
```

Tabulator's `dataChanged` fires only for data changed **through** the table — inline edit, `addRow`, `deleteRow`. A factory mutation applied elsewhere never reaches it. The table is built once from engine data and never re-reads, so nothing added the row, and `getDataCount()` then returned the *pre-mutation* count — which is why even the header number was stale.

Grid mode was already correct: it re-runs `renderVenuesGrid()` against the engine.

`deleteVenues` in `venueControl.ts` has always called `table.deleteRow(venueIds)` explicitly. Add had no counterpart.

## The fix

`createVenuesTable()` already returns a `replaceTableData` that re-reads venues from the engine; `renderTable()` was throwing it away. Keep it, and call it from the refresh callback.

The refresh **stays argument-free deliberately**. The two add paths pass different shapes to a callback that took none:

| Path | Call |
|---|---|
| Hand entry | `callback({ ...result, venue })` (`addVenue.ts`) |
| Registry | `callback(result)` — no `venue` (`addVenueFromRegistry.ts`) |

So the obvious fix — read `venue` off the argument and `addRow` it — would work for hand entry and **silently no-op for the registry**, turning a harmless inconsistency into a bug reproducing on only one of two routes. Deriving from the engine makes both paths identical by construction and leaves the argument decorative.

The header count comes from the engine rather than `getDataCount()` because `replaceData` resolves asynchronously — read synchronously after it, the table still reports the old count.

## `onMutationApplied` was considered and rejected

The standing pattern says a page's factory-read cache should subscribe to `onMutationApplied` rather than depend on a post-mutation callback. Checked, and not right for this surface:

- The venues table is a rendered view with UI state, not a memoized read cache. Each row's `rowFormatter` builds a hidden nested courts Tabulator that the user expands; `replaceData` re-runs the formatter for every row, collapsing any open court list.
- `notifyMutationApplied` fires for **every** applied mutation including remote broadcasts, so a subscription would churn the table and collapse expansions on unrelated score updates arriving from other clients while the operator sits on the tab.
- The tab has no per-render teardown hook — `destroyActiveTab()` runs only when switching to a *different* tab, while in-tab navigation (list → venue detail → back) re-invokes `renderVenueTab`, so a subscription taken there would accumulate.

## Tests

New `e2e/journeys/99-venues-table-refresh-on-add.spec.ts` — both add paths assert on the rendered table and the header count, plus a grid-mode control. Journey 92 covers the registry add but only asserts on the mutation payload and the tournament record, so it passed with the bug present; it is left as-is and this is a sibling.

**Falsified three ways:**

| Variant | hand entry | registry | grid control |
|---|---|---|---|
| Fix applied | pass | pass | pass |
| Refresh call removed | **fail** | **fail** | pass |
| Argument-driven variant (the trap) | pass | **fail** | pass |

The grid control passes in every variant, so it isolates the failure to the table path rather than to adding the venue at all.

## Gates

`pnpm lint` 0 · `pnpm check-types` 0 · `pnpm test --run` 113 files / 1193 tests · prettier clean on both touched files · Playwright journeys 92 + 99 green locally (7 passed). CI does not run Playwright, so the e2e evidence above is local.
