### PR TITLE
chore(lint): machine-enforce two coding standards that prose could not hold

### DIFF
--- a/e2e/helpers/dev-bridge.ts
+++ b/e2e/helpers/dev-bridge.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 /**
  * Initialize the dev bridge on a page.

--- a/e2e/helpers/enterScore.ts
+++ b/e2e/helpers/enterScore.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 export interface EnterScoreParams {
   matchUpId: string;

--- a/e2e/helpers/mutation-collector.ts
+++ b/e2e/helpers/mutation-collector.ts
@@ -1,4 +1,4 @@
-import type { Page, ConsoleMessage } from '@playwright/test';
+import { Page, ConsoleMessage } from '@playwright/test';
 
 export interface MutationEntry {
   methods: Array<{ method: string; params: Record<string, unknown> }>;

--- a/e2e/helpers/role-fixtures.ts
+++ b/e2e/helpers/role-fixtures.ts
@@ -1,4 +1,4 @@
-import type { APIRequestContext } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 
 /**
  * Server-side fixtures for the role-gating journey (real login, not token

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 /**
  * Mock tournament profile shape for seeding test data via mocksEngine.

--- a/e2e/journeys/100-venues-edit-venue-and-court.spec.ts
+++ b/e2e/journeys/100-venues-edit-venue-and-court.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_WITH_VENUES } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
+++ b/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { waitForAppReady } from '../helpers/dev-bridge';
 import {
   SERVER,

--- a/e2e/journeys/49-schedule2-grid-swap.spec.ts
+++ b/e2e/journeys/49-schedule2-grid-swap.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/50-schedule2-court-time-order.spec.ts
+++ b/e2e/journeys/50-schedule2-court-time-order.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/54-matchups-abandon-actions.spec.ts
+++ b/e2e/journeys/54-matchups-abandon-actions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament } from '../helpers/seed';

--- a/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
+++ b/e2e/journeys/55-schedule2-strip-preserve-scheduledtime.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
+++ b/e2e/journeys/56-schedule2-view-draw-focus.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/57-matchups-calledat-column.spec.ts
+++ b/e2e/journeys/57-matchups-calledat-column.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { TournamentPage } from '../pages/TournamentPage';
 

--- a/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
+++ b/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { waitForAppReady } from '../helpers/dev-bridge';
 import {
   SERVER,

--- a/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
+++ b/e2e/journeys/60-schedule-bulk-save-discard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { todayLocal } from '../helpers/dates';

--- a/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
+++ b/e2e/journeys/61-schedule-autocall-due-gating.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, loginAsProviderMember, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { todayLocal } from '../helpers/dates';

--- a/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
+++ b/e2e/journeys/63-schedule-clear-day-keep-completed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { todayLocal } from '../helpers/dates';

--- a/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
+++ b/e2e/journeys/64-scheduling-cross-tournament-cache.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/66-score-entry-advancement.spec.ts
+++ b/e2e/journeys/66-score-entry-advancement.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_DRAW_GENERATED } from '../helpers/seed';
 import { enterScore } from '../helpers/enterScore';

--- a/e2e/journeys/69-round-robin-standings.spec.ts
+++ b/e2e/journeys/69-round-robin-standings.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_ROUND_ROBIN } from '../helpers/seed';
 import { enterScore } from '../helpers/enterScore';

--- a/e2e/journeys/72-registrations-nav-visibility.spec.ts
+++ b/e2e/journeys/72-registrations-nav-visibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge } from '../helpers/dev-bridge';
 import { SERVER, signInSuperAdmin, SUPERADMIN_EMAIL, SUPERADMIN_PASSWORD } from '../helpers/role-fixtures';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/74-participants-signin-delete.spec.ts
+++ b/e2e/journeys/74-participants-signin-delete.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';

--- a/e2e/journeys/75-venues-add-venue.spec.ts
+++ b/e2e/journeys/75-venues-add-venue.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament, PROFILE_DRAW_GENERATED } from '../helpers/seed';

--- a/e2e/journeys/77-schedule-resolve-conflicts.spec.ts
+++ b/e2e/journeys/77-schedule-resolve-conflicts.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
+++ b/e2e/journeys/86-shared-facility-reserved-cells.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady, seedSuperAdminTokenInitScript } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/87-draw-minimap-toggle-round-change.spec.ts
+++ b/e2e/journeys/87-draw-minimap-toggle-round-change.spec.ts
@@ -21,7 +21,7 @@
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, MockProfile } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { S } from '../helpers/selectors';
 
 // drawSize 32 = 5 rounds (R32, R16, QF, SF, F) — the minimap eligibility floor

--- a/e2e/journeys/91-participants-edit-participant.spec.ts
+++ b/e2e/journeys/91-participants-edit-participant.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
 import { createMutationCollector } from '../helpers/mutation-collector';

--- a/e2e/journeys/92-venues-add-from-registry.spec.ts
+++ b/e2e/journeys/92-venues-add-from-registry.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';

--- a/e2e/journeys/94-official-picker-conflict-states.spec.ts
+++ b/e2e/journeys/94-official-picker-conflict-states.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/95-group-participant-role.spec.ts
+++ b/e2e/journeys/95-group-participant-role.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { createMutationCollector } from '../helpers/mutation-collector';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/96-schedule-locks.spec.ts
+++ b/e2e/journeys/96-schedule-locks.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { todayLocal } from '../helpers/dates';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/journeys/99-venues-table-refresh-on-add.spec.ts
+++ b/e2e/journeys/99-venues-table-refresh-on-add.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
 import { TournamentPage } from '../pages/TournamentPage';

--- a/e2e/pages/AuthFlow.ts
+++ b/e2e/pages/AuthFlow.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { waitForAppReady } from '../helpers/dev-bridge';
 
 /**

--- a/e2e/pages/CalendarPage.ts
+++ b/e2e/pages/CalendarPage.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { S } from '../helpers/selectors';
 
 /**

--- a/e2e/pages/FormatWizardModal.ts
+++ b/e2e/pages/FormatWizardModal.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { S } from '../helpers/selectors';
 
 /**

--- a/e2e/pages/TournamentPage.ts
+++ b/e2e/pages/TournamentPage.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { S } from '../helpers/selectors';
 
 /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,28 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+
+      // ── CourtHive coding standards, machine-enforced ────────────────────
+      // Prose in Mentat/standards/coding-standards.md drifts because lint,
+      // types AND prettier all pass while the code violates it. Three PRs on
+      // 2026-08-18 shipped such deviations; one merged before review caught it.
+      //
+      // Never `import type` — plain `import` covers types and values. tsconfig
+      // sets isolatedModules WITHOUT verbatimModuleSyntax, so types still
+      // elide. `disallowTypeAnnotations: false` keeps inline `import('...')`
+      // annotations available as cycle-breakers.
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { prefer: 'no-type-imports', disallowTypeAnnotations: false },
+      ],
+      // DOM data attributes are read via `.dataset`, never `.getAttribute`.
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "CallExpression[callee.property.name='getAttribute'][arguments.0.value=/^data-/]",
+          message: 'Use .dataset.propName instead of .getAttribute("data-*") — Mentat coding standards.',
+        },
+      ],
       'no-unused-expressions': 'off',
       'no-useless-assignment': 'warn',
       'preserve-caught-error': 'off',

--- a/src/components/drawers/addDraw/getDrawTypeOptions.ts
+++ b/src/components/drawers/addDraw/getDrawTypeOptions.ts
@@ -12,7 +12,7 @@ import { t } from 'i18n';
 
 // constants and types
 import { DRAW_MATIC, TOPOLOGY_TEMPLATE_PREFIX } from 'constants/tmxConstants';
-import type { TopologyTemplate } from 'courthive-components';
+import { TopologyTemplate } from 'courthive-components';
 
 const {
   ADAPTIVE,

--- a/src/components/drawers/addDraw/roundProfileEditor.stories.ts
+++ b/src/components/drawers/addDraw/roundProfileEditor.stories.ts
@@ -1,5 +1,5 @@
-import { mountRoundProfileEditor, type RoundProfileEditorController } from './roundProfileEditor';
-import type { Meta, StoryObj } from '@storybook/html-vite';
+import { mountRoundProfileEditor, RoundProfileEditorController } from './roundProfileEditor';
+import { Meta, StoryObj } from '@storybook/html-vite';
 
 type StoryArgs = {
   drawSize: number;

--- a/src/components/drawers/addDraw/submitDrawParams.ts
+++ b/src/components/drawers/addDraw/submitDrawParams.ts
@@ -3,7 +3,7 @@
  * Handles draw creation, qualifying structures, and tie format configuration.
  */
 import { editTieFormat } from 'components/overlays/editTieFormat.js/editTieFormat';
-import type { RoundProfileEditorController } from './roundProfileEditor';
+import { RoundProfileEditorController } from './roundProfileEditor';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';

--- a/src/components/drawers/addDraw/topologyTemplates.ts
+++ b/src/components/drawers/addDraw/topologyTemplates.ts
@@ -8,7 +8,7 @@ import { tmxToast } from 'services/notifications/tmxToast';
 
 import { ADD_TOURNAMENT_EXTENSION } from 'constants/mutationConstants';
 
-import type { TopologyState, TopologyTemplate } from 'courthive-components';
+import { TopologyState, TopologyTemplate } from 'courthive-components';
 
 const TopologyTemplates = 'topologyTemplates';
 

--- a/src/components/drawers/editTournamentDrawer.ts
+++ b/src/components/drawers/editTournamentDrawer.ts
@@ -18,7 +18,7 @@ import { providerConfig } from 'config/providerConfig';
 import { context } from 'services/context';
 import { t, i18next } from 'i18n';
 
-import type { AllowedTierSystem } from '@courthive/provider-config';
+import { AllowedTierSystem } from '@courthive/provider-config';
 
 import { RIGHT } from 'constants/tmxConstants';
 import {

--- a/src/components/modals/chatMonitorModal.ts
+++ b/src/components/modals/chatMonitorModal.ts
@@ -14,7 +14,7 @@ import {
   onAdminChatUpdate,
   getAdminChatMessages,
   sendAdminReply,
-  type AdminChatMessage,
+  AdminChatMessage,
 } from 'services/chat/adminChatService';
 
 const PANEL_ID = 'chatMonitorPanel';

--- a/src/components/modals/crowdTrackersModal.test.ts
+++ b/src/components/modals/crowdTrackersModal.test.ts
@@ -4,7 +4,7 @@
  * happy-dom is explicitly NOT proposed per feedback_one_dom_test_layer_per_ecosystem.md.
  */
 
-import type { CrowdScoringSession } from 'services/crowd/scoreRelayClient';
+import { CrowdScoringSession } from 'services/crowd/scoreRelayClient';
 import { describe, expect, it } from 'vitest';
 import {
   buildSecondaryLine,

--- a/src/components/modals/crowdTrackersModal.ts
+++ b/src/components/modals/crowdTrackersModal.ts
@@ -17,7 +17,7 @@ import {
   demoteSession as apiDemoteSession,
   getSessionsByMatchUpId,
   promoteSession as apiPromoteSession,
-  type CrowdScoringSession,
+  CrowdScoringSession,
 } from 'services/crowd/scoreRelayClient';
 import {
   buildSecondaryLine,

--- a/src/components/modals/crowdTrackersModalLogic.ts
+++ b/src/components/modals/crowdTrackersModalLogic.ts
@@ -4,8 +4,8 @@
  * courthive-components, which touches `document` at module load).
  */
 
-import { classifyScorer, type ScorerClassification } from 'services/crowd/classifyScorer';
-import type { CrowdScoringSession } from 'services/crowd/scoreRelayClient';
+import { classifyScorer, ScorerClassification } from 'services/crowd/classifyScorer';
+import { CrowdScoringSession } from 'services/crowd/scoreRelayClient';
 import { t } from 'i18n';
 
 export interface SessionScorerInfo {

--- a/src/components/modals/importParticipantsView.ts
+++ b/src/components/modals/importParticipantsView.ts
@@ -32,7 +32,7 @@ import { t } from 'i18n';
 import 'styles/importParticipants.css';
 
 // constants and types
-import type { ColumnMapping } from 'services/import/autoMapColumns';
+import { ColumnMapping } from 'services/import/autoMapColumns';
 import {
   RATING_SYNONYMS,
   TARGET_FIELD_GROUPS,

--- a/src/components/modals/luckyLoserSelection.stories.ts
+++ b/src/components/modals/luckyLoserSelection.stories.ts
@@ -10,7 +10,7 @@
  * UX is what we're demoing, not the persistence.
  */
 import { mocksEngine, drawDefinitionConstants } from 'tods-competition-factory';
-import type { Meta, StoryObj } from '@storybook/html-vite';
+import { Meta, StoryObj } from '@storybook/html-vite';
 
 import { mountRoundProfileEditor } from '../drawers/addDraw/roundProfileEditor';
 import { luckyLoserSelection } from './luckyLoserSelection';

--- a/src/components/modals/managePracticeRegistrationsModal.ts
+++ b/src/components/modals/managePracticeRegistrationsModal.ts
@@ -18,7 +18,7 @@ import {
   formatBookingHeader,
   formatRegistrationLabel,
   filterParticipantsForRegistration,
-  type BookingResolution,
+  BookingResolution,
 } from './managePracticeRegistrationsModal.logic';
 
 import { ADD_PRACTICE_REGISTRATION, REMOVE_PRACTICE_REGISTRATION } from 'constants/mutationConstants';

--- a/src/components/modals/printMatchCards.ts
+++ b/src/components/modals/printMatchCards.ts
@@ -4,7 +4,7 @@
 import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
 import { tournamentEngine } from 'services/factory/engine';
 import { generateMatchCardPDF } from 'pdf-factory';
-import type { MatchCardData } from 'pdf-factory';
+import { MatchCardData } from 'pdf-factory';
 
 interface PrintMatchCardsParams {
   matchUpIds: string[];

--- a/src/components/modals/printSchedule.ts
+++ b/src/components/modals/printSchedule.ts
@@ -6,7 +6,7 @@
  * resolved from provider defaults + tournament overrides + modal-runtime
  * tweaks. See Mentat/planning/PRINT_DISPATCHER_SCHEDULE_BRANCH.md.
  */
-import type { PrintCompositionConfig as PrintComposition } from 'courthive-components';
+import { PrintCompositionConfig as PrintComposition } from 'courthive-components';
 import { executePrint, resolveCompositionConfig } from 'pdf-factory';
 import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
 import { competitionEngine } from 'services/factory/engine';

--- a/src/components/modals/teamProfileModal.ts
+++ b/src/components/modals/teamProfileModal.ts
@@ -14,7 +14,7 @@
  * the existing `editGroupingParticipant` rename form and the per-person
  * `editPlayer` page; both remain reachable via the popover.
  */
-import { jerseySorter, splitMembership, type Member, type SplitMembership } from './teamProfileLogic';
+import { jerseySorter, splitMembership, Member, SplitMembership } from './teamProfileLogic';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { buildTeamCard, cModal } from 'courthive-components';
 import { tournamentEngine } from 'services/factory/engine';

--- a/src/components/popovers/courtActions.ts
+++ b/src/components/popovers/courtActions.ts
@@ -2,7 +2,7 @@
  * Court actions popover with edit option.
  * Shows tipster menu for court management actions from table rows.
  */
-import { editCourt, type CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
+import { editCourt, CourtEditResult } from 'pages/tournament/tabs/venuesTab/editCourt';
 import { competitionEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 

--- a/src/components/popovers/matchUpActions.ts
+++ b/src/components/popovers/matchUpActions.ts
@@ -11,7 +11,7 @@ import {
   isScheduleLocked,
 } from 'pages/tournament/tabs/scheduleViews/scheduleLocks';
 import { setMatchUpSchedule } from 'components/tables/matchUpsTable/setMatchUpSchedule';
-import type { CandidateConflicts } from 'services/officiating/officialConflicts';
+import { CandidateConflicts } from 'services/officiating/officialConflicts';
 import { openCrowdTrackersModal } from 'components/modals/crowdTrackersModal';
 import { getScheduleDateRange } from 'pages/tournament/tabs/scheduleUtils';
 import { getActiveSessionCount } from 'services/crowd/crowdActivityIndex';

--- a/src/components/popovers/providerSwitcher.ts
+++ b/src/components/popovers/providerSwitcher.ts
@@ -27,7 +27,7 @@ import {
 
 import { SUPER_ADMIN, TMX_TOURNAMENTS } from 'constants/tmxConstants';
 
-import type { ProviderValue } from 'types/tmx';
+import { ProviderValue } from 'types/tmx';
 
 type OpenProviderSwitcherParams = {
   target: HTMLElement;

--- a/src/components/popovers/venueActions.ts
+++ b/src/components/popovers/venueActions.ts
@@ -2,7 +2,7 @@
  * Venue actions popover with edit option.
  * Shows tipster menu for venue management actions from table rows.
  */
-import { editVenue, type VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
+import { editVenue, VenueEditResult } from 'pages/tournament/tabs/venuesTab/editVenue';
 import { tournamentEngine } from 'services/factory/engine';
 import { tipster } from 'components/popovers/tipster';
 

--- a/src/components/schedule/scheduleDateSelectorLogic.test.ts
+++ b/src/components/schedule/scheduleDateSelectorLogic.test.ts
@@ -12,7 +12,7 @@ import {
   isPublishedForDate,
   publishedDotHtml,
 } from './scheduleDateSelectorLogic';
-import type { ScheduleDate } from 'courthive-components';
+import { ScheduleDate } from 'courthive-components';
 import { describe, expect, it } from 'vitest';
 
 // 2026-07-15 is a Wednesday.

--- a/src/components/tables/common/filters/eventFilter.ts
+++ b/src/components/tables/common/filters/eventFilter.ts
@@ -1,5 +1,5 @@
 import { tournamentEngine } from 'services/factory/engine';
-import type { Event } from 'tods-competition-factory';
+import { Event } from 'tods-competition-factory';
 import { context } from 'services/context';
 import { t } from 'i18n';
 

--- a/src/components/tables/eventsTable/unified/createUnifiedEntriesPanel.ts
+++ b/src/components/tables/eventsTable/unified/createUnifiedEntriesPanel.ts
@@ -19,7 +19,7 @@ import { addDraw } from 'components/drawers/addDraw/addDraw';
 import { tournamentEngine } from 'services/factory/engine';
 import { getUnifiedColumns } from './unifiedColumns';
 import { pairFromUnified } from './pairFromUnified';
-import type { SortState } from './segmentSorter';
+import { SortState } from './segmentSorter';
 import { isFunction } from 'functions/typeOf';
 import { context } from 'services/context';
 

--- a/src/components/tables/eventsTable/unified/unifiedColumns.ts
+++ b/src/components/tables/eventsTable/unified/unifiedColumns.ts
@@ -16,7 +16,7 @@ import { navigateToEvent } from '../../common/navigateToEvent';
 import { tournamentEngine } from 'services/factory/engine';
 import { isSeedingEnabled } from '../seeding/seedingState';
 import { headerMenu } from '../../common/headerMenu';
-import type { SortState } from './segmentSorter';
+import { SortState } from './segmentSorter';
 import { context } from 'services/context';
 import { t } from 'i18n';
 

--- a/src/components/tables/matchUpsTable/createMatchUpsTable.ts
+++ b/src/components/tables/matchUpsTable/createMatchUpsTable.ts
@@ -3,7 +3,7 @@
  * Dynamically calculates predictive accuracy for all rating types present in participant data.
  */
 import { refreshReconciliationIndex } from 'services/crowd/delegatedReconciliation';
-import { startCrowdPoller, type CrowdPoller } from 'services/crowd/crowdPoller';
+import { startCrowdPoller, CrowdPoller } from 'services/crowd/crowdPoller';
 import { subscribeCrowdActivity } from 'services/crowd/crowdActivityIndex';
 import { mapMatchUp } from 'pages/tournament/tabs/matchUpsTab/mapMatchUp';
 import { headerSortElement } from '../common/sorters/headerSortElement';

--- a/src/components/tables/ratingsTable/createRatingsTable.ts
+++ b/src/components/tables/ratingsTable/createRatingsTable.ts
@@ -13,7 +13,7 @@ import { preferencesConfig } from 'config/preferencesConfig';
 import { tournamentEngine } from 'services/factory/engine';
 import { displayConfig } from 'config/displayConfig';
 import { scalesMap } from 'config/scalesConfig';
-import tippy, { type Instance } from 'tippy.js';
+import tippy, { Instance } from 'tippy.js';
 
 import { DRAWS_VIEW } from 'constants/tmxConstants';
 

--- a/src/config/providerConfig.ts
+++ b/src/config/providerConfig.ts
@@ -11,7 +11,7 @@
  *   providerConfig.isAllowed('canCreateCompetitors')        // boolean
  */
 
-import type { ProviderBranding, ProviderConfigData, ProviderPermissions } from '@courthive/provider-config';
+import { ProviderBranding, ProviderConfigData, ProviderPermissions } from '@courthive/provider-config';
 import { context } from 'services/context';
 
 export type { ProviderBranding, ProviderConfigData, ProviderPermissions };

--- a/src/functions/logMutationError.ts
+++ b/src/functions/logMutationError.ts
@@ -5,7 +5,7 @@
 import { tmxToast } from 'services/notifications/tmxToast';
 import { t } from 'i18n';
 
-import type { ExecutionResult } from 'types/services';
+import { ExecutionResult } from 'types/services';
 
 export function logMutationError(
   context: string,

--- a/src/initialState.ts
+++ b/src/initialState.ts
@@ -77,7 +77,7 @@ import 'styles/fa.min.css';
 import 'styles/icons.css';
 import 'styles/tmx.css';
 
-import type { TMXSettings } from 'services/settings/settingsStorage';
+import { TMXSettings } from 'services/settings/settingsStorage';
 import { providerConfig } from 'config/providerConfig';
 
 /**

--- a/src/pages/policies/policyBridge.ts
+++ b/src/pages/policies/policyBridge.ts
@@ -2,7 +2,7 @@ import { fixtures, policyConstants } from 'tods-competition-factory';
 import { POLICY_SCHEDULING } from 'assets/policies/schedulingPolicy';
 import { POLICY_SCORING } from 'assets/policies/scoringPolicy';
 import { POLICY_SEEDING } from 'assets/policies/seedingPolicy';
-import type { PolicyCatalogItem } from 'courthive-components';
+import { PolicyCatalogItem } from 'courthive-components';
 import { tmx2db } from 'services/storage/tmx2db';
 
 const { POLICY_TYPE_SCHEDULING, POLICY_TYPE_SCORING, POLICY_TYPE_SEEDING, POLICY_TYPE_RANKING_POINTS } =

--- a/src/pages/policies/renderPoliciesPage.ts
+++ b/src/pages/policies/renderPoliciesPage.ts
@@ -4,7 +4,7 @@ import { homeNavigation } from 'homeNavigation';
 import { context } from 'services/context';
 import { TMX_POLICIES, POLICIES } from 'constants/tmxConstants';
 import { createPolicyCatalog } from 'courthive-components';
-import type { PolicyCatalogControl } from 'courthive-components';
+import { PolicyCatalogControl } from 'courthive-components';
 import { getBuiltinPolicies, loadUserPolicies, saveUserPolicy } from './policyBridge';
 import './policyCatalog.css';
 

--- a/src/pages/policies/renderPolicyCatalogPage.ts
+++ b/src/pages/policies/renderPolicyCatalogPage.ts
@@ -13,7 +13,7 @@
  * Routed at `/policies/catalog`. Linked from /policies via a pill at
  * the top of the authoring page.
  */
-import type { PolicyCatalogItem } from 'courthive-components';
+import { PolicyCatalogItem } from 'courthive-components';
 import { showTMXpolicies } from 'services/transitions/screenSlaver';
 import './policyCatalog.css';
 import { removeAllChildNodes } from 'services/dom/transformers';

--- a/src/pages/templates/compositionBridge.ts
+++ b/src/pages/templates/compositionBridge.ts
@@ -2,7 +2,7 @@ import { clearUserCompositionRuntimeCache } from 'services/compositions/resolveC
 import { compositions } from 'courthive-components';
 import { tmx2db } from 'services/storage/tmx2db';
 
-import type { SavedComposition } from 'courthive-components';
+import { SavedComposition } from 'courthive-components';
 
 export interface CompositionCatalogItem {
   id: string;

--- a/src/pages/templates/renderTemplatesPage.ts
+++ b/src/pages/templates/renderTemplatesPage.ts
@@ -17,10 +17,10 @@ import {
 } from './compositionBridge';
 
 // types
-import type { TopologyState, SavedComposition } from 'courthive-components';
-import type { CompositionCatalogItem } from './compositionBridge';
-import type { TieFormatCatalogItem } from './tieFormatBridge';
-import type { TopologyCatalogItem } from './topologyBridge';
+import { TopologyState, SavedComposition } from 'courthive-components';
+import { CompositionCatalogItem } from './compositionBridge';
+import { TieFormatCatalogItem } from './tieFormatBridge';
+import { TopologyCatalogItem } from './topologyBridge';
 
 // constants
 import { TMX_TEMPLATES, TEMPLATES } from 'constants/tmxConstants';

--- a/src/pages/templates/topologyBridge.ts
+++ b/src/pages/templates/topologyBridge.ts
@@ -1,7 +1,7 @@
 import { standardTemplates } from 'courthive-components';
 import { tmx2db } from 'services/storage/tmx2db';
 
-import type { TopologyTemplate } from 'courthive-components';
+import { TopologyTemplate } from 'courthive-components';
 
 export interface TopologyCatalogItem {
   id: string;

--- a/src/pages/tournament/tabs/eventsTab/eventsTab.ts
+++ b/src/pages/tournament/tabs/eventsTab/eventsTab.ts
@@ -14,10 +14,10 @@ import { readDrawsViewMode, writeDrawsViewMode } from './renderDraws/drawsViewMo
 import { createStatsTable } from 'components/tables/statsTable/createStatsTable';
 import { openDisplayOptionsPopover } from './renderDraws/displayOptionsPopover';
 import { renderEventTabsBar, renderNoDrawsPlaceholder } from './eventTabsBar';
-import type { DrawCardDisplayMode } from './renderDraws/drawCardDisplayMode';
+import { DrawCardDisplayMode } from './renderDraws/drawCardDisplayMode';
 import { buildViewToggleElement } from 'components/tables/common/viewToggle';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
-import type { VizDataAvailability } from './renderDraws/drawCardVizGating';
+import { VizDataAvailability } from './renderDraws/drawCardVizGating';
 import { setEventView } from 'components/tables/eventsTable/setEventView';
 import { renderEventSelector, hideEventSelector } from './eventSelector';
 import { addFlights } from 'components/modals/addFlights/addFlights';

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
@@ -17,7 +17,7 @@ import {
 
 const { ratingsParameters } = fixtures;
 
-import type { DrawCardDisplayMode } from './drawCardDisplayMode';
+import { DrawCardDisplayMode } from './drawCardDisplayMode';
 
 const HISTOGRAM_HEIGHT = 80;
 const SUNBURST_SIZE = 240;

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/displayOptionsPopover.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/displayOptionsPopover.ts
@@ -6,7 +6,7 @@
 import tippy, { Instance } from 'tippy.js';
 
 import { buildDisplayModeOptions, VizDataAvailability } from './drawCardVizGating';
-import type { DrawCardDisplayMode } from './drawCardDisplayMode';
+import { DrawCardDisplayMode } from './drawCardDisplayMode';
 
 let tip: Instance | undefined;
 

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/drawCardVizGating.ts
@@ -10,7 +10,7 @@
  * once we have real-world telemetry. Until then a single cap is enough.
  */
 
-import type { DrawCardDisplayMode } from './drawCardDisplayMode';
+import { DrawCardDisplayMode } from './drawCardDisplayMode';
 
 export const HARD_CAP = 15;
 export const SUNBURST_CAP = 6;

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/hydrateTopology.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/hydrateTopology.ts
@@ -2,7 +2,7 @@
  * Hydrate Topology — Converts existing drawDefinition (structures + links) back to TopologyState.
  * Used for editing existing draws in the topology builder.
  */
-import type { TopologyState, TopologyNode, TopologyEdge } from 'courthive-components';
+import { TopologyState, TopologyNode, TopologyEdge } from 'courthive-components';
 
 const STAGE_MAP: Record<string, TopologyNode['stage']> = {
   MAIN: 'MAIN',

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
@@ -179,7 +179,7 @@ function applyMorphdomUpdate(
       getNodeKey(node: any) {
         if (isParticipantEl(node)) return undefined;
 
-        const matchUpId = node.getAttribute?.('data-matchup-id');
+        const matchUpId = (node as HTMLElement).dataset?.matchupId;
         if (matchUpId) return matchUpId;
 
         const id = node.getAttribute?.('id');

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/voluntaryConsolationPanel.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/voluntaryConsolationPanel.ts
@@ -6,7 +6,7 @@
  * Flow: TD selects participants → OVERLAY sets entry status (Accepted/Alternate/Clear)
  * → chips appear in table → Generate when ≥2 accepted.
  */
-import type { DrawTypeUnion } from 'tods-competition-factory';
+import { DrawTypeUnion } from 'tods-competition-factory';
 import {
   drawDefinitionConstants,
   entryStatusConstants,

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -16,7 +16,7 @@ import { tmxToast } from 'services/notifications/tmxToast';
 import { downloadUTRmatches } from 'services/export/UTR';
 import { downloadJSON } from 'services/export/download';
 import { openNotesEditor } from './notesEditorModal';
-import type { StructureInfo } from './dashboardData';
+import { StructureInfo } from './dashboardData';
 import { success } from 'components/notices/success';
 import { failure } from 'components/notices/failure';
 import { featureFlags } from 'config/featureFlags';

--- a/src/pages/tournament/tabs/registrationsTab/buildRegistrationStatusFilter.ts
+++ b/src/pages/tournament/tabs/registrationsTab/buildRegistrationStatusFilter.ts
@@ -3,7 +3,7 @@
  * dropdown value chosen by the director. Extracted so it can be unit
  * tested without standing up the DOM.
  */
-import type { RegistrationStatus } from 'services/apis/registrationsApi';
+import { RegistrationStatus } from 'services/apis/registrationsApi';
 
 export type FilterValue = 'all' | 'open' | RegistrationStatus;
 

--- a/src/pages/tournament/tabs/registrationsTab/collapseRegistrationPairs.ts
+++ b/src/pages/tournament/tabs/registrationsTab/collapseRegistrationPairs.ts
@@ -1,4 +1,4 @@
-import type { RegistrationEntry } from 'services/apis/registrationsApi';
+import { RegistrationEntry } from 'services/apis/registrationsApi';
 
 /**
  * Collapse doubles registrations into display rows (decision #3): a COMPLETE pair —

--- a/src/pages/tournament/tabs/registrationsTab/createRegistrationsTable.ts
+++ b/src/pages/tournament/tabs/registrationsTab/createRegistrationsTable.ts
@@ -7,7 +7,7 @@
  */
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 
-import type { RegistrationEntry } from 'services/apis/registrationsApi';
+import { RegistrationEntry } from 'services/apis/registrationsApi';
 import { collapseRegistrationPairs } from './collapseRegistrationPairs';
 import { TOURNAMENT_REGISTRATIONS } from 'constants/tmxConstants';
 

--- a/src/pages/tournament/tabs/registrationsTab/renderRegistrationsTab.ts
+++ b/src/pages/tournament/tabs/registrationsTab/renderRegistrationsTab.ts
@@ -11,13 +11,13 @@
 import { tournamentEngine } from 'services/factory/engine';
 import { controlBar } from 'courthive-components';
 
-import { filterEntriesByValue, type FilterValue } from './buildRegistrationStatusFilter';
+import { filterEntriesByValue, FilterValue } from './buildRegistrationStatusFilter';
 import { createRegistrationsTable } from './createRegistrationsTable';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { context } from 'services/context';
 import {
-  type RegistrationEntry,
-  type RegistrationStatus,
+  RegistrationEntry,
+  RegistrationStatus,
   acceptRegistration,
   bulkRegistrationAction,
   getTournamentRegistrations,

--- a/src/pages/tournament/tabs/scheduleViews/autoCallDueMatches.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/autoCallDueMatches.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { computeAutoCalls, type StripColumn } from './autoCallDueMatches';
+import { computeAutoCalls, StripColumn } from './autoCallDueMatches';
 
 // A ready matchUp has two sides with participants; the raw factory cell rides on
 // `payload` (schedule.scheduledTime, sides).

--- a/src/pages/tournament/tabs/scheduleViews/courtTimeOrderIssues.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/courtTimeOrderIssues.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { detectCourtTimeOrderIssues, parseClockMinutes, type TimedMatchUp } from './courtTimeOrderIssues';
+import { detectCourtTimeOrderIssues, parseClockMinutes, TimedMatchUp } from './courtTimeOrderIssues';
 
 const mu = (matchUpId: string, courtId: string, courtOrder: number | string, scheduledTime?: string): TimedMatchUp => ({
   matchUpId,

--- a/src/pages/tournament/tabs/scheduleViews/gridDropMethods.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridDropMethods.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildGridDropMethods, shouldRejectStripDrop, type GridDropPayload } from './gridDropMethods';
+import { buildGridDropMethods, shouldRejectStripDrop, GridDropPayload } from './gridDropMethods';
 import { ADD_MATCHUP_SCHEDULE_ITEMS } from 'constants/mutationConstants';
 
 const DATE = '2026-06-21';

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -20,7 +20,7 @@
  *  - On Discard: factory state reloaded from IndexedDB
  */
 import { readUserMinCourtWidth, writeUserMinCourtWidth } from 'services/schedulePreferences/userMinCourtWidth';
-import { buildGridDropMethods, shouldRejectStripDrop, type GridDropPayload } from './gridDropMethods';
+import { buildGridDropMethods, shouldRejectStripDrop, GridDropPayload } from './gridDropMethods';
 import { isScheduleLocked, lockedInDrop, scheduleLockReason } from './scheduleLocks';
 import { openScheduleLockMenu } from './scheduleLockActions';
 import {
@@ -38,7 +38,7 @@ import {
 import { getActiveRegistrationNamesByCourtId } from './practiceRegistrationStrip';
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { printCourtMatchUpCards } from 'components/modals/printCourtCards';
-import { buildGridActionBar, type GridActionBar } from './gridActionBar';
+import { buildGridActionBar, GridActionBar } from './gridActionBar';
 import {
   getOrderOfPlayPublishState,
   isOrderOfPlayDatePublished,
@@ -55,10 +55,10 @@ import { scheduleConfig } from 'config/scheduleConfig';
 import { tipster } from 'components/popovers/tipster';
 import { tmx2db } from 'services/storage/tmx2db';
 import { scheduleToast } from './scheduleToast';
-import tippy, { type Instance } from 'tippy.js';
+import tippy, { Instance } from 'tippy.js';
 import { context } from 'services/context';
 import { t } from 'i18n';
-import type {
+import {
   SchedulePageConfig,
   SchedulePageControl,
   CatalogMatchUpItem,
@@ -273,7 +273,7 @@ import {
   writeScheduledFilters,
   readInspectorVisible,
   writeInspectorVisible,
-  type SidebarTab,
+  SidebarTab,
 } from './gridViewStorage';
 import { renderReadinessSection } from './inspectorReadiness';
 

--- a/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
@@ -21,7 +21,7 @@
  * paths without dragging in the rest of the schedule grid.
  */
 
-import type { CatalogFilters, MatchUpCatalogGroupBy } from 'courthive-components';
+import { CatalogFilters, MatchUpCatalogGroupBy } from 'courthive-components';
 
 export type SidebarTab = 'unscheduled' | 'scheduled';
 

--- a/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
@@ -20,7 +20,7 @@ import { tournamentEngine } from 'services/factory/engine';
 import { t } from 'i18n';
 
 // constants and types
-import type { ReadinessFinding, ReadinessMatchUp, ReadinessResult, ReadinessTiming } from './matchUpReadiness';
+import { ReadinessFinding, ReadinessMatchUp, ReadinessResult, ReadinessTiming } from './matchUpReadiness';
 
 const FALLBACK_TIMING: ReadinessTiming = { averageMinutes: 90, recoveryMinutes: 0 };
 

--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { analyzeMatchUpReadiness, individualIds, minutesToClock } from './matchUpReadiness';
 
 // constants and types
-import type { ReadinessMatchUp, ReadinessTiming } from './matchUpReadiness';
+import { ReadinessMatchUp, ReadinessTiming } from './matchUpReadiness';
 
 /**
  * Every finding kind is asserted as a PAIR: once where it fires, and once where

--- a/src/pages/tournament/tabs/scheduleViews/profileView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/profileView.ts
@@ -23,14 +23,14 @@ import { scheduleToast } from './scheduleToast';
 import { context } from 'services/context';
 import {
   createSchedulingProfile,
-  type SchedulingProfileConfig,
-  type SchedulingProfileControl,
-  type CatalogRoundItem,
-  type VenueInfo,
-  type SchedulingProfile,
-  type AvailabilityAdapter,
-  type DemandAdapter,
-  type DependencyAdapter,
+  SchedulingProfileConfig,
+  SchedulingProfileControl,
+  CatalogRoundItem,
+  VenueInfo,
+  SchedulingProfile,
+  AvailabilityAdapter,
+  DemandAdapter,
+  DependencyAdapter,
 } from 'courthive-components';
 
 import { COMPETITION_ENGINE, SCHEDULING_TAB } from 'constants/tmxConstants';

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -19,7 +19,7 @@ import { destroyTipster } from 'components/popovers/tipster';
 import { competitionEngine } from 'services/factory/engine';
 import { timePicker } from 'components/modals/timePicker';
 import { Datepicker } from 'vanillajs-datepicker';
-import tippy, { type Instance } from 'tippy.js';
+import tippy, { Instance } from 'tippy.js';
 import { i18next, t } from 'i18n';
 
 // constants

--- a/src/pages/tournament/tabs/scheduleViews/scheduleResultsDrawer.ts
+++ b/src/pages/tournament/tabs/scheduleViews/scheduleResultsDrawer.ts
@@ -17,9 +17,9 @@ import {
   describeOverLimitAttempts,
   describeRecoveryDeferred,
   describeDependencyDeferred,
-  type MatchUpLookup,
-  type ParticipantLookup,
-  type OverLimitAttempt,
+  MatchUpLookup,
+  ParticipantLookup,
+  OverLimitAttempt,
 } from './scheduleResultsDescribe';
 
 const BLOCK_STYLE = 'margin-top: 10px;';

--- a/src/pages/tournament/tabs/schedulingTab/schedulingHeader.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingHeader.ts
@@ -12,7 +12,7 @@ import { buildScheduleDateSelector } from 'components/schedule/scheduleDateSelec
 import { ScheduleDate } from 'courthive-components';
 import { featureFlags } from 'config/featureFlags';
 
-import type { SchedulingMode } from './schedulingTab';
+import { SchedulingMode } from './schedulingTab';
 
 const BORDER_PRIMARY = 'border: 1px solid var(--tmx-border-primary)';
 const BG_PRIMARY = 'background: var(--tmx-bg-primary)';

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -52,7 +52,7 @@ import {
   resolveColumnConflicts,
   DEFAULT_MIN_COURT_GRID_ROWS,
 } from '../scheduleViews/gridView';
-import { renderAvailabilityGrid, type AvailabilityGridInstance } from '../venuesTab/renderAvailabilityGrid';
+import { renderAvailabilityGrid, AvailabilityGridInstance } from '../venuesTab/renderAvailabilityGrid';
 import { invalidateAllScheduleCaches } from '../scheduleViews/schedule2DataCache';
 import {
   readScheduleDisplayConfig,

--- a/src/pages/tournament/tabs/settingsTab/linkedTournaments.ts
+++ b/src/pages/tournament/tabs/settingsTab/linkedTournaments.ts
@@ -7,7 +7,7 @@ import { mutationRequest } from 'services/mutation/mutationRequest';
 import { openModal } from 'components/modals/baseModal/baseModal';
 import { COMPETITION_ENGINE } from 'constants/tmxConstants';
 
-import type { SiblingTournament } from './linkedTournamentsHelpers';
+import { SiblingTournament } from './linkedTournamentsHelpers';
 
 // ─── data access ────────────────────────────────────────────────────────────
 

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -3,7 +3,7 @@ import { persistConfigToStorage, loadSettings, saveSettings } from 'services/set
 import { getCachedFontCatalog, ensurePdfFontReady, PROVIDER_DEFAULT_FONT } from 'services/pdf/pdfFont';
 import { connectSocket, connected, disconnectSocket } from 'services/messaging/socketIo';
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
-import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
+import { preferencesConfig, PreferencesConfig } from 'config/preferencesConfig';
 import { ensureLocaleCurrent, fetchManifest } from 'i18n/runtime-loader';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { getLoginState } from 'services/authentication/loginState';

--- a/src/pages/tournament/tabs/venuesTab/addVenueFromRegistry.ts
+++ b/src/pages/tournament/tabs/venuesTab/addVenueFromRegistry.ts
@@ -16,8 +16,8 @@ import {
   MIN_FACILITY_QUERY,
   fetchRegistryVenue,
   searchFacilities,
-  type FacilityCandidate,
-  type RegistryVenue,
+  FacilityCandidate,
+  RegistryVenue,
 } from 'services/apis/facilitiesApi';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { openModal } from 'components/modals/baseModal/baseModal';

--- a/src/pages/tournament/tabs/venuesTab/mapVenue.ts
+++ b/src/pages/tournament/tabs/venuesTab/mapVenue.ts
@@ -1,4 +1,4 @@
-import type { AvailabilityEngine } from 'tods-competition-factory';
+import { AvailabilityEngine } from 'tods-competition-factory';
 
 function findResourceIdentifier(resources: any[] | undefined, name: string): string | undefined {
   if (!Array.isArray(resources)) return undefined;

--- a/src/pages/tournament/tabs/venuesTab/renderAvailabilityGrid.ts
+++ b/src/pages/tournament/tabs/venuesTab/renderAvailabilityGrid.ts
@@ -3,7 +3,7 @@
  * Creates a AvailabilityGrid from the tournament record and provides save logic
  * that maps engine state back to dateAvailability per court.
  */
-import { createAvailabilityGrid, AvailabilityGrid, type AvailabilityGridLabels } from 'courthive-components';
+import { createAvailabilityGrid, AvailabilityGrid, AvailabilityGridLabels } from 'courthive-components';
 import { openManagePracticeRegistrationsModal } from 'components/modals/managePracticeRegistrationsModal';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tournamentEngine } from 'services/factory/engine';

--- a/src/platform/electron.ts
+++ b/src/platform/electron.ts
@@ -4,7 +4,7 @@
  * Communicates with the main process via the preload-injected `window.electronAPI`.
  * Falls back gracefully if preload bridge is unavailable.
  */
-import type { PlatformAdapter, SaveDialogOptions, OpenDialogOptions } from './types';
+import { PlatformAdapter, SaveDialogOptions, OpenDialogOptions } from './types';
 
 /** Shape of the API exposed by the Electron preload script */
 interface ElectronBridge {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -5,7 +5,7 @@
  * `platform` and uses it without caring which environment is active.
  */
 import { createElectronPlatform } from './electron';
-import type { PlatformAdapter } from './types';
+import { PlatformAdapter } from './types';
 import { createWebPlatform } from './web';
 
 export type { PlatformAdapter, PlatformType, SaveDialogOptions, OpenDialogOptions } from './types';

--- a/src/platform/web.ts
+++ b/src/platform/web.ts
@@ -4,7 +4,7 @@
  * Default implementation — no native capabilities.
  * Server URL resolves from Vite env or window.location.origin.
  */
-import type { PlatformAdapter } from './types';
+import { PlatformAdapter } from './types';
 
 export function createWebPlatform(): PlatformAdapter {
   return {

--- a/src/services/apis/declarationsApi.test.ts
+++ b/src/services/apis/declarationsApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { mapSnapshotToEntry, type RegistrationSnapshot } from './declarationsApi';
+import { mapSnapshotToEntry, RegistrationSnapshot } from './declarationsApi';
 
 const snap: RegistrationSnapshot = {
   declarationId: 'd-1',

--- a/src/services/apis/declarationsApi.ts
+++ b/src/services/apis/declarationsApi.ts
@@ -11,7 +11,7 @@
  */
 import { getJwtTokenStorageKey } from 'config/localStorage';
 
-import type { RegistrationEntry, RegistrationStatus } from './registrationsApi';
+import { RegistrationEntry, RegistrationStatus } from './registrationsApi';
 
 // courthive-declarations REGISTRATION statuses → TMX RegistrationEntry statuses.
 const STATUS_MAP: Record<string, RegistrationStatus> = {

--- a/src/services/apis/servicesApi.ts
+++ b/src/services/apis/servicesApi.ts
@@ -1,6 +1,6 @@
 import { baseApi } from './baseApi';
 
-import type { ProvidersResponse, UsersResponse } from 'types/tmx';
+import { ProvidersResponse, UsersResponse } from 'types/tmx';
 
 export async function requestTournament({ tournamentId, silent }: { tournamentId: string; silent?: boolean }) {
   return await baseApi.post('/factory/fetch', { tournamentId }, silent ? { silenceErrors: true } : undefined);

--- a/src/services/authentication/getUserContext.ts
+++ b/src/services/authentication/getUserContext.ts
@@ -17,7 +17,7 @@
  */
 import { baseApi } from 'services/apis/baseApi';
 
-import type { UserContext } from 'types/tmx';
+import { UserContext } from 'types/tmx';
 
 let cached: UserContext | undefined;
 

--- a/src/services/authentication/isProviderAdmin.test.ts
+++ b/src/services/authentication/isProviderAdmin.test.ts
@@ -8,7 +8,7 @@ import { getLoginState } from 'services/authentication/loginState';
 import { isActiveProviderAdmin } from './isProviderAdmin';
 import { context } from 'services/context';
 
-import type { LoginState } from 'types/tmx';
+import { LoginState } from 'types/tmx';
 
 const mockedGetLoginState = vi.mocked(getLoginState);
 const BOBOCA = 'boboca-id';

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -33,7 +33,7 @@ import { context } from 'services/context';
 import { t } from 'i18n';
 
 // types
-import type { LoginState } from 'types/tmx';
+import { LoginState } from 'types/tmx';
 
 // constants
 import { SUPER_ADMIN, TMX_TOURNAMENTS, NONE } from 'constants/tmxConstants';

--- a/src/services/authentication/validateToken.ts
+++ b/src/services/authentication/validateToken.ts
@@ -3,7 +3,7 @@ import { attemptSilentRefresh, logOut } from './loginState';
 import { setDev } from 'services/setDev';
 import { jwtDecode } from 'jwt-decode';
 
-import type { LoginState } from 'types/tmx';
+import { LoginState } from 'types/tmx';
 
 export function validateToken(token: string | null | undefined): LoginState | undefined {
   if (!token || token === 'undefined') {

--- a/src/services/context.ts
+++ b/src/services/context.ts
@@ -1,6 +1,6 @@
-import type { SchedulePageCatalogState } from 'courthive-components';
+import { SchedulePageCatalogState } from 'courthive-components';
 
-import type { ProviderValue } from 'types/tmx';
+import { ProviderValue } from 'types/tmx';
 
 export const context: {
   matchUpsToBroadcast: any[];

--- a/src/services/crowd/delegatedOutcome.ts
+++ b/src/services/crowd/delegatedOutcome.ts
@@ -14,7 +14,7 @@
  * score strings internally — no caller-side string round-tripping.
  */
 
-import { classifyScorer, type ScorerClassification } from './classifyScorer';
+import { classifyScorer, ScorerClassification } from './classifyScorer';
 
 import { REMOVE_DELEGATED_OUTCOME, SET_DELEGATED_OUTCOME, SET_MATCHUP_STATUS } from 'constants/mutationConstants';
 

--- a/src/services/crowd/delegatedOutcomeFlow.ts
+++ b/src/services/crowd/delegatedOutcomeFlow.ts
@@ -20,9 +20,9 @@ import {
   buildDelegatedOutcome,
   readDelegatedOutcome,
   snapshotToSets,
-  type DelegatedOutcomeScorer,
+  DelegatedOutcomeScorer,
 } from 'services/crowd/delegatedOutcome';
-import { getSessionsByMatchUpId, promoteSession, type CrowdScoringSession } from 'services/crowd/scoreRelayClient';
+import { getSessionsByMatchUpId, promoteSession, CrowdScoringSession } from 'services/crowd/scoreRelayClient';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tournamentEngine } from 'tods-competition-factory';
 import { scoringModal } from 'components/modals/scoringV2';

--- a/src/services/factory/engine.ts
+++ b/src/services/factory/engine.ts
@@ -15,7 +15,7 @@
 import {
   tournamentEngine as untypedTournamentEngine,
   competitionEngine as untypedCompetitionEngine,
-  type FactoryEngineTyped,
+  FactoryEngineTyped,
 } from 'tods-competition-factory';
 
 export const tournamentEngine = untypedTournamentEngine as FactoryEngineTyped;

--- a/src/services/messaging/remoteMutations.ts
+++ b/src/services/messaging/remoteMutations.ts
@@ -24,7 +24,7 @@ import { t } from 'i18n';
 
 // constants and types
 import { SYNC_INDICATOR, TOURNAMENT_ENGINE, DRAWS_VIEW } from 'constants/tmxConstants';
-import type { RemoteMutationPayload } from 'types/services';
+import { RemoteMutationPayload } from 'types/services';
 
 const slog = (...args: any[]) => debugConfig.get().socketLog && console.log(...args);
 

--- a/src/services/messaging/socketIo.ts
+++ b/src/services/messaging/socketIo.ts
@@ -33,7 +33,7 @@ import {
 } from 'services/chat/adminChatService';
 
 // types
-import type { ServerAck } from 'types/services';
+import { ServerAck } from 'types/services';
 
 // constants
 import {

--- a/src/services/mutation/mutationRequest.ts
+++ b/src/services/mutation/mutationRequest.ts
@@ -19,7 +19,7 @@ import dayjs from 'dayjs';
 import { t } from 'i18n';
 
 // types
-import type { MutationMethod, ExecutionResult } from 'types/services';
+import { MutationMethod, ExecutionResult } from 'types/services';
 
 // constants
 import { SUPER_ADMIN, TOURNAMENT_ENGINE } from 'constants/tmxConstants';

--- a/src/services/pdf/export/pdfExport.ts
+++ b/src/services/pdf/export/pdfExport.ts
@@ -4,7 +4,7 @@
  * Provides functions to open, save, or get PDF data from jsPDF documents.
  */
 
-import type jsPDF from 'jspdf';
+import jsPDF from 'jspdf';
 
 /**
  * Open PDF in new browser tab/window

--- a/src/services/pdf/pdfFont.ts
+++ b/src/services/pdf/pdfFont.ts
@@ -16,7 +16,7 @@
  * may front `/fonts/`; the bundled copies remain the self-contained fallback.
  */
 
-import type { FontDefinition } from 'pdf-factory';
+import { FontDefinition } from 'pdf-factory';
 import { setDefaultFont } from 'pdf-factory';
 
 import { loadSettings } from 'services/settings/settingsStorage';

--- a/src/services/provider/providerState.ts
+++ b/src/services/provider/providerState.ts
@@ -17,7 +17,7 @@ import { providerConfig } from 'config/providerConfig';
 import { baseApi } from 'services/apis/baseApi';
 import { context } from 'services/context';
 
-import type { LoginState, ProviderValue } from 'types/tmx';
+import { LoginState, ProviderValue } from 'types/tmx';
 
 import { SUPER_ADMIN, TMX_TOURNAMENTS } from 'constants/tmxConstants';
 

--- a/src/services/publishing/orderOfPlayPublish.test.ts
+++ b/src/services/publishing/orderOfPlayPublish.test.ts
@@ -21,7 +21,7 @@ import {
   buildOrderOfPlayDateToggleMethods,
   getOrderOfPlayPublishState,
   isOrderOfPlayDatePublished,
-  type OrderOfPlayPublishState,
+  OrderOfPlayPublishState,
 } from './orderOfPlayPublish';
 
 const D1 = '2026-07-01';

--- a/src/types/tmx.ts
+++ b/src/types/tmx.ts
@@ -6,7 +6,7 @@
  * - Provider/User records: what the server APIs return
  * - API response wrappers: typed axios response shapes
  */
-import type { Organisation } from 'tods-competition-factory';
+import { Organisation } from 'tods-competition-factory';
 
 // ---------------------------------------------------------------------------
 // Authentication / JWT


### PR DESCRIPTION
Standards a **linter** enforces stay clean on their own. The ones written only in `Mentat/standards/coding-standards.md` drift — because lint, types **and** prettier all pass while the code violates them. Three PRs on 2026-08-18 shipped such deviations and one merged before review caught it.

Completes the set with courthive-components #520 and factory #4671.

## Two rules, no new dependencies

| rule | violations | fix |
|---|---|---|
| `consistent-type-imports` (`prefer: 'no-type-imports'`) | **145** | auto-fixed |
| `.getAttribute('data-*')` → `.dataset` | **3** | by hand |

`isolatedModules` is set **without** `verbatimModuleSyntax`, so plain imports still elide types. `disallowTypeAnnotations: false` keeps inline `import('...')` annotations available as cycle-breakers.

One `.getAttribute` was the optional-call form `node.getAttribute?.('data-matchup-id')` — a plain grep misses it; the AST selector caught it. That is the argument for a lint rule over search-and-replace.

## A `let result: any =` rule was drafted and removed before merge

The standard reads: *"In test files: `let result: any =` **for engine/mutation call results** (SonarQube compliance)"*. Both the qualifier and the parenthetical matter. The pattern exists so `result` can be **reassigned** across successive engine calls — where a test calls once and never reassigns, `const` is correct.

Measured in factory before backing it out: of **115 files** carrying `const result: any`, **96 never reassign it**.

`prefer-const` being off is what **permits** the `let` pattern, not what mandates it. This is judgement, not syntax, so it stays prose.

TMX made that especially clear: it has 24 `const result: any` and only **one** is in a test file — the other 23 are production source the standard never covered.

## Verified against the CI job, not `pnpm lint`

The `lint` job runs more than `pnpm lint`, so all of it was run:

- `pnpm lint` → **0**
- `pnpm check-types` → **0** (src + e2e + electron)
- `pnpm format:check` → clean
- `pnpm attr-audit --ci` → **0**
- `pnpm i18n-audit --ci` → **0**
- `pnpm test --run` → **114 files / 1201 tests**
- `pnpm build` → succeeds

## One pre-existing gap, flagged not fixed

`format:check` is `prettier --check src`. **27 files under `e2e/` and `electron/` fail prettier** and sit outside that scope — verified pre-existing by control against a stashed tree, so untouched here. Worth widening the gate separately.