### PR TITLE
fix(socket): make lifecycle recovery observable without a debug flag

### DIFF
--- a/src/services/messaging/connectionLifecycle.test.ts
+++ b/src/services/messaging/connectionLifecycle.test.ts
@@ -218,3 +218,58 @@ describe('connectionLifecycle', () => {
     });
   });
 });
+
+/**
+ * Observability of the recovery itself.
+ *
+ * Chrome logs "Page entered Back-Forward Cache" whenever it freezes a page, whether or not recovery
+ * later works — so the console looks identical in both cases. That ambiguity caused #1296 to be
+ * reported as broken on 8.19.0 when it was in fact working.
+ *
+ * `socketLog` could not settle it: it is the only debug flag with no setter in `env.ts`, so every
+ * `slog()` call is unreachable in a deployed build. Whether recovery ran must therefore be observable
+ * WITHOUT a flag — note this suite mocks `socketLog: false`, which is also the production value.
+ */
+const RECOVERY_LINE = '[lifecycle] recovery after';
+
+describe('recovery is observable without a debug flag', () => {
+  it('logs when a reconnect was actually initiated, with socketLog false', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    ensureConnected.mockReturnValueOnce(true);
+    ensureRelayConnected.mockReturnValueOnce(false);
+
+    recoverConnections('pageshow(persisted)');
+
+    const lines = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines.some((line) => line.includes(RECOVERY_LINE))).toEqual(true);
+    logSpy.mockRestore();
+  });
+
+  it('stays silent when nothing needed reconnecting — a signal, not a trace', () => {
+    // The line must mean "recovery happened", not "an event fired". A tab switch on a healthy
+    // connection must not print anything, or the signal becomes noise and gets ignored.
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    ensureConnected.mockReturnValueOnce(false);
+    ensureRelayConnected.mockReturnValueOnce(false);
+
+    recoverConnections('visibilitychange(visible)');
+
+    const lines = logSpy.mock.calls.map((call) => String(call[0]));
+    expect(lines.some((line) => line.includes(RECOVERY_LINE))).toEqual(false);
+    logSpy.mockRestore();
+  });
+
+  it('reports WHICH transport recovered, so a dead relay is not masked by a live socket', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    ensureConnected.mockReturnValueOnce(false);
+    ensureRelayConnected.mockReturnValueOnce(true);
+
+    recoverConnections('online');
+
+    const call = logSpy.mock.calls.find((entry) => String(entry[0]).includes(RECOVERY_LINE));
+    expect(call).toBeDefined();
+    // format args: reason, socket, relay
+    expect(call?.slice(1)).toEqual(['online', false, true]);
+    logSpy.mockRestore();
+  });
+});

--- a/src/services/messaging/connectionLifecycle.ts
+++ b/src/services/messaging/connectionLifecycle.ts
@@ -59,7 +59,16 @@ export function recoverConnections(reason: string): { socket: boolean; relay: bo
   const socket = ensureConnected();
   const relay = ensureRelayConnected();
   if (socket || relay) {
-    slog('[lifecycle] recovery after %s — socket=%s relay=%s', reason, socket, relay);
+    // DELIBERATELY NOT behind `socketLog`. This fires only when a reconnect was actually initiated —
+    // a rare, meaningful event, not a trace — and it is the only way to tell from a deployed build
+    // that recovery ran at all.
+    //
+    // That distinction was not academic: the bfcache messages Chrome logs on freeze
+    // ("Page entered Back-Forward Cache") look identical whether or not recovery works, so the fix
+    // was reported as broken on 8.19.0 when it was in fact working. `socketLog` could not settle it
+    // because it is the one debug flag with no setter in env.ts — every slog() call is unreachable
+    // in a deployed build. Answering "did recovery run?" must not depend on a flag nobody can set.
+    console.log('[lifecycle] recovery after %s — socket=%s relay=%s', reason, socket, relay);
   }
   return { socket, relay };
 }


### PR DESCRIPTION
CA reported the bfcache socket messages still appearing on dev at TMX 8.19.0, having expected #1296 to have fixed it.

## The fix was working — it just could not be seen

| | |
|---|---|
| #1296 (`aadd30eb`) in v8.19.0 | confirmed ancestor of the tag |
| wired at startup | `initialState.ts:179` |
| present in the **served** dev bundle | all three distinctive strings |
| CA on that build | `remoteMutations-djiS09Ss.js` matches the deployed filename exactly |

And the console evidence actually shows recovery **working**: two distinct `sid=` values. A sid is issued by the server on a successful handshake, so two sids means two separate sessions were established.

`Page entered Back-Forward Cache` is Chrome reporting that it **froze the page and closed the socket** — the fix's own doc comment quotes it verbatim as expected output. It is the trigger, not the failure.

## The real defect: the diagnostic cannot be turned on

`socketLog` is **the only debug flag with no setter**. `env.ts` exposes `log`, `renderLog`, `devNotes` and `averages` — not `socketLog`. It defaults to `false` and nothing in the codebase can set it, so **all 55 `slog()` calls across 8 files are dead in any deployed build.**

So "did recovery run?" was unanswerable from a browser, which is why a working fix was reported as broken.

## The change

The recovery line is now unconditional. It is a **signal, not a trace**:

- fires **only** when a reconnect was actually initiated — a tab switch on a healthy connection prints nothing
- reports **which** transport recovered, so a dead relay is not masked by a live socket

Note the test suite mocks `socketLog: false`, which is also the production value — so the new tests assert exactly the deployed condition.

## Falsification

| defect injected | tests failed |
|---|---|
| put it back behind `socketLog` | 2 |
| log on every event, not only on a real reconnect | 2 |

## Verification

- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · prettier clean
- full suite — **1201 passed** (run as `TZ=UTC`, per the repo's `test` script; without it six unrelated `updatedAtFormatter` tests fail on a 4-hour offset)

## Not in this PR

The missing `socketLog` setter, which would revive the other 54 call sites. Recorded as a follow-up — CA chose this option deliberately, as it answers the question permanently with no flag to set.

Prior claim on this surface (`schedule-inspector-2026-08-17`) archived as stale: heartbeat never advanced in 26 h and its work is merged.