### PR TITLE
style(venues): restore `import type` on the venue edit-drawer result types

### DIFF
--- a/src/components/popovers/courtActions.ts
+++ b/src/components/popovers/courtActions.ts
@@ -2,7 +2,7 @@
  * Court actions popover with edit option.
  * Shows tipster menu for court management actions from table rows.
  */
-import { editCourt, CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
+import { editCourt, type CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
 import { competitionEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 

--- a/src/components/popovers/venueActions.ts
+++ b/src/components/popovers/venueActions.ts
@@ -2,7 +2,7 @@
  * Venue actions popover with edit option.
  * Shows tipster menu for venue management actions from table rows.
  */
-import { editVenue, VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
+import { editVenue, type VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
 import { tournamentEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 


### PR DESCRIPTION
Two-line follow-up to #1307.

#1307 rewrote these imports to the plain form to satisfy the ecosystem rule *"never use `import type`"*. Tracing that rule found **no rationale**:

- It arrived in Mentat `0fc14e5` (2026-04-08), a **docs-only** commit, filed among the import-formatting rules (sort by length, section grouping), with no reason and no incident attached. The same commit added the since-relaxed "agents must never run install commands".
- It was contradicted at **~1250 sites** — factory 752, courthive-components 314, CFS 101, TMX 83.
- `import type` is the explicit erasure guarantee and what `verbatimModuleSyntax` requires. Enabling that flag in TMX raises **110 TS1484** errors today, so the ban pointed away from where the compiler defaults are heading.

The rule is now **"prefer `import type`"** in `standards/coding-standards.md`, so this restores the two lines to the preferred form — which is also what the other 83 sites in `src/` use.

No behaviour change: both forms erase identically while `verbatimModuleSyntax` is off. `pnpm build` green either way.

## What the standard now says instead

The blanket import ban was a generalisation of a real incident onto the wrong construct. The standard now carries the actual hazard as the hard rule:

> **Never `export type *` from a package entry point.** factory's `src/index.ts` had `export type * from './types'`, a type-only re-export that stripped the runtime side of 29 `export enum`s — `MatchUpStatusEnum` type-checked fine while `MatchUpStatusEnum.COMPLETED` was `undefined` for every consumer. Cost a five-PR arc (#4547–#4554) plus runtime and compile-time conformance guards.

Type-only **re-exports erase values**; type-only **imports do not**.

## Gates

`pnpm lint` 0 · `check-types` 0 · `format:check` 0 · `test --run` 0 · `build` 0.
