### PR TITLE
fix(deps): update tods-competition-factory to 6.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.28.1",
+    "tods-competition-factory": "6.29.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Ecosystem fan-out of factory **6.29.0**. Manifest-only — TMX overrides `tods-competition-factory` to `link:../factory`, so the lockfile records the link rather than a version. CI strips the override and installs the pin, which is what this changes.

Direct push to `main` is declined by branch protection, so this is a PR — the other ten consumers took the bump directly. That is expected on every fan-out; the bump script pushes to the default branch and will always fail here.

## What is in 6.29.0

Notice-identity and payload work. No API or behaviour change for TMX:

- **#4657** — keyed notice de-dup no longer discards identity it already had. `MODIFY_MATCHUP` is keyed on `matchUpId`, so a later emission carrying less used to erase what an earlier one knew
- **#4664 / #4665** — opt-in `participantsVersion` handshake on `getEventData`
- **#4667** — `modifyParticipant` reports when a supplied `participantName` is superseded by the person-derived name
- **#4653** — internal `setMatchUpMatchUpFormat` → `applyMatchUpFormat` (never exported; no consumer impact)

Additive throughout — nothing TMX calls changes shape.