### PR TITLE
fix(deps): update tods-competition-factory to 6.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.29.0",
+    "tods-competition-factory": "6.29.1",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Part of the ecosystem fan-out of factory **6.29.1**. Nine sibling consumers were bumped and pushed directly; TMX `main` is protected, so this one comes via PR.

## What 6.29.1 contains

The participant-privacy emission-boundary fix. `hydrateParticipants` declared `policyDefinitions` and never read it, so `competitionScheduleMatchUps` returned `mappedParticipants` — the whole raw participant record — on a public cached route.

Verified behaviourally against the **published tarball**, not inferred from the tag, with both controls asserted:

```text
factoryVersion            6.29.1
recordPersonsWithSex           8    <- control: the record really carries sex
mappedParticipantsCount        8    <- control: participants really were emitted
mappedCarryingSex              0
mappedCarryingPersonId         0
```

Production measured 157/170 carrying `person.sex` before the fix.

## Why this is manifest-only

TMX resolves factory through `link:../factory` in `pnpm-workspace.yaml`, so the lockfile specifier does not move. The `package.json` pin is what the release build installs once the link override is stripped — which is exactly the sibling-link trap: green locally, stale in CI and in the shipped bundle.

## Gates

Generated by `Mentat/scripts/bump-factory-consumers.sh 6.29.1`, which type-checked every consumer before committing. Locally on this branch:

```text
lint ✓   format:check ✓   check-types ✓   vitest 1201 passed
```