### PR TITLE
ci: bound the electron gate so a hung apt step cannot stall PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    # Same guard as electron.yml, for the same reason: no TMX workflow had a
+    # timeout, so any hung step got GitHub's 360-minute default before anyone
+    # found out. This job is the required check, so a hang here blocks merging
+    # outright. A healthy run is ~2 minutes.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -65,28 +65,54 @@ jobs:
       # runner. `install-deps` provides exactly those.
       #
       # It shells out to `apt-get`, which on hosted runners intermittently
-      # blocks — typically on the dpkg / unattended-upgrades lock, sometimes on
-      # a slow mirror. On 2026-08-18 it hung here on TWO branches at once,
-      # including `main`, while other runs minutes apart sailed through, so the
-      # stall is environmental rather than anything in the diff under test.
+      # blocks. On 2026-08-18 it hung here on TWO branches at once, including
+      # `main`, while other runs minutes apart sailed through.
       #
-      # The per-attempt `timeout` is the load-bearing part: a step-level
-      # `timeout-minutes` would kill the retry loop along with the hung attempt,
-      # which is exactly no better than hanging. Bounding each attempt instead
-      # turns an unbounded stall into a bounded retry, and a genuinely missing
-      # dependency still fails the step rather than being swallowed — the smoke
-      # test that follows would otherwise fail with a far more confusing error.
+      # Measured on run 32168607973 rather than guessed, and the numbers decide
+      # the design:
+      #
+      #   * 26 of the shared libraries are ALREADY on the ubuntu-24.04 image
+      #     ("already the newest version"). The only NEW packages are nine FONT
+      #     packages — 21.1 MB — and Electron links against none of them.
+      #   * The stall is in that font download, not in dependency resolution.
+      #
+      # So this step is advisory, not a gate. Failing the build because a font
+      # mirror stalled blocks every PR for something the desktop app does not
+      # need. The smoke test below is the real assertion: if a library Electron
+      # actually links against ever goes missing from the image, it fails there
+      # with a loud loader error, and these warnings sit directly above it.
+      #
+      # Two things make the retry work at all:
+      #   * a per-attempt `timeout` — a step-level `timeout-minutes` would kill
+      #     the retry loop along with the hung attempt, which is no better than
+      #     hanging;
+      #   * reclaiming the dpkg lock between attempts. `timeout` kills the
+      #     playwright process, but the apt-get it launched under sudo survives
+      #     as an orphan still holding /var/lib/dpkg/lock-frontend. Measured:
+      #     attempt 1 timed out mid-download and attempts 2-3 then died in
+      #     ~1s each on "held by process 2962 (apt-get)". Without this, the
+      #     retries are guaranteed to fail and the loop is decoration.
       - name: Install Chromium system dependencies
         run: |
+          reclaim_dpkg_lock() {
+            sudo pkill -TERM -x apt-get 2>/dev/null || true
+            sleep 3
+            sudo pkill -KILL -x apt-get 2>/dev/null || true
+            sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock
+            sudo dpkg --configure -a || true
+          }
           for attempt in 1 2 3; do
             if timeout 4m pnpm exec playwright install-deps chromium; then
+              echo "install-deps succeeded on attempt ${attempt}"
               exit 0
             fi
-            echo "::warning::install-deps attempt ${attempt} failed or timed out after 4m; retrying"
-            sleep 15
+            echo "::warning::install-deps attempt ${attempt} failed or timed out after 4m; reclaiming dpkg lock"
+            reclaim_dpkg_lock
           done
-          echo "::error::playwright install-deps chromium failed after 3 attempts"
-          exit 1
+          echo "::warning::install-deps did not complete after 3 attempts — continuing anyway."
+          echo "::warning::Only font packages are missing from this image; the shared libraries"
+          echo "::warning::Electron links against are preinstalled. If one were genuinely absent,"
+          echo "::warning::the smoke test below fails with a loader error — that is the real gate."
 
       # Electron always opens a real window; there is no headless mode for the
       # app shell, so Linux CI needs a virtual framebuffer.

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -18,6 +18,12 @@ jobs:
   desktop:
     name: build + smoke
     runs-on: ubuntu-latest
+    # Without this the job inherits GitHub's 360-minute default. On 2026-08-18
+    # the apt step below hung and the job sat "in progress" for 49 minutes with
+    # nearly six hours still to run, holding a PR's only outstanding check. A
+    # healthy run finishes in ~6 minutes, so 20 is generous headroom and still
+    # fails fast enough to be actionable rather than mistaken for a slow build.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -57,8 +63,30 @@ jobs:
       # Electron bundles its own Chromium, so no browser download is needed —
       # but the shared system libraries it links against are not on a bare
       # runner. `install-deps` provides exactly those.
+      #
+      # It shells out to `apt-get`, which on hosted runners intermittently
+      # blocks — typically on the dpkg / unattended-upgrades lock, sometimes on
+      # a slow mirror. On 2026-08-18 it hung here on TWO branches at once,
+      # including `main`, while other runs minutes apart sailed through, so the
+      # stall is environmental rather than anything in the diff under test.
+      #
+      # The per-attempt `timeout` is the load-bearing part: a step-level
+      # `timeout-minutes` would kill the retry loop along with the hung attempt,
+      # which is exactly no better than hanging. Bounding each attempt instead
+      # turns an unbounded stall into a bounded retry, and a genuinely missing
+      # dependency still fails the step rather than being swallowed — the smoke
+      # test that follows would otherwise fail with a far more confusing error.
       - name: Install Chromium system dependencies
-        run: pnpm exec playwright install-deps chromium
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 4m pnpm exec playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::install-deps attempt ${attempt} failed or timed out after 4m; retrying"
+            sleep 15
+          done
+          echo "::error::playwright install-deps chromium failed after 3 attempts"
+          exit 1
 
       # Electron always opens a real window; there is no headless mode for the
       # app shell, so Linux CI needs a virtual framebuffer.


### PR DESCRIPTION
## What happened

On 2026-08-18 the electron job's `Install Chromium system dependencies` step hung on **two branches at once** — `main` (the #1308 merge commit) and #1309, whose entire diff is two `type` keywords:

```
✓ Build main, preload and renderer
* Install Chromium system dependencies   ← both stuck here, 30–50 min
```

## What the run log showed (measured, not inferred)

The first cut of this PR bounded the hang, failed in 5m52s instead of hours, and **its own failure log settled the design**:

1. **26 of the shared libraries are already on the `ubuntu-24.04` image** (`already the newest version`). The only **NEW** packages are **nine font packages, 21.1 MB** — `fonts-freefont-ttf`, `fonts-ipafont-gothic`, `xfonts-cyrillic` … Electron links against none of them. The stall is in that font download.
2. **The retry loop was decoration.** `timeout` kills the playwright process, but the `apt-get` it launched under `sudo` survives as an orphan still holding `/var/lib/dpkg/lock-frontend`. Attempt 1 timed out mid-download; attempts 2 and 3 then died in ~1s each on `held by process 2962 (apt-get)`.

## The fix

**1. `timeout-minutes` on both PR-gating jobs** — electron 20, ci 15 (healthy runs ~6 min and ~2 min). No TMX workflow had a timeout, so a hung job inherited GitHub's **360-minute** default; one run sat 49 minutes with nearly six hours still to go, presenting as a slow build rather than a hang.

**2. Per-attempt `timeout` + dpkg-lock reclaim between attempts.** The per-attempt bound is load-bearing: a step-level `timeout-minutes` would kill the *retry loop* along with the hung attempt. The lock reclaim (kill the orphaned `apt-get`, clear the lock files, `dpkg --configure -a`) is what makes a retry able to accomplish anything at all.

**3. The step is now advisory, not a gate.** Failing the build because a font mirror stalled blocks every PR for something the desktop app does not need. The **smoke test is the real assertion** — if a library Electron genuinely links against ever leaves the image, it fails there with a loader error, and these warnings sit directly above it in the log.

Point 3 is the **opposite** of what the first commit argued ("a genuinely missing dependency still fails the step rather than being swallowed"). I changed it because the log showed the premise was wrong: nothing Electron needs was being installed.

`ci.yml` is included because it is the same defect from the same investigation and it is the **required** check — a hang there blocks merging outright.

## Verification

The loop was extracted from the shipped `run:` block (not retyped) and driven against stubs, before and after the rewrite:

| case | expected | result |
|---|---|---|
| succeeds first try | exit 0, no retries | ✅ |
| fails twice, then succeeds | exit 0 on attempt 3 | ✅ |
| always fails | advisory: warnings + **exit 0** | ✅ 7 warnings, exit 0 |
| hangs every time (first cut) | bounded attempts | ✅ **7s, not 180s** |

The hang case is the one that matters, and my **first attempt at it proved nothing** — macOS has no `timeout`, so the loop failed with `command not found` and still exited 1, which looks like a pass. Re-ran with a `timeout` shim on `PATH` so the bounding was actually exercised.

Both workflows re-parsed after each edit to confirm the `run:` block and timeouts land where intended.

## Note

The two hung runs from earlier were cancelled; they had been holding runners for 30–50 minutes.
