### PR TITLE
fix(venues): hand back one callback shape from the venue edit drawers

### DIFF
--- a/src/components/popovers/courtActions.ts
+++ b/src/components/popovers/courtActions.ts
@@ -2,7 +2,7 @@
  * Court actions popover with edit option.
  * Shows tipster menu for court management actions from table rows.
  */
-import { editCourt } from 'pages/tournament/tabs/venuesTab/editCourt';
+import { editCourt, type CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
 import { competitionEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 
@@ -20,7 +20,7 @@ export const courtActions =
     const row = cell.getRow();
     const courtRow = row?.getData();
 
-    const doneEditing = ({ success }: any) => {
+    const doneEditing = ({ success }: CourtEditResult) => {
       if (success) {
         // Fetch updated court from venues to ensure we have correct values
         const { venues = [] } = competitionEngine.getVenuesAndCourts();

--- a/src/components/popovers/courtActions.ts
+++ b/src/components/popovers/courtActions.ts
@@ -2,7 +2,7 @@
  * Court actions popover with edit option.
  * Shows tipster menu for court management actions from table rows.
  */
-import { editCourt, type CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
+import { editCourt, CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
 import { competitionEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 

--- a/src/components/popovers/venueActions.ts
+++ b/src/components/popovers/venueActions.ts
@@ -2,7 +2,7 @@
  * Venue actions popover with edit option.
  * Shows tipster menu for venue management actions from table rows.
  */
-import { editVenue, type VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
+import { editVenue, VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
 import { tournamentEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 

--- a/src/components/popovers/venueActions.ts
+++ b/src/components/popovers/venueActions.ts
@@ -2,7 +2,7 @@
  * Venue actions popover with edit option.
  * Shows tipster menu for venue management actions from table rows.
  */
-import { editVenue } from 'pages/tournament/tabs/venuesTab/editVenue';
+import { editVenue, type VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
 import { tournamentEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 
@@ -22,7 +22,7 @@ export const venueActions =
     const row = cell.getRow();
     const venueRow = row?.getData();
 
-    const doneEditing = ({ success, venueUpdates, courtsUpdated }: any) => {
+    const doneEditing = ({ success, venueUpdates, courtsUpdated }: VenueEditResult) => {
       if (success) {
         Object.assign(venueRow, venueUpdates);
         row.update(venueRow);

--- a/src/pages/tournament/tabs/venuesTab/editCourt.ts
+++ b/src/pages/tournament/tabs/venuesTab/editCourt.ts
@@ -16,7 +16,20 @@ import { RIGHT } from 'constants/tmxConstants';
 const { surfaceConstants } = factoryConstants;
 const EMPTY_OPTION = '------------';
 
-export function editCourt({ court, callback }: { court?: any; callback?: (result: any) => void } = {}): void {
+/**
+ * What `editCourt` hands back to its callback. `courtUpdates` is always present — see the single
+ * call site in `postMutation` — so a consumer may read it without first proving `success`.
+ */
+export type CourtEditResult = {
+  courtUpdates: Record<string, any>;
+  success?: boolean;
+  error?: any;
+};
+
+export function editCourt({
+  court,
+  callback,
+}: { court?: any; callback?: (result: CourtEditResult) => void } = {}): void {
   const values: any = {
     courtName: court?.courtName || '',
     indoorOutdoor: court?.indoorOutdoor || '',
@@ -118,13 +131,14 @@ export function editCourt({ court, callback }: { court?: any; callback?: (result
       courtUpdates.surfaceType = undefined;
     }
 
+    // ONE payload, ONE call site — see the note in `editVenue.ts`. The error branch used to hand
+    // back a bare `result` without `courtUpdates`, the same latent divergence.
     const postMutation = (result: any) => {
-      if (result.success) {
-        if (isFunction(callback)) callback({ ...result, courtUpdates });
-      } else if (result.error) {
+      if (result?.error) {
         tmxToast({ intent: 'is-warning', message: result.error?.message || t('common.error') });
-        if (isFunction(callback)) callback(result);
       }
+      if (!result?.success && !result?.error) return;
+      if (isFunction(callback) && callback) callback({ ...result, courtUpdates });
     };
 
     const courtId = court.courtId;

--- a/src/pages/tournament/tabs/venuesTab/editDrawerCallbackShape.test.ts
+++ b/src/pages/tournament/tabs/venuesTab/editDrawerCallbackShape.test.ts
@@ -23,8 +23,8 @@
  * mode this guards is a future consumer, not a current render.
  */
 
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 const DRAWERS = [
   { name: 'editVenue', path: new URL('./editVenue.ts', import.meta.url) },

--- a/src/pages/tournament/tabs/venuesTab/editDrawerCallbackShape.test.ts
+++ b/src/pages/tournament/tabs/venuesTab/editDrawerCallbackShape.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Guard: each venue edit drawer hands its callback exactly ONE shape.
+ *
+ * `editVenue` and `editCourt` used to build the callback payload twice — a success branch carrying
+ * the edit's details (`venueUpdates`/`courtsUpdated`, `courtUpdates`) and an error branch handing
+ * back a bare `result` without them. Consumers destructure those details, so on the error path they
+ * read `undefined`. Nothing depended on them there, which is precisely what made it a trap rather
+ * than a bug — it was one unguarded read away from a live defect, on whichever route happened to
+ * fail.
+ *
+ * This is the same defect class as the venues-table refresh (TMX #1306): two paths passing
+ * different shapes to a single callback, where the divergence stays invisible until someone reads
+ * the argument. The fix there was to make the shape identical by construction rather than by
+ * discipline, and the same applies here.
+ *
+ * A type alone does not hold the line — TypeScript will happily accept a second `callback(result)`
+ * whose spread satisfies the type at the widened `any` the mutation result carries. The invariant
+ * that actually prevents divergence is structural: **one construction, one call site**. So that is
+ * what this asserts. Re-split either branch and this reddens.
+ *
+ * Source-level assertion is deliberate. The behaviour it protects has no user-visible symptom
+ * today, so a DOM or e2e test would pass with the defect present and prove nothing — the failure
+ * mode this guards is a future consumer, not a current render.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const DRAWERS = [
+  { name: 'editVenue', path: new URL('./editVenue.ts', import.meta.url) },
+  { name: 'editCourt', path: new URL('./editCourt.ts', import.meta.url) },
+];
+
+/** Invocations of the callback — `callback(` — not `isFunction(callback)` or the `callback?:` type. */
+const invocations = (source: string) => source.match(/\bcallback\(/g) ?? [];
+
+describe('venue edit drawers hand back one callback shape', () => {
+  for (const drawer of DRAWERS) {
+    const source = readFileSync(drawer.path, 'utf8');
+
+    it(`${drawer.name} invokes its callback from exactly one site`, () => {
+      expect(invocations(source)).toHaveLength(1);
+    });
+
+    it(`${drawer.name} does not hand back a bare mutation result`, () => {
+      // The pre-fix error branch was literally `callback(result)`. Spreading it into the details
+      // object is the shape we want; passing it through untouched is the one we do not.
+      expect(source).not.toMatch(/\bcallback\(result\)/);
+    });
+  }
+
+  it('the detector can report dirty', () => {
+    // Falsifies the check above: the pre-fix shape, verbatim, must fail both assertions.
+    const preFix = `
+      const postMutation = (result: any) => {
+        if (result.success) {
+          if (isFunction(callback)) callback({ ...result, courtUpdates });
+        } else if (result.error) {
+          if (isFunction(callback)) callback(result);
+        }
+      };
+    `;
+    expect(invocations(preFix)).toHaveLength(2);
+    expect(preFix).toMatch(/\bcallback\(result\)/);
+  });
+});

--- a/src/pages/tournament/tabs/venuesTab/editVenue.ts
+++ b/src/pages/tournament/tabs/venuesTab/editVenue.ts
@@ -24,7 +24,24 @@ function findResource(resources: any[] | undefined, name: string): any {
   return resources.find((r) => r?.name === name);
 }
 
-export function editVenue({ venue, callback }: { venue?: any; callback?: (result: any) => void } = {}): void {
+/**
+ * What `editVenue` hands back to its callback.
+ *
+ * Typed so a new consumer sees the contract rather than discovering it by destructuring. The
+ * details are always present — see the single call site in `postMutation` — so a consumer may read
+ * them without first proving `success`.
+ */
+export type VenueEditResult = {
+  venueUpdates: Record<string, any>;
+  courtsUpdated: boolean;
+  success?: boolean;
+  error?: any;
+};
+
+export function editVenue({
+  venue,
+  callback,
+}: { venue?: any; callback?: (result: VenueEditResult) => void } = {}): void {
   // Get current venue details including courts and times
   const { venue: venueDetails } = tournamentEngine.findVenue({ venueId: venue.venueId });
   const courts = venueDetails?.courts || [];
@@ -330,18 +347,25 @@ export function editVenue({ venue, callback }: { venue?: any; callback?: (result
     resourceMutation(VENUE_WEBSITE_RESOURCE_NAME, 'WEBSITE', websiteURL, existingWebsiteResource);
     resourceMutation(VENUE_IMAGE_RESOURCE_NAME, 'IMAGE', imageURL, existingImageResource);
 
+    // ONE payload, ONE call site. The success and error branches used to build the result
+    // separately — success carried `venueUpdates`/`courtsUpdated`, error handed back a bare
+    // `result` — so a consumer that destructured the details got `undefined` for them whenever the
+    // mutation failed. Nothing reads them on the error path today, which is what made it a trap
+    // rather than a bug: the next consumer to read them unguarded finds out in production. Same
+    // defect class as the venues-table refresh (#1306), where two add paths passed different
+    // shapes to one callback. Keeping the construction in one place makes divergence impossible
+    // rather than merely absent; `editDrawerCallbackShape.test.ts` pins it.
     const postMutation = (result: any) => {
-      if (result.success) {
-        if (isFunction(callback)) {
-          callback({
-            ...result,
-            venueUpdates: { ...venueUpdates, venueWebsiteURL: websiteURL, venueImageURL: imageURL },
-            courtsUpdated,
-          });
-        }
-      } else if (result.error) {
+      if (result?.error) {
         tmxToast({ intent: 'is-warning', message: result.error?.message || t('common.error') });
-        if (isFunction(callback)) callback(result);
+      }
+      if (!result?.success && !result?.error) return;
+      if (isFunction(callback) && callback) {
+        callback({
+          ...result,
+          venueUpdates: { ...venueUpdates, venueWebsiteURL: websiteURL, venueImageURL: imageURL },
+          courtsUpdated,
+        });
       }
     };
 


### PR DESCRIPTION
Follow-up to #1306, which flagged this while fixing the venues-table refresh.

## The divergence

`editVenue` and `editCourt` each built their callback payload **twice**:

| Branch | `editVenue` | `editCourt` |
|---|---|---|
| success | `callback({ ...result, venueUpdates, courtsUpdated })` | `callback({ ...result, courtUpdates })` |
| error | `callback(result)` — details missing | `callback(result)` — details missing |

Both consumers destructure those details (`venueActions.doneEditing({ success, venueUpdates, courtsUpdated })`), so on the error path they read `undefined`.

**There is no live defect** — every consumer guards on `success` first, and `renderVenueDetail` ignores the argument entirely and re-renders from the engine. That is precisely what makes it a trap: it sits one unguarded read away from a bug that reproduces on only the failing route. Identical defect class to #1306, where two add paths passed different shapes to one callback and the divergence stayed invisible until something read the argument.

## What I checked before touching it

I suspected a live symptom in `venueActions.doneEditing`, which patches the Tabulator row from `venueUpdates` rather than re-reading the engine — `venueUpdates.courts` is a bare `[{ courtId, courtName }]`, which looked like it would clobber the row's mapped courts and blank the derived Scheduled/Unscheduled columns in the nested courts table.

Probed it in the browser instead of asserting it. **It does not happen.** `row.update()` does not rebuild the nested table, and the `courtsUpdated` branch refreshes it from the engine, so a court rename lands and `0m`/`96h` survive:

```
BEFORE  ["1 Court 1 0m 96h", "2 Court 2 0m 96h", "3 Court 3 0m 96h"]
AFTER   ["1 Stadium 1 0m 96h", "2 Stadium 2 0m 96h", "3 Stadium 3 0m 96h"]
```

So this PR is scoped to the shape divergence only, and `venueActions`' targeted row update is left alone — it is arguably better than a wholesale re-read here, since `row.update()` preserves row expansion where `replaceData` would collapse it.

## The fix

Structural, not cosmetic: **one payload built once, one call site per drawer**, so divergence is impossible rather than merely absent — aligning two branches leaves them free to drift again. Results are typed (`VenueEditResult`, `CourtEditResult`) and both consumers annotate their handlers, so the next consumer reads the contract instead of discovering it by destructuring.

`editCourt` is fixed in the same PR deliberately. It carries the identical divergence, and fixing one while leaving the other is the exact failure mode #1306 warned about.

**Behaviour is unchanged.** Success is byte-identical; the error path still toasts and still reaches consumers that return early on falsy `success`; a result carrying neither flag still invokes nothing.

## Test

`editDrawerCallbackShape.test.ts` asserts the invariant at the source level. That choice is deliberate and worth stating plainly: this defect has **no user-visible symptom today**, so a DOM or e2e test would pass with it present and prove nothing — the failure mode being guarded is a future consumer, not a current render. A type alone does not hold the line either, since TS accepts a second `callback(result)` at the widened `any` the mutation result carries.

Falsified by reverting `editCourt.ts` to the pre-fix shape: both of its assertions redden while `editVenue`'s stay green, so the guard is precise rather than blanket. The detector's own can-report-dirty case is inline.

## Gates

`pnpm lint` 0 · `pnpm check-types` 0 · `pnpm test --run` 114 files / 1198 tests (was 113/1193) · prettier clean on all five touched files · Playwright journeys 25, 86, 92, 99 green locally (15 passed). CI does not run Playwright.

## Noted, not fixed

There is no e2e covering the venue *edit* flow at all — the probe above was throwaway. Worth adding, but out of scope for a shape fix.
