### PR TITLE
chore(deps): bump @courthive/provider-config to 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "yargs": "18.1.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "0.13.0",
+    "@courthive/provider-config": "0.15.0",
     "@courthive/scoring-visualizations": "^0.2.9",
     "@eslint/js": "^10.0.1",
     "animate.css": "4.1.1",


### PR DESCRIPTION
Keeps TMX in step with the fan-out that moved `courthive-ams`, `courthive-hiveid` and `courthive-public` to 0.15.0. CFS is already there.

0.15.0 adds the `participantPrivacy.sex` toggle used by the ITA gender work. TMX does not consume it yet; this is pin hygiene so the next consumer does not have to discover the drift.

TMX `link:`-overrides the package, so the lockfile entry is advisory — the manifest pin is what CI installs once the override is stripped.

Gates run locally: lint, format:check, check-types, attr-audit --ci, i18n-audit --ci all clean.