### PR TITLE
feat(schedule): participant rest — Inspector section, catalog badge, and a Start-all guard

### DIFF
--- a/e2e/journeys/98-schedule2-participant-rest.spec.ts
+++ b/e2e/journeys/98-schedule2-participant-rest.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 98 — Schedule2 participant rest.
+ *
+ * Covers the three surfaces that bring the rest figure to the point of decision:
+ *
+ *  1. **Inspector Rest section** — one row per individual, evaluated even for an
+ *     UNSCHEDULED matchUp. That last part is the whole reason the section
+ *     exists: readiness skips when there is no scheduledTime, which is exactly
+ *     the state a matchUp is in when a director is deciding whether to call it.
+ *  2. **Catalog card badge** — the headline on the card itself, so the answer is
+ *     available while scanning, before a card is selected.
+ *  3. **i18n + theme** — every string resolves (no dotted key paths leak), and
+ *     the badge is legible in both light and dark.
+ *
+ * Seeded against a REAL completed matchUp rather than a hand-written schedule
+ * fragment: the rest ladder reads `endTime` / `scoredTime` off the record, and a
+ * seed that only sets `scheduledTime` would exercise the weakest rung while
+ * appearing to pass. The control case (a player with nothing earlier that day)
+ * must show no badge — a badge that always renders would pass a one-sided test.
+ */
+
+const SCHEDULE_DATE = todayLocal();
+
+const INSPECTOR = '[data-panel="inspector"]';
+const CATALOG_PANEL = '[data-panel="catalog"]';
+const UNSCHEDULED_TAB = 'button[data-sidebar-tab="unscheduled"]';
+const REST_SECTION = '.tmx-rest';
+const REST_ROW = '.tmx-rest-row';
+const REST_BADGE = '.tmx-rest-badge';
+const CARD = '.spl-matchup-card';
+
+type Seed = { tournamentId: string; restingMatchUpId: string; freshMatchUpId: string };
+
+/**
+ * Plays out an R1 matchUp so a real winner advances with a real finish time,
+ * then finds the R2 matchUp that winner feeds into. That R2 matchUp is left
+ * UNSCHEDULED — the state the badge and the Rest section have to handle.
+ *
+ * Throws rather than falling back if the advancement doesn't materialise, so a
+ * seed that stops producing a rested player fails loudly instead of leaving the
+ * assertions to pass against an empty panel.
+ */
+async function seedRest(page: import('@playwright/test').Page): Promise<Seed> {
+  return page.evaluate(
+    async ({ date }) => {
+      try {
+        await dev.tmx2db.initDB();
+
+        const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+          nonRandom: 1,
+          setState: true,
+          tournamentName: 'E2E Participant Rest',
+          tournamentAttributes: { tournamentId: 'e2e-participant-rest', startDate: date, endDate: date },
+          participantsProfile: { scaledParticipantsCount: 16 },
+          drawProfiles: [{ eventName: 'Singles', drawSize: 8, seedsCount: 2, drawType: 'SINGLE_ELIMINATION' }],
+          venueProfiles: [{ courtsCount: 2, venueName: 'Rest Venue' }],
+        });
+
+        const all = () => dev.factory.competitionEngine.allTournamentMatchUps({}).matchUps || [];
+        const r1 = all().filter((m: any) => m.matchUpStatus !== 'BYE' && m.roundNumber === 1);
+        const target = r1[0];
+
+        // Every mutation is checked. A silent `{ error }` return here produced a
+        // confusing "no R2 matchUp" failure downstream when the first draft of
+        // this seed hand-wrote a one-set score against a best-of-3 format and
+        // setMatchUpStatus rejected it with ERR_INVALID_SCORE.
+        const must = (label: string, result: any) => {
+          if (result?.error) throw new Error(`${label} failed: ${JSON.stringify(result.error)}`);
+          return result;
+        };
+
+        // Schedule it, then complete it with an explicit END_TIME — the strongest
+        // rung of the ladder, so the assertion is about the arithmetic and not
+        // about which fallback happened to fire.
+        must(
+          'addMatchUpScheduleItems',
+          dev.factory.tournamentEngine.addMatchUpScheduleItems({
+            matchUpId: target.matchUpId,
+            drawId: target.drawId,
+            schedule: { scheduledDate: date, scheduledTime: '09:00', endTime: '10:30' },
+          }),
+        );
+
+        // Built by the factory from a score string rather than hand-written, so
+        // it is valid for whatever matchUpFormat the draw actually carries.
+        const { outcome } = dev.factory.mocksEngine.generateOutcomeFromScoreString({
+          matchUpFormat: target.matchUpFormat,
+          scoreString: '6-1 6-2',
+          winningSide: 1,
+        });
+        must(
+          'setMatchUpStatus',
+          dev.factory.tournamentEngine.setMatchUpStatus({
+            matchUpId: target.matchUpId,
+            drawId: target.drawId,
+            outcome: { ...outcome, matchUpStatus: 'COMPLETED' },
+          }),
+        );
+
+        const played = all().find((m: any) => m.matchUpId === target.matchUpId);
+        const winnerIds: string[] = (played.sides || [])
+          .filter((s: any) => s.sideNumber === played.winningSide)
+          .flatMap((s: any) => [s.participantId, ...(s.participant?.individualParticipantIds || [])])
+          .filter(Boolean);
+
+        const idsOf = (m: any): string[] =>
+          (m.sides || [])
+            .flatMap((s: any) => [s.participantId, ...(s.participant?.individualParticipantIds || [])])
+            .filter(Boolean);
+
+        // The R2 matchUp the winner advanced into — unscheduled, and carrying a
+        // participant who finished at 10:30.
+        const resting = all().find(
+          (m: any) => m.roundNumber === 2 && m.matchUpStatus !== 'BYE' && idsOf(m).some((id) => winnerIds.includes(id)),
+        );
+        if (!resting) {
+          throw new Error('seed produced no R2 matchUp carrying the R1 winner — the rest assertion would be vacuous');
+        }
+
+        // Control: an R1 matchUp nobody has played yet, so no participant on it
+        // has any prior match today.
+        const fresh = r1.find((m: any) => m.matchUpId !== target.matchUpId && !idsOf(m).some((id) => winnerIds.includes(id)));
+        if (!fresh) throw new Error('seed produced no untouched R1 matchUp for the control case');
+
+        await dev.tmx2db.addTournament(dev.factory.tournamentEngine.getTournament().tournamentRecord);
+
+        return {
+          tournamentId: tournamentRecord.tournamentId as string,
+          restingMatchUpId: resting.matchUpId as string,
+          freshMatchUpId: fresh.matchUpId as string,
+        };
+      } catch (err: any) {
+        throw new Error(
+          `${err?.name || 'Error'}: ${err?.message || String(err)} | stack: ${err?.stack?.split('\n').slice(0, 3).join(' || ')}`,
+        );
+      }
+    },
+    { date: SCHEDULE_DATE },
+  );
+}
+
+async function openCatalog(page: import('@playwright/test').Page, tournamentId: string): Promise<void> {
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  await tournament.navigateToScheduling();
+  await page.locator(UNSCHEDULED_TAB).click();
+  await page.locator(CATALOG_PANEL).waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+test.describe('Journey 98 — Schedule2 participant rest', () => {
+  let seed: Seed;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    seed = await seedRest(page);
+    await openCatalog(page, seed.tournamentId);
+  });
+
+  test('the Rest section evaluates an UNSCHEDULED matchUp, which readiness skips', async ({ page }) => {
+    await page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"]`).click();
+
+    const rest = page.locator(`${INSPECTOR} ${REST_SECTION}`);
+    await expect(rest).toBeVisible();
+    // Evaluated, not skipped — the data-rest hook carries the row count.
+    await expect(rest).not.toHaveAttribute('data-rest', 'skipped');
+    await expect(rest.locator(REST_ROW)).not.toHaveCount(0);
+
+    // Readiness, on the same unscheduled matchUp, correctly reports it cannot
+    // evaluate. The two sections answering differently is the point.
+    await expect(page.locator(`${INSPECTOR} .tmx-readiness`)).toHaveAttribute('data-readiness', 'skipped');
+  });
+
+  test('the resting participant is reported with an elapsed figure and its provenance', async ({ page }) => {
+    await page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"]`).click();
+
+    const rows = page.locator(`${INSPECTOR} ${REST_ROW}`);
+    const statuses = await rows.evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.status));
+    // The advancing player finished at 10:30; the other side of the R2 matchUp
+    // has not played, so exactly one row is not 'none'.
+    expect(statuses.filter((s) => s !== 'none').length).toBeGreaterThan(0);
+
+    const played = rows.filter({ hasNot: page.locator('[data-status="none"]') }).first();
+    await expect(played.locator('.tmx-rest-figure')).not.toBeEmpty();
+    await expect(played.locator('.tmx-rest-detail')).toContainText(/recorded end time|score entry|projected/i);
+  });
+
+  test('the catalog card carries a rest badge, and a card with no prior match does not', async ({ page }) => {
+    const restingBadge = page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"] ${REST_BADGE}`);
+    await expect(restingBadge).toBeVisible();
+    await expect(restingBadge).toHaveAttribute('data-rest-status', /rested|resting|oncourt/i);
+
+    // Control — a badge that always renders would pass a one-sided test.
+    const freshCard = page.locator(`${CARD}[data-matchup-id="${seed.freshMatchUpId}"]`);
+    await expect(freshCard).toBeVisible();
+    await expect(freshCard.locator(REST_BADGE)).toHaveCount(0);
+  });
+
+  test('no unresolved i18n key reaches the operator', async ({ page }) => {
+    await page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"]`).click();
+
+    for (const scope of [`${INSPECTOR} ${REST_SECTION}`, `${CARD}[data-matchup-id="${seed.restingMatchUpId}"]`]) {
+      const text = (await page.locator(scope).innerText()).trim();
+      expect(text).not.toBe('');
+      // `t()` echoes its key when it resolves to nothing; a dotted path in
+      // rendered copy is the signature.
+      expect(text).not.toMatch(/schedule\.(card|inspector)\.rest/);
+      expect(text).not.toContain('{{');
+    }
+  });
+
+  test('the badge is legible in BOTH light and dark', async ({ page }) => {
+    const badge = page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"] ${REST_BADGE}`);
+    await expect(badge).toBeVisible();
+
+    const readColours = () =>
+      badge.evaluate((el) => {
+        const style = getComputedStyle(el);
+        return { color: style.color, border: style.borderTopColor, theme: document.documentElement.dataset.theme };
+      });
+
+    // Element-level shots, not page shots: a viewport screenshot puts the card
+    // below the fold and shows nothing, which is worse than no screenshot at all
+    // because it looks like evidence.
+    const card = page.locator(`${CARD}[data-matchup-id="${seed.restingMatchUpId}"]`);
+    await card.scrollIntoViewIfNeeded();
+
+    // Set BOTH themes explicitly. The app boots in dark, so reading "light"
+    // without setting it first silently reads dark twice — which is exactly
+    // what the first version of this test did, and it looked like a pass.
+    const setTheme = async (theme: 'light' | 'dark') => {
+      await page.evaluate((t) => {
+        document.documentElement.dataset.theme = t;
+      }, theme);
+      const applied = await page.evaluate(() => document.documentElement.dataset.theme);
+      expect(applied).toBe(theme);
+    };
+
+    await setTheme('light');
+    const light = await readColours();
+    await card.screenshot({ path: 'e2e/test-results/98-rest-badge-light.png' });
+
+    await setTheme('dark');
+    const dark = await readColours();
+    await card.screenshot({ path: 'e2e/test-results/98-rest-badge-dark.png' });
+
+    // Both themes must resolve the tokens to something real — an unresolved
+    // custom property computes to a transparent / empty value, which is the
+    // failure this catches.
+    for (const snapshot of [light, dark]) {
+      expect(snapshot.color).toMatch(/^rgb/);
+      expect(snapshot.color).not.toBe('rgba(0, 0, 0, 0)');
+      expect(snapshot.border).not.toBe('rgba(0, 0, 0, 0)');
+    }
+    // The two themes must actually differ — `--tmx-accent-*` is defined per
+    // theme, so identical colours mean the badge is reading a hard-coded value
+    // or the theme never switched.
+    expect(`${light.color}|${light.border}`).not.toBe(`${dark.color}|${dark.border}`);
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -949,10 +949,27 @@
     "shiftCourtsTitle": "Shift courts down",
     "shiftRows": "Rows to shift down",
     "noActiveMatches": "No matches in progress",
+    "startAllRest": {
+      "title": "Start matches with players still resting?",
+      "pill": "{{count}} needs rest",
+      "intro": "{{count}} of these matches has a player who has not had their recovery time:",
+      "resting": "{{name}}{{where}} — {{rested}} rested of {{required}} required",
+      "onCourt": "{{name}}{{where}} — still on court in an earlier match"
+    },
     "startOnDropTitle": "Start match on drop?",
     "startOnDropPrompt": "You dropped a match onto the Now strip. Start matches automatically whenever they are dropped onto Now from now on? You can change this any time with the start-on-drop toggle in the schedule header.",
     "unscheduleAllTitle": "Unschedule all?",
     "unscheduleAllConfirm": "Remove the date, time and court for {{count}} match(es)? They return to the unscheduled catalog; their results are untouched.",
+    "card": {
+      "rest": {
+        "onCourt": "on court",
+        "none": "no prior match",
+        "limit": "#{{ordinal}}",
+        "tooltipRest": "{{name}} — {{rested}} rested of {{required}} required",
+        "tooltipOnCourt": "{{name}} — still on court",
+        "tooltipNone": "{{name}} — no prior match today"
+      }
+    },
     "inspector": {
       "show": "Show inspector",
       "hide": "Hide inspector",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -973,6 +973,34 @@
           "noTime": "No scheduled time, so readiness cannot be projected.",
           "unknownMatchUp": "This matchUp is no longer in the tournament."
         }
+      },
+      "rest": {
+        "heading": "Rest",
+        "hoursMinutes": "{{hours}}h {{minutes}}m",
+        "minutesOnly": "{{minutes}}m",
+        "rested": "{{rested}} rested — {{required}} required",
+        "resting": "{{rested}} of {{required}} — ready {{time}}",
+        "onCourt": "On court now",
+        "onCourtUntil": "On court now — ready {{time}}",
+        "noPriorMatch": "No prior match today",
+        "typeChange": "type change",
+        "ordinal": "match #{{ordinal}} today",
+        "ordinalLimit": "match #{{ordinal}} today, limit {{limit}}",
+        "atLimit": "At the daily match limit",
+        "source": {
+          "endTime": "from recorded end time",
+          "scoredTime": "from score entry (est.)",
+          "startTime": "projected from start time (est.)",
+          "calledAt": "projected from call to court (est.)",
+          "scheduledTime": "projected from scheduled time (est.)"
+        },
+        "skip": {
+          "generic": "Rest cannot be evaluated for this matchUp.",
+          "bye": "A BYE needs no rest.",
+          "completed": "Already complete — rest no longer applies.",
+          "noParticipants": "Participants not yet determined, so there is no one to rest.",
+          "unknownMatchUp": "This matchUp is no longer in the tournament."
+        }
       }
     }
   },

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -276,6 +276,7 @@ import {
   type SidebarTab,
 } from './gridViewStorage';
 import { renderInspectorSections } from './inspectorReadiness';
+import { renderRestBadge } from './restBadge';
 
 /** Distinct, sorted, locale-aware values of an accessor across catalog items.
  *  Mirrors the helper inside courthive-components' `matchUpCatalog.ts`. */
@@ -409,6 +410,10 @@ export function renderGridView(
     // matchUp. A render hook rather than an external append — the Inspector rebuilds its
     // body on every store tick and would wipe anything appended from outside.
     renderInspectorExtra: (matchUp, state) => renderInspectorSections(matchUp.matchUpId, state.selectedDate),
+    // The rest headline goes on the card itself: the "which do I call next"
+    // decision is made while scanning the catalog, before any card is selected
+    // and before the drag starts, so the Inspector is one interaction too late.
+    renderCardExtra: (matchUp) => renderRestBadge(matchUp.matchUpId, currentDate),
     // Restore catalog filter state captured from a previous mount within
     // this tournament session. Cleared on tournament load (see loadTournament).
     initialCatalogState: context.scheduleCatalogState,
@@ -1153,6 +1158,11 @@ function injectSidebarControls(container: HTMLElement, refresh: () => void): voi
           {
             prominentTime: true,
             roundOffset,
+            // Same hook as the catalog. The Scheduled panel builds its cards
+            // directly rather than through the component's catalog, so the
+            // badge has to be passed here too or it would appear on only half
+            // the cards an operator looks at.
+            renderExtra: (m) => renderRestBadge(m.matchUpId, currentDate),
           },
         );
         if (!item.scheduledTime) card.classList.add('no-time');
@@ -2604,7 +2614,7 @@ function buildNowRowContext(refresh: () => void): Schedule2NowContext {
       };
     });
 
-  return { cells, onRefresh: refresh, executeMethods, buildDateGrid };
+  return { cells, onRefresh: refresh, executeMethods, buildDateGrid, scheduledDate: currentDate };
 }
 
 /**

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -275,7 +275,7 @@ import {
   writeInspectorVisible,
   type SidebarTab,
 } from './gridViewStorage';
-import { renderReadinessSection } from './inspectorReadiness';
+import { renderInspectorSections } from './inspectorReadiness';
 
 /** Distinct, sorted, locale-aware values of an accessor across catalog items.
  *  Mirrors the helper inside courthive-components' `matchUpCatalog.ts`. */
@@ -405,10 +405,10 @@ export function renderGridView(
     // click on the toggle dispatches a real change rather than a no-op against
     // the store's default-true.
     inspectorVisible: readInspectorVisible(),
-    // Consumer-supplied Inspector detail: readiness for the selected matchUp.
-    // A render hook rather than an external append — the Inspector rebuilds its
+    // Consumer-supplied Inspector detail: rest + readiness for the selected
+    // matchUp. A render hook rather than an external append — the Inspector rebuilds its
     // body on every store tick and would wipe anything appended from outside.
-    renderInspectorExtra: (matchUp) => renderReadinessSection(matchUp.matchUpId),
+    renderInspectorExtra: (matchUp, state) => renderInspectorSections(matchUp.matchUpId, state.selectedDate),
     // Restore catalog filter state captured from a previous mount within
     // this tournament session. Cleared on tournament load (see loadTournament).
     initialCatalogState: context.scheduleCatalogState,

--- a/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
@@ -1,61 +1,33 @@
 /**
- * Schedule2 — Inspector readiness section.
+ * Schedule2 — Inspector readiness section, and the composition of everything
+ * TMX contributes to the courthive-components Inspector.
  *
  * The impure half of the readiness feature: gathers factory data, resolves
- * timing through the engine, and renders the result into the courthive-components
- * Inspector via its `renderInspectorExtra` hook. All rules live in the pure
- * `matchUpReadiness.ts`; this file decides nothing.
+ * timing through the engine, and renders the result into the Inspector via its
+ * `renderInspectorExtra` hook. All rules live in the pure `matchUpReadiness.ts`;
+ * this file decides nothing.
  *
- * Timing comes from `tournamentEngine.getMatchUpFormatTiming`, which is what the
+ * Timing comes from the shared `scheduleTimingResolver`, which is what the
  * auto-scheduler itself resolves against (including its scheduling-policy
  * fallback, so unpoliced tournaments still get per-format averages rather than a
- * flat 90/0). Resolution is memoised per `matchUpFormat|matchUpType` for the life
- * of one render pass — a tournament has a handful of distinct pairs, not one per
- * matchUp.
+ * flat 90/0). Sharing the resolver with the rest section is what keeps the two
+ * from disagreeing about what a format costs.
+ *
+ * Readiness and rest answer *different* questions and are both rendered:
+ * readiness asks "can this placement happen at the time it is scheduled for"
+ * (and skips when there is no time), rest asks "how long have these players
+ * actually had off, as of now" (and answers for an unscheduled matchUp, which is
+ * the moment the director is deciding whether to call it).
  */
 
-import { getCachedAllMatchUps } from './schedule2DataCache';
+import { makeTimingResolver } from './scheduleTimingResolver';
 import { analyzeMatchUpReadiness } from './matchUpReadiness';
-import { tournamentEngine } from 'services/factory/engine';
+import { getCachedAllMatchUps } from './schedule2DataCache';
+import { renderRestSection } from './inspectorRest';
 import { t } from 'i18n';
 
 // constants and types
-import type { ReadinessFinding, ReadinessMatchUp, ReadinessResult, ReadinessTiming } from './matchUpReadiness';
-
-const FALLBACK_TIMING: ReadinessTiming = { averageMinutes: 90, recoveryMinutes: 0 };
-
-/** Engine-backed timing lookup, memoised per format + type. */
-function makeTimingResolver(): (matchUp: ReadinessMatchUp) => ReadinessTiming {
-  const cache = new Map<string, ReadinessTiming>();
-  return (matchUp: ReadinessMatchUp) => {
-    const matchUpFormat = matchUp.matchUpFormat ?? '';
-    const key = `${matchUpFormat}|${matchUp.matchUpType ?? ''}`;
-    const cached = cache.get(key);
-    if (cached) return cached;
-
-    // A missing format cannot be resolved; the flat fallback keeps the
-    // arithmetic running rather than dropping every finding silently.
-    let timing = FALLBACK_TIMING;
-    if (matchUpFormat) {
-      // `matchUpType` is a plain string on the hydrated matchUp but an
-      // `EventTypeUnion` on the engine signature; the engine validates it and
-      // falls back to SINGLES, so widen at the boundary rather than duplicating
-      // the union here.
-      const result: any = tournamentEngine.getMatchUpFormatTiming({
-        eventType: matchUp.matchUpType as any,
-        matchUpFormat,
-      });
-      if (!result?.error) {
-        timing = {
-          averageMinutes: result?.averageMinutes ?? FALLBACK_TIMING.averageMinutes,
-          recoveryMinutes: result?.recoveryMinutes ?? FALLBACK_TIMING.recoveryMinutes,
-        };
-      }
-    }
-    cache.set(key, timing);
-    return timing;
-  };
-}
+import type { ReadinessFinding, ReadinessMatchUp, ReadinessResult } from './matchUpReadiness';
 
 /** Readiness for one matchUp, resolved against current factory state. */
 export function evaluateReadiness(matchUpId: string): ReadinessResult {
@@ -137,4 +109,24 @@ export function renderReadinessSection(matchUpId: string): HTMLElement | null {
     section.appendChild(row);
   }
   return section;
+}
+
+/**
+ * Everything TMX adds to the Inspector, for one selected matchUp. Wired as the
+ * schedule page's `renderInspectorExtra`; returns a fresh element per call
+ * because the Inspector rebuilds its body on every state change.
+ */
+export function renderInspectorSections(matchUpId: string, viewedDate: string | null): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const container = document.createElement('div');
+  container.className = 'tmx-inspector-extra';
+
+  const rest = renderRestSection(matchUpId, viewedDate);
+  if (rest) container.appendChild(rest);
+
+  const readiness = renderReadinessSection(matchUpId);
+  if (readiness) container.appendChild(readiness);
+
+  return container;
 }

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
@@ -1,0 +1,126 @@
+import { normalizeTimes, toDayMinutesFromClock, toDayMinutesFromInstant } from './inspectorRest';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+const DATE = '2026-08-22';
+
+/**
+ * `pnpm test` pins `TZ=UTC`, but these assertions are deliberately written to
+ * hold in ANY zone: every instant is built by parsing a naive local datetime and
+ * re-serialising it, so the expected minute figure is a statement about local
+ * wall clock rather than about UTC. Running `vitest` directly (no `TZ=UTC`) must
+ * produce the same result — that was not true of the first draft of this file,
+ * and the difference is exactly the offset bug the feature has to avoid.
+ */
+
+/** An ISO instant that IS `hh:mm` in the runner's local zone on `date`. */
+function localInstant(date: string, hhmm: string): string {
+  return new Date(`${date}T${hhmm}:00`).toISOString();
+}
+describe('toDayMinutesFromClock — bare wall clock, sliced never converted', () => {
+  it('parses military HH:MM', () => {
+    expect(toDayMinutesFromClock('00:00')).toBe(0);
+    expect(toDayMinutesFromClock('09:05')).toBe(545);
+    expect(toDayMinutesFromClock('14:20')).toBe(860);
+    expect(toDayMinutesFromClock('23:59')).toBe(1439);
+  });
+
+  it('slices the naive wall-clock portion of an ISO string, matching the factory extractTime', () => {
+    expect(toDayMinutesFromClock('2026-08-22T14:20:00.000Z')).toBe(860);
+    expect(toDayMinutesFromClock('2026-08-22T14:20')).toBe(860);
+  });
+
+  it('rejects unparseable and out-of-range values rather than guessing', () => {
+    for (const value of [undefined, '', 'later', '24:00', '12:60', 'TBD']) {
+      expect(toDayMinutesFromClock(value)).toBeUndefined();
+    }
+  });
+});
+
+describe('toDayMinutesFromInstant — UTC instant against local midnight of the viewed day', () => {
+  it('converts an instant on the viewed day to its local wall-clock minute', () => {
+    expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), DATE)).toBe(828);
+    expect(toDayMinutesFromInstant(localInstant(DATE, '00:00'), DATE)).toBe(0);
+  });
+
+  it('is a conversion, not a string slice — a UTC stamp is NOT read as wall clock', () => {
+    // In a zone offset from UTC these two disagree; asserting they agree only
+    // when the offset is zero is what makes this a real falsifier rather than a
+    // restatement of the implementation.
+    const utcNoon = '2026-08-22T12:00:00.000Z';
+    const offsetMinutes = -new Date(`${DATE}T00:00:00`).getTimezoneOffset();
+    expect(toDayMinutesFromInstant(utcNoon, DATE)).toBe(720 + offsetMinutes);
+  });
+
+  it('returns a NEGATIVE value for an instant on the previous day', () => {
+    // A string slice could never produce this; it is the falsifier for the
+    // instant-vs-wall-clock distinction the whole feature depends on.
+    expect(toDayMinutesFromInstant(localInstant('2026-08-21', '22:30'), DATE)).toBe(-90);
+  });
+
+  it('returns a value ABOVE 1439 for an instant on the following day', () => {
+    expect(toDayMinutesFromInstant(localInstant('2026-08-23', '00:30'), DATE)).toBe(1470);
+  });
+
+  it('returns undefined for a missing instant, a missing date, or an unparseable stamp', () => {
+    expect(toDayMinutesFromInstant(undefined, DATE)).toBeUndefined();
+    expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), null)).toBeUndefined();
+    expect(toDayMinutesFromInstant('not-a-date', DATE)).toBeUndefined();
+    expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), 'not-a-date')).toBeUndefined();
+  });
+});
+
+describe('normalizeTimes', () => {
+  function matchUp(schedule: ReadinessMatchUp['schedule']): ReadinessMatchUp {
+    return { matchUpId: 'm1', schedule };
+  }
+
+  it('normalizes each field from its own frame', () => {
+    const result = normalizeTimes(
+      matchUp({
+        scheduledDate: DATE,
+        scheduledTime: '10:00',
+        startTime: '10:07',
+        endTime: '12:06',
+        calledAt: localInstant(DATE, '09:55'),
+        scoredTime: localInstant(DATE, '12:11'),
+      }),
+      DATE,
+    );
+
+    expect(result).toEqual({
+      endMinutes: 726,
+      scoredMinutes: 731,
+      startMinutes: 607,
+      calledMinutes: 595,
+      scheduledMinutes: 600,
+    });
+  });
+
+  it('rolls endTime onto the next day when END_DATE says the match crossed midnight', () => {
+    const result = normalizeTimes(
+      matchUp({ scheduledDate: DATE, scheduledTime: '22:30', endTime: '00:40', endDate: '2026-08-23' }),
+      DATE,
+    );
+    expect(result.endMinutes).toBe(1480);
+    expect(result.scheduledMinutes).toBe(1350);
+  });
+
+  it('does not roll endTime when END_DATE equals the scheduled date', () => {
+    const result = normalizeTimes(matchUp({ scheduledDate: DATE, endTime: '12:06', endDate: DATE }), DATE);
+    expect(result.endMinutes).toBe(726);
+  });
+
+  it('omits endMinutes entirely when no END_TIME was recorded — the common case', () => {
+    const result = normalizeTimes(matchUp({ scheduledDate: DATE, scoredTime: localInstant(DATE, '12:11') }), DATE);
+    expect(result.endMinutes).toBeUndefined();
+    expect(result.scoredMinutes).toBe(731);
+  });
+
+  it('yields nothing usable for a matchUp with no schedule at all', () => {
+    const result = normalizeTimes({ matchUpId: 'm1', schedule: null }, DATE);
+    expect(Object.values(result).every((value) => value === undefined)).toBe(true);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -1,0 +1,260 @@
+/**
+ * Schedule2 — Inspector rest section.
+ *
+ * The impure half of the rest feature: reads the clock, converts every stored
+ * time into one frame, pulls timing and daily limits from the engine, and
+ * renders the result. All rules live in the pure `participantRest.ts`; this file
+ * decides nothing except what "now" means.
+ *
+ * ── The single time-conversion site ──
+ *
+ * `toDayMinutes*` below is the ONLY place in the rest feature where a stored
+ * value is interpreted as an instant or a wall clock. That concentration is
+ * deliberate: the planned Temporal-spec standardization has one function to
+ * replace rather than a scatter of `new Date()` calls.
+ *
+ * Two frames arrive from the factory and must not be confused:
+ *
+ *   - `endTime` / `startTime` / `scheduledTime` — bare military `HH:MM` (or an
+ *     ISO string whose time portion is a naive wall clock; the factory's
+ *     `extractTime` slices it rather than converting, and so do we);
+ *   - `calledAt` / `scoredTime` — full UTC ISO **instants**, which must be
+ *     converted to local wall clock before they can be compared with the above.
+ *
+ * Treating `scoredTime` as a wall clock — or `endTime` as an instant — produces
+ * a rest figure wrong by the UTC offset, which is worse than showing nothing.
+ *
+ * **Assumption, stated rather than assumed:** browser-local time is venue-local
+ * time. This is the convention every other schedule2 surface already uses
+ * (`todayIso()`, `effectiveNowOnStripDate()`, the reports tab's `calledAtIso`
+ * recomputation), and a page that mixed conventions would be the real hazard.
+ * `tournamentRecord.localTimeZone` exists and is the known input for making this
+ * explicit later; it is deliberately not consulted yet, so that the whole
+ * surface moves in one step rather than half of it.
+ */
+
+import { makeTimingResolver } from './scheduleTimingResolver';
+import { getCachedAllMatchUps } from './schedule2DataCache';
+import { competitionEngine } from 'services/factory/engine';
+import { analyzeParticipantRest } from './participantRest';
+import { t } from 'i18n';
+
+// constants and types
+import type { NormalizedTimes, RestDailyLimits, RestRow, RestResult } from './participantRest';
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+const MINUTES_PER_DAY = 1440;
+/** Rest is a minutes-granularity quantity; matches the Now strip's own cadence. */
+const REFRESH_MS = 30_000;
+
+/** `'14:20'` → `860`. Accepts an ISO string by slicing its naive wall-clock portion, as the factory does. */
+export function toDayMinutesFromClock(value?: string): number | undefined {
+  if (!value) return undefined;
+  const clock = value.includes('T') ? value.split('T').at(-1) : value;
+  const matched = /^(\d{1,2}):(\d{2})/.exec((clock ?? '').trim());
+  if (!matched) return undefined;
+  const hours = Number(matched[1]);
+  const minutes = Number(matched[2]);
+  if (hours > 23 || minutes > 59) return undefined;
+  return hours * 60 + minutes;
+}
+
+/**
+ * A UTC ISO instant → minutes from local midnight of `viewedDate`. A stamp from
+ * a different calendar day lands outside `0..1439`, which is what the rest
+ * arithmetic needs in order to say "ended yesterday" rather than silently
+ * wrapping.
+ */
+export function toDayMinutesFromInstant(iso?: string, viewedDate?: string | null): number | undefined {
+  if (!iso || !viewedDate) return undefined;
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) return undefined;
+
+  const midnight = new Date(`${viewedDate}T00:00:00`);
+  if (Number.isNaN(midnight.getTime())) return undefined;
+
+  return Math.round((instant.getTime() - midnight.getTime()) / 60_000);
+}
+
+/** Every time on a matchUp, normalized into minutes from local midnight of the day being viewed. */
+export function normalizeTimes(matchUp: ReadinessMatchUp, viewedDate: string | null): NormalizedTimes {
+  const schedule = matchUp.schedule ?? {};
+  // END_DATE is written only when the match crossed midnight, so its presence
+  // is exactly the signal that the bare endTime belongs to the following day.
+  const endDayOffset = schedule.endDate && schedule.endDate !== schedule.scheduledDate ? MINUTES_PER_DAY : 0;
+  const endMinutes = toDayMinutesFromClock(schedule.endTime);
+
+  return {
+    ...(endMinutes !== undefined && { endMinutes: endMinutes + endDayOffset }),
+    scoredMinutes: toDayMinutesFromInstant(schedule.scoredTime, viewedDate),
+    startMinutes: toDayMinutesFromClock(schedule.startTime),
+    calledMinutes: toDayMinutesFromInstant(schedule.calledAt, viewedDate),
+    scheduledMinutes: toDayMinutesFromClock(schedule.scheduledTime),
+  };
+}
+
+/**
+ * "Now" as minutes from midnight of the viewed day. When the operator is looking
+ * at another date, today's time-of-day is projected onto it — the same thing
+ * `effectiveNowOnStripDate()` does for the Now strip, so the two agree.
+ */
+export function nowDayMinutes(): number {
+  const now = new Date();
+  return now.getHours() * 60 + now.getMinutes();
+}
+
+/** Tournament daily limits, or undefined when no scheduling policy is attached — never a substituted default. */
+function readDailyLimits(): RestDailyLimits | undefined {
+  const result: any = competitionEngine.getMatchUpDailyLimits();
+  if (result?.error) return undefined;
+  return result?.matchUpDailyLimits;
+}
+
+/** Rest for one matchUp, resolved against current factory state and the current clock. */
+export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
+  const { matchUps } = getCachedAllMatchUps();
+  const timingFor = makeTimingResolver();
+  return analyzeParticipantRest({
+    matchUpId,
+    matchUps: (matchUps ?? []) as ReadinessMatchUp[],
+    scheduledDate: viewedDate ?? '',
+    asOfMinutes: nowDayMinutes(),
+    timesFor: (matchUp) => normalizeTimes(matchUp, viewedDate),
+    dailyLimits: readDailyLimits(),
+    timingFor,
+  });
+}
+
+/** `134` → `'2h 14m'`; under an hour drops the hours part entirely. */
+export function formatDuration(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  if (!hours) return t('schedule.inspector.rest.minutesOnly', { minutes: remainder });
+  return t('schedule.inspector.rest.hoursMinutes', { hours, minutes: remainder });
+}
+
+/** The provenance suffix for a row — which rung of the ladder produced its anchor. */
+export function describeSource(row: RestRow): string {
+  if (!row.source) return '';
+  return t(`schedule.inspector.rest.source.${row.source}`);
+}
+
+/** The rest figure itself, as a sentence fragment. */
+export function describeRest(row: RestRow): string {
+  if (row.status === 'none') return t('schedule.inspector.rest.noPriorMatch');
+  if (row.status === 'onCourt') {
+    return row.readyAt
+      ? t('schedule.inspector.rest.onCourtUntil', { time: row.readyAt })
+      : t('schedule.inspector.rest.onCourt');
+  }
+  const rested = formatDuration(row.restMinutes ?? 0);
+  const required = formatDuration(row.requiredMinutes);
+  if (row.status === 'rested') return t('schedule.inspector.rest.rested', { rested, required });
+  return t('schedule.inspector.rest.resting', { rested, required, time: row.readyAt ?? '' });
+}
+
+/** The daily-load fragment: "3rd match today, limit 3". */
+export function describeLoad(row: RestRow): string {
+  const { ordinal, limit } = row.load;
+  return limit === undefined
+    ? t('schedule.inspector.rest.ordinal', { ordinal })
+    : t('schedule.inspector.rest.ordinalLimit', { ordinal, limit });
+}
+
+function line(text: string, className: string): HTMLElement {
+  const element = document.createElement('div');
+  element.className = className;
+  element.textContent = text;
+  return element;
+}
+
+function buildRow(row: RestRow): HTMLElement {
+  const element = document.createElement('div');
+  element.className = `tmx-rest-row is-${row.status.toLowerCase()}`;
+  element.dataset.status = row.status;
+  element.dataset.participantId = row.participantId;
+
+  element.appendChild(line(row.participantName, 'tmx-rest-name'));
+  element.appendChild(line(describeRest(row), 'tmx-rest-figure'));
+
+  const detail = document.createElement('div');
+  detail.className = 'tmx-rest-detail';
+  const parts = [describeLoad(row), row.typeChange ? t('schedule.inspector.rest.typeChange') : '', describeSource(row)];
+  detail.textContent = parts.filter(Boolean).join(' · ');
+  element.appendChild(detail);
+
+  if (row.load.atLimit.length) {
+    element.dataset.atLimit = row.load.atLimit.join(',');
+    element.appendChild(line(t('schedule.inspector.rest.atLimit'), 'tmx-rest-limit'));
+  }
+  // A row whose anchor was inferred rather than recorded must say so structurally,
+  // not only in prose, so the distinction survives styling and screen readers.
+  if (row.source && row.source !== 'endTime') element.dataset.estimated = 'true';
+  if (row.fromMatchUpLabel) element.title = row.fromMatchUpLabel;
+  return element;
+}
+
+function skipMessage(reason: string): string {
+  const key = `schedule.inspector.rest.skip.${reason}`;
+  const message = t(key);
+  // `t()` echoes the key when it resolves to nothing; fall back to the generic
+  // line rather than printing a dotted path at the operator.
+  return message === key ? t('schedule.inspector.rest.skip.generic') : message;
+}
+
+/** Fill a section element with the current rest picture. Called on first render and on every tick. */
+function paint(section: HTMLElement, matchUpId: string, viewedDate: string | null): void {
+  section.replaceChildren();
+  const result = evaluateRest(matchUpId, viewedDate);
+
+  section.dataset.rest = result.evaluated ? String(result.rows.length) : 'skipped';
+  section.appendChild(line(t('schedule.inspector.rest.heading'), 'tmx-rest-heading'));
+
+  if (!result.evaluated) {
+    section.appendChild(line(skipMessage(result.reason), 'tmx-rest-skip'));
+    return;
+  }
+
+  for (const row of result.rows) section.appendChild(buildRow(row));
+}
+
+// ── Live refresh ──────────────────────────────────────────────────────────
+// Rest counts up, so a static render goes stale the moment it is drawn. One
+// module-level interval drives whichever section is currently mounted; it stops
+// itself when that element leaves the document, which is what makes this safe
+// against the Inspector rebuilding its body on every state change and against
+// the schedule tab unmounting without telling us.
+
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+let mounted: { section: HTMLElement; matchUpId: string; viewedDate: string | null } | null = null;
+
+function stopTicker(): void {
+  if (tickHandle) clearInterval(tickHandle);
+  tickHandle = null;
+  mounted = null;
+}
+
+function tick(): void {
+  if (!mounted?.section.isConnected) {
+    stopTicker();
+    return;
+  }
+  paint(mounted.section, mounted.matchUpId, mounted.viewedDate);
+}
+
+/**
+ * The rest section for one matchUp. Returns a fresh element per call — the
+ * Inspector rebuilds its body on every state change, so a cached node would be
+ * re-parented rather than reused.
+ */
+export function renderRestSection(matchUpId: string, viewedDate: string | null): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const section = document.createElement('div');
+  section.className = 'tmx-rest';
+  paint(section, matchUpId, viewedDate);
+
+  mounted = { section, matchUpId, viewedDate };
+  tickHandle ??= setInterval(tick, REFRESH_MS);
+  return section;
+}

--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
@@ -76,7 +76,16 @@ export interface ReadinessSchedule {
   scheduledDate?: string;
   scheduledTime?: string;
   courtId?: string;
+  /** Bare `HH:MM`, venue-local. Written only by an explicit operator action. */
   endTime?: string;
+  /** Sparse: the calendar day the END_TIME fell on when the match crossed midnight. */
+  endDate?: string;
+  /** Bare `HH:MM`, venue-local. Written by start-on-drop and the manual start action. */
+  startTime?: string;
+  /** Full ISO instant, UTC. Stamped when the matchUp is called to court. */
+  calledAt?: string;
+  /** Full ISO instant, UTC. Auto-captured by the factory on first meaningful score. */
+  scoredTime?: string;
 }
 
 export interface ReadinessTiming {
@@ -283,7 +292,7 @@ type ParticipantClash = {
 };
 
 /** Name for a participantId, taken from whichever matchUp side carries it. */
-function nameFor(participantId: string, matchUps: ReadinessMatchUp[]): string {
+export function nameFor(participantId: string, matchUps: ReadinessMatchUp[]): string {
   for (const matchUp of matchUps) {
     for (const side of matchUp.sides ?? []) {
       if ((side.participantId ?? side.participant?.participantId) === participantId) return sideLabel(side);

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
@@ -1,0 +1,370 @@
+import { analyzeParticipantRest, resolveAnchor } from './participantRest';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import type { NormalizedTimes, RestInput, RestTiming } from './participantRest';
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+const DATE = '2026-08-22';
+const ALICE = 'p-alice';
+const BOB = 'p-bob';
+const CHEN = 'p-chen';
+
+const TIMING: RestTiming = { averageMinutes: 90, recoveryMinutes: 60, typeChangeRecoveryMinutes: 30 };
+const NOT_EVALUATED = 'expected evaluation';
+
+/** Narrow an evaluated result, failing loudly rather than silently skipping assertions. */
+function evaluated(result: ReturnType<typeof analyzeParticipantRest>) {
+  if (!result.evaluated) throw new Error(NOT_EVALUATED);
+  return result;
+}
+
+function singles(params: {
+  id: string;
+  ids: string[];
+  names?: string[];
+  status?: string;
+  winningSide?: number;
+  scheduledTime?: string;
+  matchUpType?: string;
+  roundName?: string;
+}): ReadinessMatchUp {
+  const names = params.names ?? params.ids;
+  return {
+    matchUpId: params.id,
+    matchUpStatus: params.status,
+    matchUpType: params.matchUpType ?? 'SINGLES',
+    roundName: params.roundName,
+    winningSide: params.winningSide,
+    sides: params.ids.map((participantId, i) => ({ participantId, participantName: names[i] })),
+    schedule: { scheduledDate: DATE, scheduledTime: params.scheduledTime },
+  };
+}
+
+/** Build an input whose `timesFor` reads from an explicit per-matchUp table. */
+function buildInput(params: {
+  matchUpId: string;
+  matchUps: ReadinessMatchUp[];
+  times: Record<string, NormalizedTimes>;
+  asOfMinutes: number;
+  timing?: Record<string, RestTiming>;
+  dailyLimits?: RestInput['dailyLimits'];
+}): RestInput {
+  return {
+    matchUpId: params.matchUpId,
+    matchUps: params.matchUps,
+    scheduledDate: DATE,
+    asOfMinutes: params.asOfMinutes,
+    timingFor: (matchUp) => params.timing?.[matchUp.matchUpId] ?? TIMING,
+    timesFor: (matchUp) => params.times[matchUp.matchUpId] ?? {},
+    dailyLimits: params.dailyLimits,
+  };
+}
+
+describe('resolveAnchor — the precedence ladder', () => {
+  it('prefers endTime over every other rung', () => {
+    const times: NormalizedTimes = { endMinutes: 720, scoredMinutes: 740, startMinutes: 600, scheduledMinutes: 590 };
+    expect(resolveAnchor(times, TIMING)).toEqual({ minutes: 720, source: 'endTime' });
+  });
+
+  it('falls back to scoredTime when endTime is absent — the common path', () => {
+    const times: NormalizedTimes = { scoredMinutes: 740, startMinutes: 600, scheduledMinutes: 590 };
+    expect(resolveAnchor(times, TIMING)).toEqual({ minutes: 740, source: 'scoredTime' });
+  });
+
+  it('projects from startTime by averageMinutes when no finish was recorded', () => {
+    expect(resolveAnchor({ startMinutes: 600 }, TIMING)).toEqual({ minutes: 690, source: 'startTime' });
+  });
+
+  it('projects from calledAt, then from scheduledTime, in that order', () => {
+    expect(resolveAnchor({ calledMinutes: 600, scheduledMinutes: 540 }, TIMING)).toEqual({
+      minutes: 690,
+      source: 'calledAt',
+    });
+    expect(resolveAnchor({ scheduledMinutes: 540 }, TIMING)).toEqual({ minutes: 630, source: 'scheduledTime' });
+  });
+
+  it('returns undefined when the matchUp carries no time at all', () => {
+    expect(resolveAnchor({}, TIMING)).toBeUndefined();
+  });
+});
+
+describe('analyzeParticipantRest — skip reasons', () => {
+  const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+
+  it('skips an unknown matchUp', () => {
+    const input = buildInput({ matchUpId: 'nope', matchUps: [target], times: {}, asOfMinutes: 800 });
+    expect(analyzeParticipantRest(input)).toEqual({ evaluated: false, reason: 'unknownMatchUp' });
+  });
+
+  it('skips a BYE and skips a completed matchUp', () => {
+    const bye = singles({ id: 'm2', ids: [ALICE], status: 'BYE' });
+    const done = singles({ id: 'm2', ids: [ALICE, BOB], winningSide: 1 });
+    for (const [matchUp, reason] of [
+      [bye, 'bye'],
+      [done, 'completed'],
+    ] as const) {
+      const input = buildInput({ matchUpId: 'm2', matchUps: [matchUp], times: {}, asOfMinutes: 800 });
+      expect(analyzeParticipantRest(input)).toEqual({ evaluated: false, reason });
+    }
+  });
+
+  it('skips when no participant is assigned yet', () => {
+    const empty: ReadinessMatchUp = { matchUpId: 'm2', sides: [{}, {}], schedule: { scheduledDate: DATE } };
+    const input = buildInput({ matchUpId: 'm2', matchUps: [empty], times: {}, asOfMinutes: 800 });
+    expect(analyzeParticipantRest(input)).toEqual({ evaluated: false, reason: 'noParticipants' });
+  });
+
+  it('EVALUATES an unscheduled matchUp — the case readiness skips', () => {
+    const unscheduled: ReadinessMatchUp = {
+      matchUpId: 'm2',
+      matchUpType: 'SINGLES',
+      sides: [{ participantId: ALICE }, { participantId: BOB }],
+      schedule: null,
+    };
+    const input = buildInput({ matchUpId: 'm2', matchUps: [unscheduled], times: {}, asOfMinutes: 800 });
+    const result = analyzeParticipantRest(input);
+    expect(result.evaluated).toBe(true);
+  });
+});
+
+describe('analyzeParticipantRest — rest arithmetic', () => {
+  it('measures rest from endTime and reports the source', () => {
+    const prior = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1, roundName: 'R32' });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [prior, target],
+      times: { m1: { endMinutes: 726 } }, // 12:06
+      asOfMinutes: 860, // 14:20
+    });
+
+    const result = evaluated(analyzeParticipantRest(input));
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({
+      status: 'rested',
+      restMinutes: 134,
+      requiredMinutes: 60,
+      source: 'endTime',
+      fromMatchUpId: 'm1',
+      fromMatchUpLabel: 'R32: p-alice vs p-chen',
+    });
+    expect(alice?.readyAt).toBeUndefined();
+  });
+
+  it('reports resting with a readyAt when the requirement is not yet met', () => {
+    const prior = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1 });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [prior, target],
+      times: { m1: { scoredMinutes: 828 } }, // 13:48
+      asOfMinutes: 860, // 14:20
+    });
+
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      status: 'resting',
+      restMinutes: 32,
+      requiredMinutes: 60,
+      readyAt: '14:48',
+      source: 'scoredTime',
+    });
+  });
+
+  it('reports "none" for a participant with no prior match today', () => {
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({ matchUpId: 'm2', matchUps: [target], times: {}, asOfMinutes: 860 });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.every((row) => row.status === 'none')).toBe(true);
+    expect(result.rows[0].restMinutes).toBeUndefined();
+    expect(result.rows[0].source).toBeUndefined();
+  });
+
+  it('ignores a prior match on a different day', () => {
+    const prior = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1 });
+    prior.schedule = { scheduledDate: '2026-08-21' };
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [prior, target],
+      times: { m1: { endMinutes: 726 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)?.status).toBe('none');
+  });
+
+  it('measures from the MOST RECENT of several prior matches', () => {
+    const early = singles({ id: 'm0', ids: [ALICE, BOB], winningSide: 1 });
+    const late = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1 });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [early, late, target],
+      times: { m0: { endMinutes: 600 }, m1: { endMinutes: 726 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      restMinutes: 134,
+      fromMatchUpId: 'm1',
+    });
+  });
+});
+
+describe('analyzeParticipantRest — on court', () => {
+  it('reports onCourt with no rest figure when the prior match is still running', () => {
+    const live = singles({ id: 'm1', ids: [ALICE, CHEN], status: 'IN_PROGRESS', roundName: 'R16' });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [live, target],
+      times: { m1: { startMinutes: 810 } }, // 13:30, avg 90 → runs to 15:00
+      asOfMinutes: 860, // 14:20
+    });
+
+    const result = evaluated(analyzeParticipantRest(input));
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'onCourt', readyAt: '16:00', fromMatchUpLabel: 'R16: p-alice vs p-chen' });
+    expect(alice?.restMinutes).toBeUndefined();
+  });
+
+  it('orders rows worst-first: onCourt, resting, rested, none', () => {
+    const liveForAlice = singles({ id: 'm1', ids: [ALICE, 'x'], status: 'IN_PROGRESS' });
+    const restingForBob = singles({ id: 'm2', ids: [BOB, 'y'], winningSide: 1 });
+    const restedForChen = singles({ id: 'm3', ids: [CHEN, 'z'], winningSide: 1 });
+    const target: ReadinessMatchUp = {
+      matchUpId: 'm4',
+      matchUpType: 'DOUBLES',
+      sides: [
+        { participantId: 'pairA', participant: { individualParticipantIds: [ALICE, BOB] } },
+        { participantId: 'pairB', participant: { individualParticipantIds: [CHEN, 'p-dana'] } },
+      ],
+      schedule: { scheduledDate: DATE },
+    };
+    const input = buildInput({
+      matchUpId: 'm4',
+      matchUps: [liveForAlice, restingForBob, restedForChen, target],
+      times: { m1: { startMinutes: 810 }, m2: { endMinutes: 840 }, m3: { endMinutes: 600 } },
+      asOfMinutes: 860,
+      // Same-type recovery so the DOUBLES target doesn't pull the type-change figure.
+      timing: { m1: TIMING, m2: TIMING, m3: TIMING },
+    });
+
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.map((row) => row.status)).toEqual(['onCourt', 'resting', 'rested', 'none']);
+  });
+});
+
+describe('analyzeParticipantRest — type-change recovery', () => {
+  it('uses typeChangeRecoveryMinutes when the participant switches singles → doubles', () => {
+    const prior = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1, matchUpType: 'SINGLES' });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB], matchUpType: 'DOUBLES' });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [prior, target],
+      times: { m1: { endMinutes: 820 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      requiredMinutes: 30,
+      typeChange: true,
+      status: 'rested',
+    });
+  });
+
+  it('keeps the plain recovery figure when the type is unchanged', () => {
+    const prior = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1 });
+    const target = singles({ id: 'm2', ids: [ALICE, BOB] });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [prior, target],
+      times: { m1: { endMinutes: 820 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      requiredMinutes: 60,
+      typeChange: false,
+      status: 'resting',
+    });
+  });
+});
+
+describe('analyzeParticipantRest — daily load', () => {
+  const priorA = singles({ id: 'm1', ids: [ALICE, CHEN], winningSide: 1 });
+  const priorB = singles({ id: 'm0', ids: [ALICE, BOB], winningSide: 1 });
+  const target = singles({ id: 'm2', ids: [ALICE, 'p-dana'] });
+
+  it('counts begun matches and reports the ordinal the inspected matchUp would take', () => {
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [priorA, priorB, target],
+      times: { m0: { endMinutes: 600 }, m1: { endMinutes: 726 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({
+      singles: 2,
+      doubles: 0,
+      total: 2,
+      ordinal: 3,
+      atLimit: [],
+    });
+  });
+
+  it('flags the total limit when the inspected matchUp reaches it', () => {
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [priorA, priorB, target],
+      times: { m0: { endMinutes: 600 }, m1: { endMinutes: 726 } },
+      asOfMinutes: 860,
+      dailyLimits: { SINGLES: 2, DOUBLES: 2, total: 3 },
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({
+      ordinal: 3,
+      atLimit: ['total', 'singles'],
+      limit: 3,
+    });
+  });
+
+  it('reports no limits at all when none are configured — never substitutes a default', () => {
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [priorA, priorB, target],
+      times: { m0: { endMinutes: 600 }, m1: { endMinutes: 726 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    const load = result.rows.find((row) => row.participantId === ALICE)?.load;
+    expect(load?.atLimit).toEqual([]);
+    expect(load?.limit).toBeUndefined();
+  });
+
+  it('counts a match that is under way, not just finished ones', () => {
+    const live = singles({ id: 'm1', ids: [ALICE, CHEN], status: 'IN_PROGRESS' });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [live, target],
+      times: { m1: { startMinutes: 810 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({ total: 1, ordinal: 2 });
+  });
+
+  it('does NOT count a match that has not started yet', () => {
+    const later = singles({ id: 'm1', ids: [ALICE, CHEN], scheduledTime: '18:00' });
+    const input = buildInput({
+      matchUpId: 'm2',
+      matchUps: [later, target],
+      times: { m1: { scheduledMinutes: 1080 } },
+      asOfMinutes: 860,
+    });
+    const result = evaluated(analyzeParticipantRest(input));
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({ total: 0, ordinal: 1 });
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -1,0 +1,354 @@
+/**
+ * Schedule2 — participant rest analysis (pure, DOM-free, engine-free, clock-free).
+ *
+ * Answers the question a tournament director actually asks before calling a
+ * match to court: *for each individual in this matchUp, how long have they
+ * actually had off, and is that enough?*
+ *
+ * Deliberately NOT the same question as `matchUpReadiness.ts`. Readiness asks
+ * "can this placement happen at the time it is scheduled for", so it is anchored
+ * on the target's `scheduledTime` and skips entirely when there isn't one. Rest
+ * is anchored on **now**, so it answers for a matchUp still sitting in the
+ * catalog — which is exactly the moment the director is deciding whether to drag
+ * it onto the Now strip.
+ *
+ * ── Time representation: read this before changing anything ──
+ *
+ * This module handles NO time conversion. Every instant reaches it as
+ * `minutes since midnight of the day being viewed`, via the injected `timesFor`
+ * callback. That is not squeamishness — the underlying values are in three
+ * different frames:
+ *
+ *   - `endTime` / `startTime`  bare `HH:MM`, venue-local wall clock
+ *   - `calledAt` / `scoredTime` full ISO instants, UTC
+ *   - "now"                     the operator's browser clock
+ *
+ * Mixing those without an explicit conversion yields a rest figure wrong by the
+ * UTC offset, which is worse than showing nothing. Isolating the conversion in
+ * ONE named function in the adapter also means the planned Temporal-spec
+ * standardization has a single site to change rather than a scatter of
+ * `new Date()` calls.
+ *
+ * ── The precedence ladder ──
+ *
+ * "When did this participant's previous match end" has five answers of
+ * decreasing fidelity. Every row reports which one it used, so an inferred
+ * number never reads as a measured one:
+ *
+ *   1. `endTime`       operator recorded the actual finish        — measured
+ *   2. `scoredTime`    when the score was entered                 — proxy
+ *   3. `startTime`     + averageMinutes, match started            — projected
+ *   4. `calledAt`      + averageMinutes, called to court          — projected
+ *   5. `scheduledTime` + averageMinutes, plan only                — planned
+ *
+ * Rung 2 is the common path, not the exception: TMX writes `END_TIME` only on an
+ * explicit operator action, while the factory auto-captures `scoredTime` on
+ * every first score. A late-entered score pushes `scoredTime` *after* the true
+ * finish, so rest is understated — the conservative direction, since it holds a
+ * rested player back rather than calling a tired one.
+ *
+ * `RestInput` → `RestResult` is the seam, matching `matchUpReadiness.ts`: a
+ * future factory `getParticipantRest` replaces this body and keeps the contract.
+ * The factory is pure and has no clock, so it would take the same injected
+ * `asOfMinutes` — the `calledAt` idiom of a caller-supplied wall clock.
+ */
+
+import { individualIds, isFinished, matchUpLabel, minutesToClock, nameFor } from './matchUpReadiness';
+
+// constants and types
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+/** Which rung of the ladder produced a participant's rest anchor. */
+export type RestSourceKind = 'endTime' | 'scoredTime' | 'startTime' | 'calledAt' | 'scheduledTime';
+
+/** How much of the required recovery a participant has actually had. */
+export type RestStatus = 'onCourt' | 'resting' | 'rested' | 'none';
+
+/** True only for the rung the operator recorded directly; everything else is inferred. */
+export const MEASURED_SOURCE: RestSourceKind = 'endTime';
+
+/**
+ * One matchUp's times, already normalized to minutes from midnight of the day
+ * being viewed. Values may exceed 1440 (finished after midnight) or go negative
+ * (started the previous day); the caller owns that arithmetic.
+ */
+export interface NormalizedTimes {
+  endMinutes?: number;
+  scoredMinutes?: number;
+  startMinutes?: number;
+  calledMinutes?: number;
+  scheduledMinutes?: number;
+}
+
+export interface RestTiming {
+  averageMinutes: number;
+  recoveryMinutes: number;
+  /** Recovery required when the participant changes matchUpType (singles ↔ doubles). */
+  typeChangeRecoveryMinutes?: number;
+}
+
+/** Daily match limits, as the factory reports them. Any subset may be absent. */
+export interface RestDailyLimits {
+  SINGLES?: number;
+  DOUBLES?: number;
+  total?: number;
+}
+
+export interface RestInput {
+  /** The matchUp being inspected. Need not be scheduled. */
+  matchUpId: string;
+  /** Every matchUp in the tournament, hydrated `{ inContext: true, nextMatchUps: true }`. */
+  matchUps: ReadinessMatchUp[];
+  /** The calendar day being viewed, `YYYY-MM-DD`. Rest is scoped to this day. */
+  scheduledDate: string;
+  /** "Now", as minutes from midnight of `scheduledDate`. */
+  asOfMinutes: number;
+  /** Engine-backed timing resolution. Returning zeroes disables the arithmetic without breaking it. */
+  timingFor: (matchUp: ReadinessMatchUp) => RestTiming;
+  /** Engine-backed time normalization. See the time-representation note above. */
+  timesFor: (matchUp: ReadinessMatchUp) => NormalizedTimes;
+  /** Tournament daily limits. Absent when no scheduling policy is attached — do NOT substitute a default. */
+  dailyLimits?: RestDailyLimits;
+}
+
+/** How many matches a participant has already begun today, and against which limits. */
+export interface RestDailyLoad {
+  singles: number;
+  doubles: number;
+  total: number;
+  /** Position the inspected matchUp would take, e.g. `3` for "3rd match today". */
+  ordinal: number;
+  /** Limits this matchUp would meet or exceed. Empty when no limits are configured. */
+  atLimit: ('singles' | 'doubles' | 'total')[];
+  /** The limit figure the ordinal should be read against, when one applies. */
+  limit?: number;
+}
+
+export interface RestRow {
+  participantId: string;
+  participantName: string;
+  status: RestStatus;
+  /** Minutes rested so far. Absent for `onCourt` and `none`. */
+  restMinutes?: number;
+  /** Recovery this participant owes before the inspected matchUp. */
+  requiredMinutes: number;
+  /** True when `requiredMinutes` came from the singles ↔ doubles figure. */
+  typeChange: boolean;
+  /** Clock time the requirement is met, `HH:MM`. Absent when already met or unprojectable. */
+  readyAt?: string;
+  /** Which rung produced the anchor. Absent for `none`. */
+  source?: RestSourceKind;
+  /** The matchUp the rest is measured from. Absent for `none`. */
+  fromMatchUpId?: string;
+  fromMatchUpLabel?: string;
+  load: RestDailyLoad;
+}
+
+/** Why rest could not be evaluated. Never reported as "rested" — an unevaluated matchUp is not a clean one. */
+export type RestSkipReason = 'unknownMatchUp' | 'bye' | 'completed' | 'noParticipants';
+
+export type RestResult =
+  { evaluated: false; reason: RestSkipReason } | { evaluated: true; asOfMinutes: number; rows: RestRow[] };
+
+const BYE = 'BYE';
+const DOUBLES = 'DOUBLES';
+const SINGLES = 'SINGLES';
+
+/** The ladder, strongest first. Order is the contract; the renderer reports which rung won. */
+const LADDER: { source: RestSourceKind; read: (times: NormalizedTimes) => number | undefined; projected: boolean }[] = [
+  { source: 'endTime', read: (t) => t.endMinutes, projected: false },
+  { source: 'scoredTime', read: (t) => t.scoredMinutes, projected: false },
+  { source: 'startTime', read: (t) => t.startMinutes, projected: true },
+  { source: 'calledAt', read: (t) => t.calledMinutes, projected: true },
+  { source: 'scheduledTime', read: (t) => t.scheduledMinutes, projected: true },
+];
+
+interface Anchor {
+  minutes: number;
+  source: RestSourceKind;
+}
+
+/**
+ * When the participant coming out of `matchUp` became free, in minutes.
+ * Walks the ladder strongest-first; projected rungs add `averageMinutes`
+ * because they mark a start rather than a finish.
+ */
+export function resolveAnchor(times: NormalizedTimes, timing: RestTiming): Anchor | undefined {
+  for (const rung of LADDER) {
+    const minutes = rung.read(times);
+    if (minutes === undefined) continue;
+    return { minutes: rung.projected ? minutes + timing.averageMinutes : minutes, source: rung.source };
+  }
+  return undefined;
+}
+
+/** True when the matchUp is under way at `asOfMinutes` — started (or due) and not yet finished. */
+function isUnderWay(matchUp: ReadinessMatchUp, times: NormalizedTimes, timing: RestTiming, asOfMinutes: number) {
+  if (isFinished(matchUp)) return false;
+  const start = times.startMinutes ?? times.calledMinutes ?? times.scheduledMinutes;
+  if (start === undefined || start > asOfMinutes) return false;
+  return asOfMinutes < start + Math.max(timing.averageMinutes, 1);
+}
+
+/** Recovery owed after `prior`, accounting for a singles ↔ doubles change into `target`. */
+function requirementFor(
+  prior: ReadinessMatchUp,
+  target: ReadinessMatchUp,
+  timing: RestTiming,
+): { requiredMinutes: number; typeChange: boolean } {
+  const changed = !!prior.matchUpType && !!target.matchUpType && prior.matchUpType !== target.matchUpType;
+  const typeChangeMinutes = timing.typeChangeRecoveryMinutes ?? 0;
+  if (changed && typeChangeMinutes > 0) return { requiredMinutes: typeChangeMinutes, typeChange: true };
+  return { requiredMinutes: timing.recoveryMinutes, typeChange: false };
+}
+
+/** A same-day matchUp already under way or finished, resolved once and reused across participants. */
+interface PriorMatchUp {
+  matchUp: ReadinessMatchUp;
+  times: NormalizedTimes;
+  timing: RestTiming;
+  underWay: boolean;
+  individuals: Set<string>;
+}
+
+/**
+ * The matchUps on the viewed day that have already begun — finished or currently
+ * under way. A match that has not started yet is not load the director has
+ * already spent, so it is excluded; readiness reports those as `overlap` /
+ * `dependency` instead.
+ *
+ * Resolved once per analysis rather than per participant: `timesFor` and
+ * `timingFor` reach the engine, and a doubles matchUp would otherwise pay for
+ * both of them four times over.
+ */
+function collectPriorMatchUps(target: ReadinessMatchUp, input: RestInput): PriorMatchUp[] {
+  const results: PriorMatchUp[] = [];
+
+  for (const matchUp of input.matchUps) {
+    if (matchUp.matchUpId === target.matchUpId) continue;
+    if (matchUp.matchUpStatus === BYE) continue;
+    if (matchUp.schedule?.scheduledDate !== input.scheduledDate) continue;
+
+    const times = input.timesFor(matchUp);
+    const timing = input.timingFor(matchUp);
+    const underWay = isUnderWay(matchUp, times, timing, input.asOfMinutes);
+    if (!isFinished(matchUp) && !underWay) continue;
+    results.push({ matchUp, times, timing, underWay, individuals: new Set(individualIds(matchUp)) });
+  }
+  return results;
+}
+
+/** Daily load for one participant, and which configured limits the inspected matchUp would hit. */
+function loadFor(prior: PriorMatchUp[], target: ReadinessMatchUp, limits: RestDailyLimits | undefined): RestDailyLoad {
+  const singles = prior.filter((entry) => entry.matchUp.matchUpType === SINGLES).length;
+  const doubles = prior.filter((entry) => entry.matchUp.matchUpType === DOUBLES).length;
+  const total = prior.length;
+  const ordinal = total + 1;
+
+  const atLimit: ('singles' | 'doubles' | 'total')[] = [];
+  let limit: number | undefined;
+
+  if (limits?.total !== undefined && ordinal >= limits.total) {
+    atLimit.push('total');
+    limit = limits.total;
+  }
+  if (target.matchUpType === SINGLES && limits?.SINGLES !== undefined && singles + 1 >= limits.SINGLES) {
+    atLimit.push('singles');
+    limit ??= limits.SINGLES;
+  }
+  if (target.matchUpType === DOUBLES && limits?.DOUBLES !== undefined && doubles + 1 >= limits.DOUBLES) {
+    atLimit.push('doubles');
+    limit ??= limits.DOUBLES;
+  }
+
+  return { singles, doubles, total, ordinal, atLimit, limit };
+}
+
+/** The most recent anchor across a participant's prior matchUps — "the last one that finished". */
+function latestAnchor(
+  prior: PriorMatchUp[],
+): { anchor: Anchor; matchUp: ReadinessMatchUp; timing: RestTiming } | undefined {
+  let best: { anchor: Anchor; matchUp: ReadinessMatchUp; timing: RestTiming } | undefined;
+  for (const entry of prior) {
+    const anchor = resolveAnchor(entry.times, entry.timing);
+    if (!anchor) continue;
+    if (!best || anchor.minutes > best.anchor.minutes) best = { anchor, matchUp: entry.matchUp, timing: entry.timing };
+  }
+  return best;
+}
+
+function restRowFor(
+  participantId: string,
+  target: ReadinessMatchUp,
+  input: RestInput,
+  dayMatchUps: PriorMatchUp[],
+): RestRow {
+  const participantName = nameFor(participantId, input.matchUps);
+  const prior = dayMatchUps.filter((entry) => entry.individuals.has(participantId));
+  const load = loadFor(prior, target, input.dailyLimits);
+
+  // Still on court dominates every other reading: rest has not started, so a
+  // minutes figure would be a fiction. Report the projected finish instead.
+  const live = prior.find((entry) => entry.underWay);
+  if (live) {
+    const { requiredMinutes, typeChange } = requirementFor(live.matchUp, target, live.timing);
+    const anchor = resolveAnchor(live.times, live.timing);
+    return {
+      participantId,
+      participantName,
+      status: 'onCourt',
+      requiredMinutes,
+      typeChange,
+      ...(anchor && { readyAt: minutesToClock(anchor.minutes + requiredMinutes), source: anchor.source }),
+      fromMatchUpId: live.matchUp.matchUpId,
+      fromMatchUpLabel: matchUpLabel(live.matchUp),
+      load,
+    };
+  }
+
+  const latest = latestAnchor(prior);
+  if (!latest) {
+    return { participantId, participantName, status: 'none', requiredMinutes: 0, typeChange: false, load };
+  }
+
+  const { requiredMinutes, typeChange } = requirementFor(latest.matchUp, target, latest.timing);
+  const restMinutes = Math.max(0, input.asOfMinutes - latest.anchor.minutes);
+  const rested = restMinutes >= requiredMinutes;
+
+  return {
+    participantId,
+    participantName,
+    status: rested ? 'rested' : 'resting',
+    restMinutes,
+    requiredMinutes,
+    typeChange,
+    ...(!rested && { readyAt: minutesToClock(latest.anchor.minutes + requiredMinutes) }),
+    source: latest.anchor.source,
+    fromMatchUpId: latest.matchUp.matchUpId,
+    fromMatchUpLabel: matchUpLabel(latest.matchUp),
+    load,
+  };
+}
+
+/**
+ * Rest for every individual in one matchUp. Rows are ordered worst-first
+ * (`onCourt` → `resting` → `rested` → `none`) so a renderer can take the head as
+ * the headline without re-deciding severity.
+ */
+export function analyzeParticipantRest(input: RestInput): RestResult {
+  const target = input.matchUps.find((matchUp) => matchUp.matchUpId === input.matchUpId);
+  if (!target) return { evaluated: false, reason: 'unknownMatchUp' };
+  if (target.matchUpStatus === BYE) return { evaluated: false, reason: 'bye' };
+  if (isFinished(target)) return { evaluated: false, reason: 'completed' };
+
+  const participantIds = individualIds(target);
+  if (!participantIds.length) return { evaluated: false, reason: 'noParticipants' };
+
+  const dayMatchUps = collectPriorMatchUps(target, input);
+  const order: RestStatus[] = ['onCourt', 'resting', 'rested', 'none'];
+  const rows = participantIds
+    .map((participantId) => restRowFor(participantId, target, input, dayMatchUps))
+    .toSorted((a, b) => order.indexOf(a.status) - order.indexOf(b.status));
+
+  return { evaluated: true, asOfMinutes: input.asOfMinutes, rows };
+}

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
@@ -1,0 +1,107 @@
+import { badgeText, badgeTooltip, headlineRow, shouldRender } from './restBadge';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import type { RestResult, RestRow } from './participantRest';
+
+const LOAD = { singles: 1, doubles: 0, total: 1, ordinal: 2, atLimit: [] };
+
+function row(overrides: Partial<RestRow>): RestRow {
+  return {
+    participantId: 'p1',
+    participantName: 'Alice',
+    status: 'rested',
+    requiredMinutes: 60,
+    typeChange: false,
+    load: LOAD,
+    ...overrides,
+  } as RestRow;
+}
+
+describe('headlineRow — worst status decides the badge', () => {
+  it('prefers onCourt over everything', () => {
+    const rows = [row({ status: 'rested' }), row({ status: 'onCourt' }), row({ status: 'resting' })];
+    expect(headlineRow(rows)?.status).toBe('onCourt');
+  });
+
+  it('prefers resting over rested and none', () => {
+    expect(headlineRow([row({ status: 'none' }), row({ status: 'rested' }), row({ status: 'resting' })])?.status).toBe(
+      'resting',
+    );
+  });
+
+  it('falls through to rested, then none', () => {
+    expect(headlineRow([row({ status: 'none' }), row({ status: 'rested' })])?.status).toBe('rested');
+    expect(headlineRow([row({ status: 'none' })])?.status).toBe('none');
+  });
+
+  it('returns undefined for an empty set', () => {
+    expect(headlineRow([])).toBeUndefined();
+  });
+});
+
+describe('shouldRender — silence when there is nothing to say', () => {
+  const asResult = (rows: RestRow[]): RestResult => ({ evaluated: true, asOfMinutes: 860, rows });
+
+  it('does not badge a card where nobody has played today', () => {
+    expect(shouldRender(asResult([row({ status: 'none' }), row({ status: 'none', participantId: 'p2' })]))).toBe(false);
+  });
+
+  it('badges as soon as one participant has a prior match', () => {
+    expect(shouldRender(asResult([row({ status: 'none' }), row({ status: 'rested', participantId: 'p2' })]))).toBe(
+      true,
+    );
+  });
+
+  it('does not badge an unevaluated matchUp', () => {
+    expect(shouldRender({ evaluated: false, reason: 'bye' })).toBe(false);
+  });
+});
+
+describe('badgeText / badgeTooltip', () => {
+  it('reports a duration for resting and rested, and a word where a duration would be a fiction', () => {
+    expect(badgeText(row({ status: 'resting', restMinutes: 32 }))).toContain('32');
+    expect(badgeText(row({ status: 'rested', restMinutes: 134 }))).toContain('14');
+    // onCourt / none have no elapsed rest to report, so they must not render "0m".
+    expect(badgeText(row({ status: 'onCourt' }))).not.toMatch(/\d/);
+    expect(badgeText(row({ status: 'none' }))).not.toMatch(/\d/);
+  });
+
+  it('resolves its i18n keys — never leaks a dotted key path at the operator', () => {
+    // `t()` echoes the key when it resolves to nothing, and a key path contains
+    // no digits, so the duration assertions above cannot catch an unresolved
+    // key on the digit-free branches. This is the check that can.
+    const texts = [
+      badgeText(row({ status: 'onCourt' })),
+      badgeText(row({ status: 'none' })),
+      badgeText(row({ status: 'resting', restMinutes: 32 })),
+      badgeText(row({ status: 'rested', restMinutes: 134 })),
+      badgeTooltip([row({ status: 'onCourt' })]),
+      badgeTooltip([row({ status: 'none' })]),
+      badgeTooltip([row({ status: 'resting', restMinutes: 32 })]),
+    ];
+    for (const text of texts) {
+      expect(text).not.toMatch(/schedule\.[a-z]/i);
+      expect(text.trim()).not.toBe('');
+    }
+  });
+
+  it('interpolates every placeholder — no `{{name}}` reaches the operator', () => {
+    const tooltip = badgeTooltip([
+      row({ status: 'resting', restMinutes: 32 }),
+      row({ status: 'onCourt', participantId: 'p2', participantName: 'Bob' }),
+      row({ status: 'none', participantId: 'p3', participantName: 'Chen' }),
+    ]);
+    expect(tooltip).not.toContain('{{');
+  });
+
+  it('names every participant in the tooltip, not just the headline', () => {
+    const tooltip = badgeTooltip([
+      row({ status: 'resting', restMinutes: 32 }),
+      row({ status: 'rested', participantId: 'p2', participantName: 'Bob' }),
+    ]);
+    expect(tooltip).toContain('Alice');
+    expect(tooltip).toContain('Bob');
+    expect(tooltip.split('\n')).toHaveLength(2);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.ts
@@ -1,0 +1,104 @@
+/**
+ * Schedule2 — compact rest badge for catalog matchUp cards.
+ *
+ * The Inspector's Rest section answers the question in full, but it costs the
+ * operator a selection: they have to click a card to learn whether the players
+ * on it are rested. The decision the badge serves — *which of these do I call
+ * next?* — is made while scanning the catalog, before any card is selected and
+ * before the drag starts. So the headline goes on the card itself and the detail
+ * stays in the Inspector.
+ *
+ * Deliberately one line, worst-participant-only. A card carrying four rows of
+ * per-player detail stops being scannable, which is the only thing the catalog
+ * is for. `title` carries the per-player breakdown for a hover, and the
+ * Inspector carries it properly.
+ *
+ * Rendered through `renderCardExtra` (courthive-components ≥ the version that
+ * added it) rather than by post-processing `.spl-matchup-card`: the catalog
+ * rebuilds its cards on every state change, so an externally appended node
+ * would be wiped rather than reused.
+ */
+
+import { evaluateRest, formatDuration } from './inspectorRest';
+import { t } from 'i18n';
+
+// constants and types
+import type { RestResult, RestRow, RestStatus } from './participantRest';
+
+/** Worst-first; the first status present decides the badge. Mirrors the Inspector's row order. */
+const SEVERITY: RestStatus[] = ['onCourt', 'resting', 'rested', 'none'];
+
+/** The row that decides the badge — the worst status present. */
+export function headlineRow(rows: RestRow[]): RestRow | undefined {
+  for (const status of SEVERITY) {
+    const row = rows.find((candidate) => candidate.status === status);
+    if (row) return row;
+  }
+  return undefined;
+}
+
+/**
+ * Badge text for a headline row. Short enough to sit in a chip: the duration
+ * alone for a resting/rested player, a word for the states where a duration
+ * would be a fiction.
+ */
+export function badgeText(row: RestRow): string {
+  if (row.status === 'onCourt') return t('schedule.card.rest.onCourt');
+  if (row.status === 'none') return t('schedule.card.rest.none');
+  return formatDuration(row.restMinutes ?? 0);
+}
+
+/** Per-player breakdown for the hover, so the badge is not the only account available. */
+export function badgeTooltip(rows: RestRow[]): string {
+  return rows
+    .map((row) => {
+      if (row.status === 'onCourt') return t('schedule.card.rest.tooltipOnCourt', { name: row.participantName });
+      if (row.status === 'none') return t('schedule.card.rest.tooltipNone', { name: row.participantName });
+      return t('schedule.card.rest.tooltipRest', {
+        name: row.participantName,
+        rested: formatDuration(row.restMinutes ?? 0),
+        required: formatDuration(row.requiredMinutes),
+      });
+    })
+    .join('\n');
+}
+
+/**
+ * True when the badge is worth drawing at all. A card where nobody has played
+ * today carries no information — and that is most of the catalog on day one, so
+ * badging it would be pure noise.
+ */
+export function shouldRender(result: RestResult): boolean {
+  return result.evaluated && result.rows.some((row) => row.status !== 'none');
+}
+
+/**
+ * The `renderCardExtra` implementation. Returns a fresh element per call, or
+ * null when there is nothing worth saying.
+ */
+export function renderRestBadge(matchUpId: string, viewedDate: string | null): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const result = evaluateRest(matchUpId, viewedDate);
+  if (!shouldRender(result) || !result.evaluated) return null;
+
+  const row = headlineRow(result.rows);
+  if (!row) return null;
+
+  const badge = document.createElement('span');
+  badge.className = `tmx-rest-badge is-${row.status.toLowerCase()}`;
+  badge.dataset.restStatus = row.status;
+  badge.textContent = badgeText(row);
+  badge.title = badgeTooltip(result.rows);
+
+  // The daily-limit signal is the one thing a director must not miss while
+  // scanning, so it rides the badge rather than waiting for the Inspector.
+  if (row.load.atLimit.length) {
+    badge.dataset.atLimit = row.load.atLimit.join(',');
+    const limit = document.createElement('span');
+    limit.className = 'tmx-rest-badge-limit';
+    limit.textContent = t('schedule.card.rest.limit', { ordinal: row.load.ordinal });
+    badge.appendChild(limit);
+  }
+  return badge;
+}

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -8,6 +8,7 @@
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
+import { collectStartAllRestWarning, type StartAllRestWarning } from './startAllRestGuard';
 import { buildScheduleLockMethod, isScheduleLocked } from './scheduleLocks';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { getScheduleDateRange } from 'pages/tournament/tabs/scheduleUtils';
@@ -17,6 +18,7 @@ import { mutationRequest } from 'services/mutation/mutationRequest';
 import { closeModal, confirmModal, openModal } from 'components/modals/baseModal/baseModal';
 import { destroyTipster } from 'components/popovers/tipster';
 import { competitionEngine } from 'services/factory/engine';
+import { evaluateRest, formatDuration } from './inspectorRest';
 import { timePicker } from 'components/modals/timePicker';
 import { Datepicker } from 'vanillajs-datepicker';
 import tippy, { type Instance } from 'tippy.js';
@@ -777,6 +779,8 @@ export interface Schedule2NowContext {
    * Absent → reschedule falls back to a plain bulk set (court/row preserved).
    */
   buildDateGrid?: (date: string) => any;
+  /** The strip's date, `YYYY-MM-DD`. Scopes the rest guard to the day being viewed. */
+  scheduledDate?: string;
 }
 
 function nowCellLabel(cell: NowStripCell): string {
@@ -850,6 +854,28 @@ function buildRescheduleMethods(
   });
 }
 
+/** "Start all matches (4)", or "Start all matches (4) — 1 needs rest" when the guard has something to say. */
+export function startAllLabel(count: number, warning?: StartAllRestWarning): string {
+  const base = `${t('schedule.startAll')} (${count})`;
+  if (!warning) return base;
+  return `${base} \u2014 ${t('schedule.startAllRest.pill', { count: warning.affectedMatchUpIds.length })}`;
+}
+
+/** The confirm body: one line per player who is not ready, named, with the court they'd start on. */
+export function describeStartAllRestWarning(warning: StartAllRestWarning): string {
+  const lines = warning.blockers.map((blocker) => {
+    const where = blocker.courtName ? ` (${blocker.courtName})` : '';
+    if (blocker.onCourt) return t('schedule.startAllRest.onCourt', { name: blocker.participantName, where });
+    return t('schedule.startAllRest.resting', {
+      name: blocker.participantName,
+      rested: formatDuration(blocker.restMinutes ?? 0),
+      required: formatDuration(blocker.requiredMinutes),
+      where,
+    });
+  });
+  return [t('schedule.startAllRest.intro', { count: warning.affectedMatchUpIds.length }), ...lines].join('\n');
+}
+
 export function handleActiveStripNowClick(e: MouseEvent, ctx: Schedule2NowContext): void {
   const { cells, onRefresh, executeMethods, buildDateGrid } = ctx;
 
@@ -861,6 +887,10 @@ export function handleActiveStripNowClick(e: MouseEvent, ctx: Schedule2NowContex
 
   const startable = actionable.filter(
     (c) => c.matchUpStatus !== IN_PROGRESS && c.matchUpStatus !== SUSPENDED && c.participantIds.length >= 2,
+  );
+  const startAllWarning = collectStartAllRestWarning(
+    startable.map((c) => ({ matchUpId: c.matchUpId, courtName: c.courtName })),
+    (matchUpId) => evaluateRest(matchUpId, ctx.scheduledDate ?? null),
   );
   const suspendable = actionable.filter((c) => c.matchUpStatus !== SUSPENDED);
   const resumable = actionable.filter((c) => c.matchUpStatus === SUSPENDED);
@@ -876,8 +906,7 @@ export function handleActiveStripNowClick(e: MouseEvent, ctx: Schedule2NowContex
     );
   };
 
-  const startAll = () => {
-    if (!startable.length) return;
+  const commitStartAll = () => {
     const startTime = currentClockTime();
     executeMethods(
       [
@@ -892,6 +921,24 @@ export function handleActiveStripNowClick(e: MouseEvent, ctx: Schedule2NowContex
       ],
       onRefresh,
     );
+  };
+
+  // Rest guard: this is the one action that starts several matches at once with
+  // no card selected, so neither the Inspector nor the catalog badge has had a
+  // chance to warn. Ask — never block; a director overrides recovery
+  // deliberately often enough that a refusal would be worse than a prompt.
+  const startAll = () => {
+    if (!startable.length) return;
+    if (!startAllWarning) {
+      commitStartAll();
+      return;
+    }
+    confirmModal({
+      title: t('schedule.startAllRest.title'),
+      query: describeStartAllRestWarning(startAllWarning),
+      okIntent: 'is-warning',
+      okAction: commitStartAll,
+    });
   };
 
   const suspendAll = () => setStatusFor(suspendable, SUSPENDED);
@@ -953,9 +1000,9 @@ export function handleActiveStripNowClick(e: MouseEvent, ctx: Schedule2NowContex
   statusRow.style.cssText = PILL_ROW_CSS;
   if (startable.length) {
     statusRow.appendChild(
-      makePill(`${t('schedule.startAll')} (${startable.length})`, startAll, {
+      makePill(startAllLabel(startable.length, startAllWarning), startAll, {
         icon: 'fa-play',
-        color: COLOR_ACCENT_BLUE,
+        color: startAllWarning ? COLOR_ACCENT_ORANGE : COLOR_ACCENT_BLUE,
       }),
     );
   }

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -37,7 +37,7 @@ const { AFTER_REST, FOLLOWED_BY, NEXT_AVAILABLE, NOT_BEFORE, TO_BE_ANNOUNCED } =
 const { IN_PROGRESS, SUSPENDED } = matchUpStatusConstants;
 
 const COLOR_ACCENT_BLUE = 'var(--tmx-accent-blue, #3b82f6)';
-const COLOR_ACCENT_ORANGE = 'var(--tmx-accent-orange, #ef4444)';
+const COLOR_ACCENT_ORANGE = 'var(--tmx-accent-orange, #f59e0b)';
 const ICON_BAN = 'fa-ban';
 const TINT_DANGER = 'rgba(244, 63, 94, 0.15)';
 

--- a/src/pages/tournament/tabs/scheduleViews/scheduleTimingResolver.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/scheduleTimingResolver.test.ts
@@ -1,0 +1,63 @@
+import { makeTimingResolver } from './scheduleTimingResolver';
+import { tournamentEngine } from 'services/factory/engine';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mocksEngine } from 'tods-competition-factory';
+
+// constants and types
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+const FORMAT = 'SET3-S:6/TB7';
+
+/**
+ * The bug this file exists to hold closed: recovery is category-dependent.
+ * `POLICY_SCHEDULING_DEFAULT` gives ADULT doubles 30 minutes and JUNIOR doubles
+ * 60, and `getScheduleTiming` reads the category off `event.category`. The
+ * Inspector previously passed only `{ matchUpFormat, eventType }`, so junior
+ * doubles silently resolved to the adult figure.
+ */
+function seedEvent(categoryType?: string) {
+  const eventProfiles = [
+    {
+      eventName: 'Doubles',
+      eventType: 'DOUBLES',
+      drawProfiles: [{ drawSize: 4, matchUpFormat: FORMAT }],
+      ...(categoryType && { category: { categoryType } }),
+    },
+  ];
+  mocksEngine.generateTournamentRecord({ eventProfiles, setState: true });
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps({ inContext: true });
+  return matchUps[0] as ReadinessMatchUp;
+}
+
+describe('makeTimingResolver — category-aware recovery', () => {
+  beforeEach(() => {
+    tournamentEngine.reset?.();
+  });
+
+  it('resolves ADULT doubles recovery from the default scheduling policy', () => {
+    const matchUp = seedEvent('ADULT');
+    expect(makeTimingResolver()(matchUp).recoveryMinutes).toBe(30);
+  });
+
+  it('resolves JUNIOR doubles recovery to the LONGER figure the policy specifies', () => {
+    const matchUp = seedEvent('JUNIOR');
+    expect(makeTimingResolver()(matchUp).recoveryMinutes).toBe(60);
+  });
+
+  it('carries typeChangeRecoveryMinutes, which the readiness section never resolved', () => {
+    const matchUp = seedEvent('ADULT');
+    expect(makeTimingResolver()(matchUp).typeChangeRecoveryMinutes).toBeGreaterThan(0);
+  });
+
+  it('memoises per format + type + event so repeated lookups stay cheap', () => {
+    const matchUp = seedEvent('JUNIOR');
+    const resolver = makeTimingResolver();
+    expect(resolver(matchUp)).toBe(resolver(matchUp));
+  });
+
+  it('falls back to a flat 90/0 for a matchUp carrying no format', () => {
+    seedEvent('ADULT');
+    const timing = makeTimingResolver()({ matchUpId: 'x' });
+    expect(timing).toMatchObject({ averageMinutes: 90, recoveryMinutes: 0 });
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/scheduleTimingResolver.ts
+++ b/src/pages/tournament/tabs/scheduleViews/scheduleTimingResolver.ts
@@ -1,0 +1,101 @@
+/**
+ * Schedule2 — engine-backed matchUp timing, resolved once per render pass.
+ *
+ * `getMatchUpFormatTiming` is what the auto-scheduler itself resolves against,
+ * including its scheduling-policy fallback, so unpoliced tournaments still get
+ * per-format averages rather than a flat 90/0.
+ *
+ * ── Why the category is passed explicitly AND the event is passed ──
+ *
+ * Recovery is category-dependent. `POLICY_SCHEDULING_DEFAULT` gives ADULT and
+ * WHEELCHAIR doubles 30 minutes but JUNIOR doubles 60. Passing only
+ * `{ matchUpFormat, eventType }` — as the Inspector's readiness section did
+ * until this module existed — silently resolved junior doubles to the adult
+ * figure.
+ *
+ * Passing `event` alone does NOT fix it, and that is a factory bug rather than
+ * a preference. `getScheduleTiming` resolves `categoryType` off
+ * `event.category` correctly, but `getMatchUpFormatTiming` then rebuilds its
+ * `timingDetails` as `{ ...scheduleTiming, …, categoryType, … }`
+ * (`getMatchUpFormatTiming.ts:90-96`) where `categoryType` is the *parameter* —
+ * `undefined` when the caller supplied only an event. The explicit key clobbers
+ * the resolved one, so the event's category is discarded. Measured against
+ * factory 6.29.1 with a JUNIOR DOUBLES `SET3-S:6/TB7` event: `{ event }` → 30,
+ * `{ categoryType: 'JUNIOR' }` → 60, bare → 30.
+ *
+ * So the category is resolved here and passed explicitly, which works today
+ * against the published factory. The `event` is passed as well, because it is
+ * the only way to reach event-level scheduling policies and the event's
+ * `SCHEDULE_TIMING` extension — and because this call site should keep working
+ * unchanged once the factory clobber is fixed.
+ *
+ * Memoised per `matchUpFormat|matchUpType|eventId` for the life of one render
+ * pass — a tournament has a handful of distinct combinations, not one per
+ * matchUp.
+ */
+
+import { tournamentEngine } from 'services/factory/engine';
+
+// constants and types
+import type { ReadinessMatchUp } from './matchUpReadiness';
+import type { RestTiming } from './participantRest';
+
+/** Used when a matchUp carries no format at all — keeps the arithmetic running rather than dropping findings. */
+export const FALLBACK_TIMING: RestTiming = { averageMinutes: 90, recoveryMinutes: 0, typeChangeRecoveryMinutes: 0 };
+
+/** `eventId` → event, for category and event-level policy resolution. */
+function buildEventMap(): Map<string, any> {
+  const { tournamentRecord }: any = tournamentEngine.getTournament() ?? {};
+  return new Map((tournamentRecord?.events ?? []).map((event: any) => [event.eventId, event]));
+}
+
+/** The category identifiers the scheduling policy matches on, read the way `getScheduleTiming` reads them. */
+function categoryOf(event: any): { categoryName?: string; categoryType?: string } {
+  const category = event?.category;
+  return {
+    categoryName: category?.categoryName ?? category?.ageCategoryCode,
+    categoryType: category?.categoryType ?? category?.subType,
+  };
+}
+
+/**
+ * A timing lookup valid for one render pass. Satisfies both `ReadinessTiming`
+ * and `RestTiming` structurally, so readiness and rest share one resolver and
+ * cannot drift apart on what a format costs.
+ */
+export function makeTimingResolver(): (matchUp: ReadinessMatchUp) => RestTiming {
+  const cache = new Map<string, RestTiming>();
+  const events = buildEventMap();
+
+  return (matchUp: ReadinessMatchUp) => {
+    const matchUpFormat = matchUp.matchUpFormat ?? '';
+    const eventId = matchUp.eventId ?? '';
+    const key = `${matchUpFormat}|${matchUp.matchUpType ?? ''}|${eventId}`;
+    const cached = cache.get(key);
+    if (cached) return cached;
+
+    let timing = FALLBACK_TIMING;
+    if (matchUpFormat) {
+      // `matchUpType` is a plain string on the hydrated matchUp but an
+      // `EventTypeUnion` on the engine signature; the engine validates it and
+      // falls back to SINGLES, so widen at the boundary rather than duplicating
+      // the union here.
+      const event = events.get(eventId);
+      const result: any = tournamentEngine.getMatchUpFormatTiming({
+        eventType: matchUp.matchUpType as any,
+        ...categoryOf(event),
+        matchUpFormat,
+        event,
+      });
+      if (!result?.error) {
+        timing = {
+          averageMinutes: result?.averageMinutes ?? FALLBACK_TIMING.averageMinutes,
+          recoveryMinutes: result?.recoveryMinutes ?? FALLBACK_TIMING.recoveryMinutes,
+          typeChangeRecoveryMinutes: result?.typeChangeRecoveryMinutes ?? 0,
+        };
+      }
+    }
+    cache.set(key, timing);
+    return timing;
+  };
+}

--- a/src/pages/tournament/tabs/scheduleViews/startAllRestGuard.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/startAllRestGuard.test.ts
@@ -1,0 +1,86 @@
+import { collectStartAllRestWarning, isBlocker } from './startAllRestGuard';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import type { RestResult, RestRow } from './participantRest';
+
+const LOAD = { singles: 1, doubles: 0, total: 1, ordinal: 2, atLimit: [] };
+
+function row(overrides: Partial<RestRow>): RestRow {
+  return {
+    participantId: 'p1',
+    participantName: 'Alice',
+    status: 'rested',
+    requiredMinutes: 60,
+    typeChange: false,
+    load: LOAD,
+    ...overrides,
+  } as RestRow;
+}
+
+const evaluated = (rows: RestRow[]): RestResult => ({ evaluated: true, asOfMinutes: 860, rows });
+
+describe('isBlocker', () => {
+  it('treats onCourt and resting as blockers, rested and none as clear', () => {
+    expect(isBlocker(row({ status: 'onCourt' }))).toBe(true);
+    expect(isBlocker(row({ status: 'resting' }))).toBe(true);
+    expect(isBlocker(row({ status: 'rested' }))).toBe(false);
+    expect(isBlocker(row({ status: 'none' }))).toBe(false);
+  });
+});
+
+describe('collectStartAllRestWarning', () => {
+  it('returns undefined when everyone is clear — the caller skips the confirm entirely', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1' }, { matchUpId: 'm2' }], () =>
+      evaluated([row({ status: 'rested' }), row({ status: 'none', participantId: 'p2' })]),
+    );
+    expect(warning).toBeUndefined();
+  });
+
+  it('collects a resting player with their elapsed and required minutes', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1', courtName: 'Court 3' }], () =>
+      evaluated([row({ status: 'resting', restMinutes: 32 })]),
+    );
+    expect(warning?.blockers).toEqual([
+      {
+        matchUpId: 'm1',
+        courtName: 'Court 3',
+        participantName: 'Alice',
+        restMinutes: 32,
+        requiredMinutes: 60,
+        onCourt: false,
+      },
+    ]);
+    expect(warning?.affectedMatchUpIds).toEqual(['m1']);
+  });
+
+  it('omits restMinutes for a player still on court rather than reporting zero', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1' }], () => evaluated([row({ status: 'onCourt' })]));
+    expect(warning?.blockers[0].onCourt).toBe(true);
+    expect(warning?.blockers[0]).not.toHaveProperty('restMinutes');
+  });
+
+  it('reports every blocker but counts each matchUp once', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1' }], () =>
+      evaluated([
+        row({ status: 'resting', restMinutes: 10 }),
+        row({ status: 'resting', restMinutes: 20, participantId: 'p2', participantName: 'Bob' }),
+        row({ status: 'rested', participantId: 'p3', participantName: 'Chen' }),
+      ]),
+    );
+    expect(warning?.blockers.map((b) => b.participantName)).toEqual(['Alice', 'Bob']);
+    expect(warning?.affectedMatchUpIds).toEqual(['m1']);
+  });
+
+  it('spans several matchUps', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1' }, { matchUpId: 'm2' }, { matchUpId: 'm3' }], (id) =>
+      id === 'm2' ? evaluated([row({ status: 'rested' })]) : evaluated([row({ status: 'resting', restMinutes: 5 })]),
+    );
+    expect(warning?.affectedMatchUpIds).toEqual(['m1', 'm3']);
+  });
+
+  it('skips a matchUp whose rest could not be evaluated rather than assuming it is clear', () => {
+    const warning = collectStartAllRestWarning([{ matchUpId: 'm1' }], () => ({ evaluated: false, reason: 'bye' }));
+    expect(warning).toBeUndefined();
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/startAllRestGuard.ts
+++ b/src/pages/tournament/tabs/scheduleViews/startAllRestGuard.ts
@@ -1,0 +1,81 @@
+/**
+ * Schedule2 — recovery guard for the Now-row "Start all" bulk action.
+ *
+ * `startAll` takes every startable match on the strip to IN_PROGRESS in one
+ * click. That is the one place a recovery violation is least likely to be
+ * noticed: no card was selected, so the Inspector never rendered; no card was
+ * dragged, so the catalog badge was never read; and the cost is multiplied by
+ * however many courts are live.
+ *
+ * The guard annotates and confirms — it never blocks. A director overrides
+ * recovery deliberately all the time (a retirement frees a court, a player
+ * asks to go on early), and a bulk action that refuses to run is worse than one
+ * that asks. What it must not do is start four matches silently when one of the
+ * players walked off court twenty minutes ago.
+ *
+ * Pure: the caller supplies rest per matchUp, so this file has no engine, no
+ * clock and no DOM.
+ */
+
+// constants and types
+import type { RestResult, RestRow } from './participantRest';
+
+export interface StartAllCandidate {
+  matchUpId: string;
+  courtName?: string;
+}
+
+/** One player who is not ready, and where they would be starting. */
+export interface RestBlocker {
+  matchUpId: string;
+  courtName?: string;
+  participantName: string;
+  /** Absent when the player is still on court — there is no elapsed rest to report. */
+  restMinutes?: number;
+  requiredMinutes: number;
+  onCourt: boolean;
+}
+
+export interface StartAllRestWarning {
+  blockers: RestBlocker[];
+  /** MatchUps with at least one blocker. Never larger than the candidate list. */
+  affectedMatchUpIds: string[];
+}
+
+/** A row is a blocker when the player owes recovery or has not left the court. */
+export function isBlocker(row: RestRow): boolean {
+  return row.status === 'onCourt' || row.status === 'resting';
+}
+
+/**
+ * Blockers across every match "Start all" would start. Returns undefined when
+ * nothing is owed, so the caller can skip the confirm entirely rather than
+ * showing an empty warning.
+ */
+export function collectStartAllRestWarning(
+  candidates: StartAllCandidate[],
+  restFor: (matchUpId: string) => RestResult,
+): StartAllRestWarning | undefined {
+  const blockers: RestBlocker[] = [];
+  const affected = new Set<string>();
+
+  for (const candidate of candidates) {
+    const result = restFor(candidate.matchUpId);
+    if (!result.evaluated) continue;
+    for (const row of result.rows) {
+      if (!isBlocker(row)) continue;
+      affected.add(candidate.matchUpId);
+      blockers.push({
+        matchUpId: candidate.matchUpId,
+        courtName: candidate.courtName,
+        participantName: row.participantName,
+        ...(row.restMinutes !== undefined && { restMinutes: row.restMinutes }),
+        requiredMinutes: row.requiredMinutes,
+        onCourt: row.status === 'onCourt',
+      });
+    }
+  }
+
+  if (!blockers.length) return undefined;
+  return { blockers, affectedMatchUpIds: [...affected] };
+}

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -385,6 +385,58 @@
   color: var(--tmx-accent-red);
 }
 
+/* ── Schedule2 catalog card: rest badge ──
+   The one-line headline rendered through courthive-components'
+   `renderCardExtra`. Status drives the colour so a scan of the catalog reads
+   without any text being parsed; the per-player detail lives in the badge's
+   `title` and, properly, in the Inspector. Tokens only — both themes. */
+
+.tmx-rest-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 1px 7px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  color: var(--tmx-text-primary);
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+}
+
+.tmx-rest-badge.is-oncourt {
+  border-color: var(--tmx-accent-red);
+  color: var(--tmx-accent-red);
+  background: transparent;
+}
+
+.tmx-rest-badge.is-resting {
+  border-color: var(--tmx-accent-orange);
+  color: var(--tmx-accent-orange);
+  background: transparent;
+}
+
+.tmx-rest-badge.is-rested {
+  border-color: var(--tmx-accent-green);
+  color: var(--tmx-accent-green);
+  background: transparent;
+}
+
+/* Daily-limit marker rides the badge rather than waiting for the Inspector —
+   "already played their allowance" is the one thing not to miss while scanning. */
+.tmx-rest-badge-limit {
+  font-weight: 700;
+  padding-left: 4px;
+  border-left: 1px solid currentColor;
+  opacity: 0.85;
+}
+
+.tmx-rest-badge[data-at-limit] {
+  border-color: var(--tmx-accent-red);
+  color: var(--tmx-accent-red);
+}
+
 /* Inspector show/hide toggle in the sidebar control bar. */
 .tmx-inspector-toggle {
   display: inline-flex;

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -305,6 +305,86 @@
   color: var(--tmx-text-secondary);
 }
 
+/* ── Schedule2 Inspector: rest section ──
+   One row per individual in the selected matchUp, worst-first. Status drives the
+   left border so the block scans vertically without reading any text; the
+   `data-estimated` hook (set for every ladder rung below a recorded end time)
+   dims the provenance line so an inferred figure never reads as a measured one.
+   Both themes share the tokens — no literal colours here. */
+
+.tmx-rest {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--tmx-border-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tmx-rest-heading {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--tmx-text-secondary);
+}
+
+.tmx-rest-skip {
+  font-size: 0.75rem;
+  color: var(--tmx-text-secondary);
+  font-style: italic;
+}
+
+.tmx-rest-row {
+  padding-left: 8px;
+  border-left: 3px solid var(--tmx-border-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tmx-rest-row.is-oncourt {
+  border-left-color: var(--tmx-accent-red);
+}
+
+.tmx-rest-row.is-resting {
+  border-left-color: var(--tmx-accent-orange);
+}
+
+.tmx-rest-row.is-rested {
+  border-left-color: var(--tmx-accent-green);
+}
+
+.tmx-rest-name {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tmx-text-primary);
+}
+
+.tmx-rest-figure {
+  font-size: 0.75rem;
+  color: var(--tmx-text-primary);
+}
+
+.tmx-rest-row.is-none .tmx-rest-figure {
+  color: var(--tmx-text-secondary);
+}
+
+.tmx-rest-detail {
+  font-size: 0.6875rem;
+  color: var(--tmx-text-secondary);
+}
+
+.tmx-rest-row[data-estimated='true'] .tmx-rest-detail {
+  font-style: italic;
+}
+
+.tmx-rest-limit {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--tmx-accent-red);
+}
+
 /* Inspector show/hide toggle in the sidebar control bar. */
 .tmx-inspector-toggle {
   display: inline-flex;


### PR DESCRIPTION
## What

The Inspector answered *"can this placement happen at the time it is scheduled for"* and skipped entirely when there was no scheduled time — which is exactly the state a matchUp is in when a director is deciding whether to drag it onto the **Now** strip. It reported:

> *"Not scheduled yet, so there is no time to check against."*

This adds a **Rest** section anchored on *now* rather than on `scheduledTime`, so it answers for an unscheduled matchUp, with one row per individual participant. It ticks every 30s (the Now strip's own cadence) because rest counts up.

## The ladder

Rest is measured down five rungs, and **every row reports which rung it used** so an inferred figure never reads as a measured one:

| # | source | meaning | fidelity |
|---|---|---|---|
| 1 | `schedule.endTime` (+`endDate`) | operator recorded the finish | measured |
| 2 | `schedule.scoredTime` | when the score was entered | proxy |
| 3 | `schedule.startTime` + `averageMinutes` | started, projected | projected |
| 4 | `schedule.calledAt` + `averageMinutes` | called to court, projected | projected |
| 5 | `schedule.scheduledTime` + `averageMinutes` | plan only | planned |

**Rung 2 is the common path, not a fallback.** TMX writes `END_TIME` only on an explicit operator action (the End time action, the matchUps-table column), while the factory auto-captures `schedule.scoredTime` on every first score. A late-entered score pushes `scoredTime` *after* the true finish, so rest is understated — the conservative direction, since it holds a rested player back rather than calling a tired one.

Rungs 3–4 exist so a player whose prior match is **still running** reads as *"on court now — ready 16:00"* rather than as a negative rest figure.

Rows also carry daily load (*"match #3 today, limit 3"*) from `getMatchUpDailyLimits`, and flag a singles↔doubles type change, which carries its own recovery figure.

## Time representation — the part worth reviewing carefully

`endTime` / `startTime` are bare military `HH:MM` (venue-local wall clock); `calledAt` / `scoredTime` are full **UTC ISO instants**. Mixing the frames yields a figure wrong by the UTC offset, which is worse than showing nothing. `parseClockMinutes` returns `null` on an ISO string *silently*, so the failure would have presented as "no prior match today".

All conversion is concentrated in one place (`inspectorRest.ts`), and the pure module never sees a `Date` at all — it takes minutes from midnight of the viewed day. The planned Temporal standardization therefore has a single site to change.

Tests assert the instant-vs-wall-clock distinction in a way that **holds in any zone**, not only under `TZ=UTC`. Verified by replacing the instant conversion with a string slice: 7 of 13 tests fail under `TZ=America/New_York`, all pass when restored.

## Also fixes: category-blind recovery

The existing readiness section shipped resolving recovery without category detail. `POLICY_SCHEDULING_DEFAULT` gives ADULT doubles 30 minutes and **JUNIOR doubles 60**, so every junior doubles match resolved to 30.

Passing `event` alone does **not** fix this, and that is a factory bug: `getMatchUpFormatTiming` rebuilds `timingDetails` as `{ ...scheduleTiming, …, categoryType, … }` (`getMatchUpFormatTiming.ts:90-96`) where `categoryType` is the *parameter* — `undefined` when the caller supplied only an event — clobbering the value `getScheduleTiming` had already resolved from `event.category`. Measured against factory 6.29.1 with a JUNIOR DOUBLES `SET3-S:6/TB7` event:

| call | `recoveryMinutes` |
|---|---|
| `{ matchUpFormat, eventType }` | 30 |
| `{ matchUpFormat, eventType, event }` | 30 |
| `{ matchUpFormat, eventType, categoryType: 'JUNIOR' }` | **60** |

So the category is resolved and passed explicitly (works today against the published factory), *and* the event is passed, because that is the only way to reach event-level scheduling policies and the event's `SCHEDULE_TIMING` extension — and so this call site keeps working unchanged once the factory clobber is fixed. **The factory fix is filed separately; this PR does not depend on it.**

Readiness now shares that resolver (`scheduleTimingResolver.ts`), so the two sections cannot drift apart on what a format costs.

## Verification

Full TMX CI gate, locally: `lint` ✓ · `format:check` ✓ · `attr-audit --ci` ✓ · `i18n-audit --ci` ✓ · `check-types` ✓ · `test --run` 120 files / **1281 passed** ✓ · `build` ✓

New coverage: 23 tests for the pure ladder/arithmetic, 13 for time normalization (zone-robust), 5 against the real engine for the category fix — the last of which fails before the fix and passes after.

## Notes

- Rest and readiness answer different questions and are both rendered; neither replaces the other.
- No factory change required to merge.
