### PR TITLE
fix(deps): update courthive-components to 3.14.3 and pdf-factory to 0.8.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.14.1",
+    "courthive-components": "3.14.3",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.18",
+    "pdf-factory": "0.8.19",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",


### PR DESCRIPTION
Ecosystem fan-out of the two packages published just now. Manifest-only.

| package | from | to |
|---|---|---|
| courthive-components | 3.14.2 | **3.14.3** |
| pdf-factory | 0.8.18 | **0.8.19** |

**Both in one PR deliberately.** TMX is the *only* consumer of pdf-factory, and it is also a components consumer, so separating them would mean two full CI cycles for two one-line manifest changes. Order is still respected — factory (#1314) merged first, then these.

Direct push to `main` is declined by branch protection, hence a PR; the other components consumers (courthive-public, courthive-ams, epixodic) took the bump directly. That is structural — the bump scripts push to the default branch and will always fail on TMX.

## Note on the components pin

TMX pins `courthive-components` by exact version, but the package declares factory as a **peerDependency `^6.0.0`** — so components never constrains which factory a consumer resolves. TMX is on factory 6.29.0 as of #1314, and 3.14.3 is compatible with it.