### PR TITLE
chore(lint): machine-enforce the .dataset standard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,20 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+
+      // ── CourtHive coding standards, machine-enforced ────────────────────
+      // Prose in Mentat/standards/coding-standards.md drifts because lint,
+      // types AND prettier all pass while the code violates it. This rule is
+      // the one from that document a linter can hold without judgement.
+      //
+      // DOM data attributes are read via `.dataset`, never `.getAttribute`.
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "CallExpression[callee.property.name='getAttribute'][arguments.0.value=/^data-/]",
+          message: 'Use .dataset.propName instead of .getAttribute("data-*") — Mentat coding standards.',
+        },
+      ],
       'no-unused-expressions': 'off',
       'no-useless-assignment': 'warn',
       'preserve-caught-error': 'off',

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
@@ -179,7 +179,7 @@ function applyMorphdomUpdate(
       getNodeKey(node: any) {
         if (isParticipantEl(node)) return undefined;
 
-        const matchUpId = node.getAttribute?.('data-matchup-id');
+        const matchUpId = (node as HTMLElement).dataset?.matchupId;
         if (matchUpId) return matchUpId;
 
         const id = node.getAttribute?.('id');


### PR DESCRIPTION
Replaces #1313, which bundled this rule with a second one that has since been
countermanded. Companion: courthive-components #523.

## What this keeps

`no-restricted-syntax` banning `.getAttribute('data-*')` in favour of
`.dataset`, plus the one call site it finds.

That site is the interesting one: `node.getAttribute?.('data-matchup-id')` in
`renderDrawView.ts:182` — the optional-call form, which a plain grep for
`getAttribute('data-` misses entirely and the AST selector catches. That
asymmetry is the whole argument for a lint rule over search-and-replace.

## A correction to #1313's numbers

#1313's description claims **3** violations of this rule. Running it across
`src e2e electron` finds **one**. Lint is clean with only this single fix
applied, so the other two either never existed or were counted from a different
tree. Recorded because an inflated count is how a rule looks better-justified
than it is — the single optional-call catch justifies it on its own.

## What this drops, and why

#1313 also added `@typescript-eslint/consistent-type-imports` with
`prefer: 'no-type-imports'`, auto-rewriting 145 imports here (1,283 across the
three repos).

That rule encodes a standard that no longer exists. The `import type` ban was
softened to a preference on 2026-08-18 at 12:22 — "a preference for new code,
NOT a cleanup task: do not rewrite existing imports in either direction" — and
#1313 was opened at 16:34 the same day still enforcing the ban. #1309 had
already merged at 14:27 *restoring* `import type` on two lines, so the tree was
being pulled in both directions on the same afternoon.

Root cause was a stale local hook instructing every session "Never `import
type`". That hook has been corrected; without that fix this would simply be
re-opened by the next session.

## Verified against the CI job, not just `pnpm lint`

- `eslint src e2e electron --max-warnings 0` → 0
- `tsc --noEmit` × 3 projects (src, e2e, electron) → 0
- `prettier --check src` → clean
- `attr-audit` → exit 0
- `i18n-audit --ci` → exit 0
- `TZ=UTC vitest run` → 114 files / 1201 tests passing

The rule was falsified in both directions rather than assumed: a probe file
produces the warning, and reverting the one real fix reddens exactly that line.
Import statements are untouched.