### PR TITLE
chore(lint): ban JSON.parse(JSON.stringify()) as a deep-copy idiom

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,21 @@ export default [
       'import/no-named-as-default': 'off',
       'import/no-named-as-default-member': 'off',
       'import/no-unresolved': 'off',
+      // Ban `JSON.parse(JSON.stringify(x))` as a deep-copy idiom — it silently drops `undefined`,
+      // functions, `Date`/`Map`/`Set` and throws on cycles. Ecosystem-wide as of 2026-08-21; mirrors the
+      // rule in factory, competition-factory-server and courthive-components. Keep them in step.
+      //
+      // ⚠️ Flat config REPLACES a rule's options rather than merging them, so the `e2e/**` block below
+      // re-declares this selector alongside its own. Adding a selector here means adding it there too.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='JSON'][callee.property.name='parse'] > CallExpression[callee.object.name='JSON'][callee.property.name='stringify']",
+          message:
+            'Use structuredClone() to deep-copy — JSON.parse(JSON.stringify(x)) drops undefined/functions/Date/Map/Set and throws on cycles. For tournamentRecords use tools.makeDeepCopy, which carries factory extension semantics.',
+        },
+      ],
     },
   },
   {
@@ -110,6 +125,14 @@ export default [
           selector: "CallExpression[callee.property.name='slice'][callee.object.callee.property.name='toISOString']",
           message:
             'Seed calendar days with todayLocal() from e2e/helpers/dates — toISOString() is UTC, but TMX renders the local day. See Mentat/planning/E2E_SCHEDULE2_UTC_LOCAL_DAY_MISMATCH.md',
+        },
+        // Re-declared from the main block: flat config replaces rule options, it does not merge them,
+        // so omitting this would silently exempt every e2e file from the deep-copy ban.
+        {
+          selector:
+            "CallExpression[callee.object.name='JSON'][callee.property.name='parse'] > CallExpression[callee.object.name='JSON'][callee.property.name='stringify']",
+          message:
+            'Use structuredClone() to deep-copy — JSON.parse(JSON.stringify(x)) drops undefined/functions/Date/Map/Set and throws on cycles. For tournamentRecords use tools.makeDeepCopy, which carries factory extension semantics.',
         },
       ],
     },

--- a/src/config/locationConfig.ts
+++ b/src/config/locationConfig.ts
@@ -41,7 +41,7 @@ const leafletDefaults: LeafletConfig = {
 };
 
 let currentLocation: LocationConfig = { ...locationDefaults };
-let currentLeaflet: LeafletConfig = JSON.parse(JSON.stringify(leafletDefaults));
+let currentLeaflet: LeafletConfig = structuredClone(leafletDefaults);
 
 export const locationConfig = {
   get: (): LocationConfig => currentLocation,

--- a/src/config/scoringConfig.ts
+++ b/src/config/scoringConfig.ts
@@ -66,7 +66,7 @@ const defaults: ScoreboardConfig = {
   },
 };
 
-let current: ScoreboardConfig = JSON.parse(JSON.stringify(defaults));
+let current: ScoreboardConfig = structuredClone(defaults);
 
 export const scoringBoardConfig = {
   get: (): Readonly<ScoreboardConfig> => current,
@@ -74,6 +74,6 @@ export const scoringBoardConfig = {
     current = { ...current, ...partial };
   },
   reset: () => {
-    current = JSON.parse(JSON.stringify(defaults));
+    current = structuredClone(defaults);
   },
 } as const;

--- a/src/services/mutation/mutationRequest.test.ts
+++ b/src/services/mutation/mutationRequest.test.ts
@@ -5,7 +5,7 @@ vi.mock('services/storage/saveTournamentRecord', () => ({ saveTournamentRecord: 
 vi.mock('services/notifications/tmxToast', () => ({ tmxToast: vi.fn() }));
 vi.mock('services/messaging/socketIo', () => ({ emitTmx: vi.fn() }));
 vi.mock('tods-competition-factory', () => ({
-  tools: { unique: (a: any[]) => [...new Set(a)], makeDeepCopy: (a: any) => JSON.parse(JSON.stringify(a)) },
+  tools: { unique: (a: any[]) => [...new Set(a)], makeDeepCopy: (a: any) => structuredClone(a) },
   // `services/factory/engine` wrapper imports both engines from the factory;
   // stub them so the wrapper resolves at module-load even though this test
   // never calls into them.

--- a/src/services/schedulingWorkspace/queueService.test.ts
+++ b/src/services/schedulingWorkspace/queueService.test.ts
@@ -65,7 +65,7 @@ vi.mock('services/notifications/tmxToast', () => ({
 }));
 
 vi.mock('tods-competition-factory', () => ({
-  tools: { makeDeepCopy: (v: any) => JSON.parse(JSON.stringify(v)) },
+  tools: { makeDeepCopy: (v: any) => structuredClone(v) },
 }));
 
 vi.mock('constants/tmxConstants', () => ({


### PR DESCRIPTION
Completes the ecosystem-wide ban started in factory and competition-factory-server. `JSON.parse(JSON.stringify(x))` silently drops `undefined`, functions, `Date`/`Map`/`Set` and throws on cycles.

It surfaced because it was the idiom in use where a shared privacy-policy fixture needed copying, beside three call sites that copied nothing at all and mutated that fixture in place — a live leak on a public cached route. Machine-enforced because prose could not hold it.

## Sites converted (5)

| file | what |
|---|---|
| `src/config/locationConfig.ts:44` | leaflet defaults |
| `src/config/scoringConfig.ts:69` | scoreboard defaults |
| `src/config/scoringConfig.ts:77` | scoreboard reset |
| `src/services/schedulingWorkspace/queueService.test.ts` | `tools.makeDeepCopy` mock |
| `src/services/mutation/mutationRequest.test.ts` | `tools.makeDeepCopy` mock |

## ⚠️ The flat-config trap this had to avoid

TMX already scoped a `no-restricted-syntax` to `e2e/**` — the `toISOString().slice(0,10)` calendar-day ban. **Flat config replaces a rule's options rather than merging them**, so declaring the deep-copy selector only in the main block would have silently exempted every e2e file from it.

The selector is re-declared in both blocks, and the falsification probe checks **both scopes**: the e2e probe must report *two* violations, not one. A selector added to one block has to be added to the other.

## Verification

Rule falsified in both directions — fires on a planted line in `src/` and in `e2e/`, silent on the real tree.

Full TMX CI gate run locally, not just `pnpm lint`:

```text
lint ✓  format:check ✓  check-types ✓  attr-audit --ci ✓  i18n-audit --ci ✓
vitest  114 files | 1201 passed
```