### PR TITLE
feat(participants): adopt the CODES contact model

### DIFF
--- a/src/components/modals/groupContactPerson.test.ts
+++ b/src/components/modals/groupContactPerson.test.ts
@@ -5,7 +5,7 @@
  * The resolver is deliberately strict about membership — a pointer to someone who has since been removed
  * is stale, not authoritative.
  */
-import { CONTACT_PERSON_EXTENSION, designatedContactPersonId } from './groupContactPerson';
+import { CONTACT_PERSON_EXTENSION, designatedContactPersonId, hasContactPersonExtension } from './groupContactPerson';
 import { describe, expect, it } from 'vitest';
 
 const group = (extensions: any, individualParticipantIds: string[] = ['p1', 'p2']) => ({
@@ -38,5 +38,65 @@ describe('designatedContactPersonId', () => {
 
   it('ignores an empty pointer value', () => {
     expect(designatedContactPersonId(group([{ name: CONTACT_PERSON_EXTENSION, value: '' }]))).toBeUndefined();
+  });
+});
+
+describe('designatedContactPersonId — contactParticipantIds (factory #4683)', () => {
+  const withField = (contactParticipantIds: any, extensions: any = [], members = ['p1', 'p2']) => ({
+    participantId: 'g1',
+    individualParticipantIds: members,
+    contactParticipantIds,
+    extensions,
+  });
+
+  it('resolves the first-class field', () => {
+    expect(designatedContactPersonId(withField(['p2']))).toEqual('p2');
+  });
+
+  it('PREFERS the first-class field over a disagreeing extension', () => {
+    // Both can be present on a group edited before and after the migration. The field the factory
+    // validates on write wins over the one it never validated.
+    const both = withField(['p2'], [{ name: CONTACT_PERSON_EXTENSION, value: 'p1' }]);
+    expect(designatedContactPersonId(both)).toEqual('p2');
+  });
+
+  it('FALLS BACK to the extension for a group written before the migration', () => {
+    // The reason the extension read is not deleted: nothing migrates these records in bulk, so a group
+    // created between TMX #1324 and this change resolves only through the fallback.
+    expect(designatedContactPersonId(withField(undefined, [{ name: CONTACT_PERSON_EXTENSION, value: 'p1' }]))).toEqual(
+      'p1',
+    );
+  });
+
+  it('falls back when the first-class field is present but points at a non-member', () => {
+    const stale = withField(['p9'], [{ name: CONTACT_PERSON_EXTENSION, value: 'p1' }]);
+    expect(designatedContactPersonId(stale)).toEqual('p1');
+  });
+
+  it('treats an empty array as "no designation" rather than as an error', () => {
+    expect(designatedContactPersonId(withField([]))).toBeUndefined();
+  });
+
+  it('takes the first RESOLVABLE member, not merely the first entry', () => {
+    // The field is plural and the UI is single-select. A non-member in position 0 must not mask a
+    // valid designation behind it.
+    expect(designatedContactPersonId(withField(['p9', 'p2']))).toEqual('p2');
+  });
+});
+
+describe('hasContactPersonExtension', () => {
+  it('reports an extension that the resolver would REJECT', () => {
+    // Deliberately not membership-checked. This answers "is there an extension to remove", and a
+    // pointer to a non-member is exactly the kind that most needs removing — if it were skipped, a
+    // later re-add of that member would resurrect a designation nobody asked for.
+    const stale = group([{ name: CONTACT_PERSON_EXTENSION, value: 'p9' }]);
+    expect(designatedContactPersonId(stale)).toBeUndefined();
+    expect(hasContactPersonExtension(stale)).toBe(true);
+  });
+
+  it('is false when no such extension exists', () => {
+    expect(hasContactPersonExtension(group([]))).toBe(false);
+    expect(hasContactPersonExtension(group([{ name: 'somethingElse', value: 'p1' }]))).toBe(false);
+    expect(hasContactPersonExtension({} as any)).toBe(false);
   });
 });

--- a/src/components/modals/groupContactPerson.ts
+++ b/src/components/modals/groupContactPerson.ts
@@ -1,15 +1,17 @@
 /**
  * A GROUP's designated contact person — "who do I call about this group". Entirely optional.
  *
- * Stored as a POINTER to one of the group's members
- * (`extensions[{ name: 'contactPerson', value: participantId }]`) rather than by copying their details
- * onto the group. A copy would be a snapshot: rename the person or change their number and the group
- * would keep advertising the old one. The pointer resolves live.
+ * Stored as a POINTER to one of the group's members rather than by copying their details onto the
+ * group. A copy would be a snapshot: rename the person or change their number and the group would keep
+ * advertising the old one. The pointer resolves live.
  *
- * An extension because CODES has no contact-person field on `Participant` — verified against the types,
- * not assumed — and inventing one is a standards decision rather than a UI one. `modifyParticipant` does
- * not accept `extensions` either, which is why the UI dispatches the dedicated add/remove mutations. If
- * this earns a first-class home later, the extension migrates.
+ * **Now first-class.** It began as `extensions[{ name: 'contactPerson' }]` because CODES had no field
+ * for it — checked at the time, not assumed. Factory #4683 added `Participant.contactParticipantIds`,
+ * which is validated against membership on write and pruned by `deleteParticipants`; the extension was
+ * none of those. So this module reads BOTH and writes only the new field.
+ *
+ * The extension read is not legacy debt to be tidied away on sight: groups created between TMX #1324
+ * and this change carry it and nothing migrates them in bulk. It can go once no record answers to it.
  *
  * Lives in its own module so it can be tested without importing the modal, which pulls Tabulator and
  * touches `document` at import time.
@@ -17,14 +19,40 @@
 export const CONTACT_PERSON_EXTENSION = 'contactPerson';
 
 /**
+ * Whether this group still carries the pre-#4683 extension.
+ *
+ * Deliberately NOT membership-checked, unlike the resolver: this answers "is there an extension to
+ * remove", and an extension pointing at a non-member is exactly the kind that most needs removing.
+ */
+export function hasContactPersonExtension(group: any): boolean {
+  return (group?.extensions ?? []).some((entry: any) => entry?.name === CONTACT_PERSON_EXTENSION);
+}
+
+/** Only ids that are actually members resolve — see `designatedContactPersonId`. */
+function firstMember(candidates: string[], memberIds: string[]): string | undefined {
+  return candidates.find((candidate) => candidate && memberIds.includes(candidate));
+}
+
+/**
  * The designated member's participantId, or `undefined`.
  *
- * Strict about membership on purpose: a pointer to someone who has since been removed from the group is
- * stale, not authoritative. Resolving it anyway would show a name the group no longer contains and offer
- * that person's number as the group's contact.
+ * Reads `contactParticipantIds` first and falls back to the extension, so a group written by either
+ * version resolves. The factory validates the new field against membership on write; the extension was
+ * never validated at all, which is why membership is re-checked here for both.
+ *
+ * Strict about membership on purpose: a pointer to someone since removed from the group is stale, not
+ * authoritative. Resolving it anyway would show a name the group no longer contains and offer that
+ * person's number as the group's contact.
+ *
+ * The field is an array and the UI is single-select, so the first resolvable member wins. Storing one
+ * element rather than adding a second source of truth for "which one is primary".
  */
 export function designatedContactPersonId(group: any): string | undefined {
+  const memberIds = group?.individualParticipantIds ?? [];
+
+  const firstClass = firstMember(group?.contactParticipantIds ?? [], memberIds);
+  if (firstClass) return firstClass;
+
   const extension = (group?.extensions ?? []).find((entry: any) => entry?.name === CONTACT_PERSON_EXTENSION);
-  const value = extension?.value;
-  return value && (group?.individualParticipantIds ?? []).includes(value) ? value : undefined;
+  return firstMember([extension?.value].filter(Boolean), memberIds);
 }

--- a/src/components/modals/groupProfileModal.ts
+++ b/src/components/modals/groupProfileModal.ts
@@ -19,7 +19,7 @@
  */
 import { participantConstants, participantRoles, positionActionConstants, tools } from 'tods-competition-factory';
 import { removeFromTeam } from 'pages/tournament/tabs/participantTab/controlBar/removeFromTeam';
-import { CONTACT_PERSON_EXTENSION, designatedContactPersonId } from './groupContactPerson';
+import { CONTACT_PERSON_EXTENSION, designatedContactPersonId, hasContactPersonExtension } from './groupContactPerson';
 import { roleBadge } from 'components/tables/common/formatters/roleBadge';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -30,7 +30,7 @@ import { t } from 'i18n';
 
 import {
   ADD_INDIVIDUAL_PARTICIPANT_IDS,
-  ADD_PARTICIPANT_EXTENSION,
+  MODIFY_PARTICIPANT,
   REMOVE_PARTICIPANT_EXTENSION,
 } from 'constants/mutationConstants';
 
@@ -157,19 +157,27 @@ function buildContactPersonRow(group: any, onChanged: () => void): HTMLElement {
   select.addEventListener('change', () => {
     const participantId = group.participantId;
     const value = select.value;
-    const methods = value
-      ? [
-          {
-            method: ADD_PARTICIPANT_EXTENSION,
-            params: { participantId, extension: { name: CONTACT_PERSON_EXTENSION, value } },
-          },
-        ]
-      : [
-          {
-            method: REMOVE_PARTICIPANT_EXTENSION,
-            params: { participantId, extensionName: CONTACT_PERSON_EXTENSION },
-          },
-        ];
+
+    // Write the first-class field (factory #4683), which the engine validates against membership.
+    // A one-element array: the field is plural, this select is single, and storing one element beats
+    // adding a second source of truth for "which of these is the primary".
+    const methods: any[] = [
+      {
+        method: MODIFY_PARTICIPANT,
+        params: { participant: { participantId, contactParticipantIds: value ? [value] : [] } },
+      },
+    ];
+
+    // Collapse the two sources on first edit, and — the part that is not merely tidiness — REMOVE the
+    // extension whenever this group still carries one. `designatedContactPersonId` falls back to the
+    // extension when the first-class field resolves to nothing, so clearing the contact on a
+    // pre-migration group would otherwise RESURRECT the old pointer on the next read.
+    if (hasContactPersonExtension(group)) {
+      methods.push({
+        method: REMOVE_PARTICIPANT_EXTENSION,
+        params: { participantId, extensionName: CONTACT_PERSON_EXTENSION },
+      });
+    }
     // Updates its own detail rather than re-rendering the modal: the select already shows the new
     // choice, and rebuilding the table underneath would drop any row selection the TD had made.
     mutationRequest({

--- a/src/constants/contactRelationships.ts
+++ b/src/constants/contactRelationships.ts
@@ -1,0 +1,31 @@
+/**
+ * Whose number a contact is — `Contact.relationship`, added to CODES by factory #4683.
+ *
+ * A minor's contact is routinely a parent, a guardian or a travelling chaperone, and a Contact could
+ * previously carry only a `name`. `SELF` earns its place because without it "the competitor's own
+ * mobile" and "an unlabelled number" are the same state.
+ *
+ * ## Why this is a local list and not `ContactRelationshipEnum` from the factory
+ *
+ * TMX CI strips the `link:../factory` override and installs the PUBLISHED pin (`ci.yml` — "Strip link:
+ * overrides for CI"), currently 6.29.1. `ContactRelationshipEnum` does not exist there, so importing it
+ * would fail the type-check gate and throw at runtime in CI while passing locally against the rebuilt
+ * dist — the exact class of divergence that `link:` overrides hide.
+ *
+ * This is therefore a DELIBERATE, TEMPORARY duplication with a defined end: once the factory publishes
+ * and TMX's pin is bumped, replace the array below with
+ *
+ *     const { ContactRelationshipEnum } = require('tods-competition-factory');
+ *
+ * and delete this comment. Tracked in `Mentat/TASKS.md` under "TMX: adopt the CODES contact model".
+ * A hand-copied vocabulary that outlives its reason is how SCOREKEEPER and TIMEKEEPER stayed missing
+ * from the Staff view for months — this one is scheduled to die.
+ */
+export const CONTACT_RELATIONSHIPS = ['SELF', 'PARENT', 'GUARDIAN', 'CHAPERONE', 'EMERGENCY', 'OTHER'] as const;
+
+export type ContactRelationship = (typeof CONTACT_RELATIONSHIPS)[number];
+
+/** i18n key for a relationship value; the values double as the key suffixes. */
+export function relationshipKey(relationship: string): string {
+  return `pages.participants.contactRelationship.${relationship.toLowerCase()}`;
+}

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -25,7 +25,6 @@ export const ATTACH_CONSOLATION_STRUCTURES = 'attachConsolationStructures';
 export const ATTACH_PLAYOFF_STRUCTURES = 'attachPlayoffStructures';
 export const ADD_TOURNAMENT_EXTENSION = 'addTournamentExtension';
 export const REMOVE_PARTICIPANT_EXTENSION = 'removeParticipantExtension';
-export const ADD_PARTICIPANT_EXTENSION = 'addParticipantExtension';
 export const ADD_TOURNAMENT_TIMEITEM = 'addTournamentTimeItem';
 export const ADD_VENUE = 'addVenue';
 export const ABANDON_TOURNAMENT_MATCHUPS = 'abandonTournamentMatchUps';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2205,7 +2205,10 @@
         "mobilePlaceholder": "Mobile number",
         "email": "Email",
         "emailPlaceholder": "Email address",
-        "contactIsPublic": "Contact may be shared publicly"
+        "contactIsPublic": "Contact may be shared publicly",
+        "contactRelationship": "Contact is",
+        "contactName": "Contact name",
+        "contactNamePlaceholder": "Name of the contact, if not the participant"
       },
       "newTeam": "New team",
       "newGroup": "New group",
@@ -2224,6 +2227,15 @@
         "male": "Male",
         "female": "Female",
         "unknown": "Unknown"
+      },
+      "contactRelationship": {
+        "unspecified": "Unspecified",
+        "self": "The participant",
+        "parent": "Parent",
+        "guardian": "Guardian",
+        "chaperone": "Chaperone",
+        "emergency": "Emergency contact",
+        "other": "Other"
       },
       "groupRole": "Group role",
       "rowActions": {

--- a/src/pages/tournament/tabs/participantTab/editIndividualParticipant.test.ts
+++ b/src/pages/tournament/tabs/participantTab/editIndividualParticipant.test.ts
@@ -189,6 +189,81 @@ const CONTACT_INPUTS = {
 const contactsFrom = (methods: any[]) => methods[0]?.params?.participant?.person?.contacts;
 const createdContactsFrom = (methods: any[]) => methods[0]?.params?.participants?.[0]?.person?.contacts;
 
+describe('contact relationship (factory #4683)', () => {
+  const RELATIONSHIP_INPUTS = {
+    ...CONTACT_INPUTS,
+    contactRelationship: { value: 'GUARDIAN' },
+    contactName: { value: 'Ana Rivas' },
+  };
+
+  it('offers a relationship select and a contact name in every view', () => {
+    for (const view of ['INDIVIDUAL', OFFICIAL, STAFF]) {
+      const fields = openForm({ view }, RELATIONSHIP_INPUTS);
+      expect(fields?.map((f: any) => f.field)).toEqual(expect.arrayContaining(['contactRelationship', 'contactName']));
+    }
+  });
+
+  it('offers the whole vocabulary plus an explicit unspecified option', () => {
+    const fields = openForm({ view: 'INDIVIDUAL' }, RELATIONSHIP_INPUTS);
+    const select = fields?.find((f: any) => f.field === 'contactRelationship');
+    expect(select.options.map((o: any) => o.value)).toEqual([
+      '',
+      'SELF',
+      'PARENT',
+      'GUARDIAN',
+      'CHAPERONE',
+      'EMERGENCY',
+      'OTHER',
+    ]);
+  });
+
+  it('defaults to UNSPECIFIED, never to SELF', () => {
+    // Defaulting to SELF would assert that a number belongs to the participant when nobody said so —
+    // on the field that decides who a director may ring at 9pm about a minor.
+    const fields = openForm({ view: 'INDIVIDUAL' }, RELATIONSHIP_INPUTS);
+    const select = fields?.find((f: any) => f.field === 'contactRelationship');
+    expect(select.options.find((o: any) => o.selected).value).toEqual('');
+  });
+
+  it('persists the relationship and the contact name', () => {
+    const contacts = createdContactsFrom(save({ view: 'INDIVIDUAL' }, RELATIONSHIP_INPUTS));
+    expect(contacts[0].relationship).toEqual('GUARDIAN');
+    expect(contacts[0].name).toEqual('Ana Rivas');
+  });
+
+  it('preselects a stored relationship when editing', () => {
+    const participant = {
+      participantId: 'p1',
+      person: { contacts: [{ mobileTelephone: STORED_MOBILE, relationship: 'PARENT', name: 'Dad' }] },
+    };
+    const fields = openForm({ view: 'INDIVIDUAL', participant }, RELATIONSHIP_INPUTS);
+    const select = fields?.find((f: any) => f.field === 'contactRelationship');
+    expect(select.options.find((o: any) => o.selected).value).toEqual('PARENT');
+    expect(fields?.find((f: any) => f.field === 'contactName').value).toEqual('Dad');
+  });
+
+  it('clears a stored relationship when the select is emptied', () => {
+    const participant = {
+      participantId: 'p1',
+      person: { contacts: [{ mobileTelephone: STORED_MOBILE, relationship: 'PARENT' }] },
+    };
+    const emptied = { ...CONTACT_INPUTS, contactRelationship: { value: '' }, contactName: { value: '' } };
+    expect(contactsFrom(save({ view: 'INDIVIDUAL', participant }, emptied))[0].relationship).toBeUndefined();
+  });
+
+  it('leaves a stored name ALONE when the drawer renders no name input', () => {
+    // Absent input and emptied input are different instructions. A reduced form must not speak for a
+    // field it never offered — spreading `name: undefined` unconditionally would erase it.
+    const participant = {
+      participantId: 'p1',
+      person: { contacts: [{ mobileTelephone: STORED_MOBILE, name: 'desk', relationship: 'SELF' }] },
+    };
+    const primary = contactsFrom(save({ view: 'INDIVIDUAL', participant }, CONTACT_INPUTS))[0];
+    expect(primary.name).toEqual('desk');
+    expect(primary.relationship).toEqual('SELF');
+  });
+});
+
 describe('contact details', () => {
   it('offers mobile, email and a public checkbox in every view', () => {
     for (const view of ['INDIVIDUAL', OFFICIAL, STAFF]) {

--- a/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
@@ -12,6 +12,7 @@ import { t, i18next } from 'i18n';
 
 // constants
 import { ADD_PARTICIPANTS, MODIFY_PARTICIPANT } from 'constants/mutationConstants';
+import { CONTACT_RELATIONSHIPS, relationshipKey } from 'constants/contactRelationships';
 import { RIGHT, STAFF, SUCCESS } from 'constants/tmxConstants';
 import { STAFF_ROLES } from 'constants/staffRoles';
 
@@ -64,7 +65,9 @@ export function editIndividualParticipant({
     firstName: participant?.person?.standardGivenName,
     lastName: participant?.person?.standardFamilyName,
     mobileTelephone: primaryContact.mobileTelephone,
+    contactRelationship: primaryContact.relationship,
     emailAddress: primaryContact.emailAddress,
+    contactName: primaryContact.name,
     nickname: participant?.participantOtherName,
     contactIsPublic: primaryContact.isPublic === true,
     birthDate: participant?.person?.birthDate,
@@ -92,20 +95,33 @@ export function editIndividualParticipant({
   const submittedContacts = (): any[] | undefined => {
     const mobileTelephone = inputs.mobileTelephone?.value?.trim() || undefined;
     const emailAddress = inputs.emailAddress?.value?.trim() || undefined;
+    const relationship = inputs.contactRelationship?.value || undefined;
+    const name = inputs.contactName?.value?.trim() || undefined;
     const isPublic = !!inputs.contactIsPublic?.checked;
 
     // Nothing entered and nothing stored — send no `contacts` key at all.
     if (!mobileTelephone && !emailAddress && !existingContacts.length) return undefined;
 
-    // Both fields cleared on a participant whose primary contact carried only those two: drop that
-    // entry rather than persisting an empty shell, but keep any other contacts they have.
+    // Emptiness is still decided by the REACHABLE fields alone. A relationship or a name with no number
+    // and no address is not a contact — keeping the entry alive for them would persist a shell that
+    // renders as a blank row, and would make "clear this contact" impossible without also clearing
+    // fields the user never touched.
     const primaryIsEmpty = !mobileTelephone && !emailAddress;
     const rest = existingContacts.slice(1);
     if (primaryIsEmpty) return rest;
 
-    // Spread the existing entry first so fields this drawer does not edit — `name`, `telephone`, `fax`,
+    // Spread the existing entry first so fields this drawer does not edit — `telephone`, `fax`,
     // `notes`, extensions — survive.
-    return [{ ...primaryContact, mobileTelephone, emailAddress, isPublic }, ...rest];
+    //
+    // `relationship` and `name` are applied only when their inputs are actually PRESENT. An absent
+    // input and an emptied one are different instructions: emptied means clear, absent means the
+    // drawer never offered the field and must not speak for it. Spreading `name: undefined`
+    // unconditionally would erase a stored contact name for any caller rendering a reduced form.
+    const edits: any = { mobileTelephone, emailAddress, isPublic };
+    if (inputs.contactRelationship) edits.relationship = relationship;
+    if (inputs.contactName) edits.name = name;
+
+    return [{ ...primaryContact, ...edits }, ...rest];
   };
 
   const nationalityCodeValue = (value: string) => (values.nationalityCode = value);
@@ -241,6 +257,36 @@ export function editIndividualParticipant({
           label: t('pages.participants.editParticipant.email'),
           value: values.emailAddress || '',
           field: 'emailAddress',
+        },
+        {
+          // Whose number this is. Defaults to UNSET rather than to SELF: defaulting would assert
+          // something nobody entered, on a field that decides who a director may ring at 9pm about a
+          // minor. An unlabelled contact stays unlabelled until someone says otherwise.
+          label: t('pages.participants.editParticipant.contactRelationship'),
+          field: 'contactRelationship',
+          options: [
+            // Explicit empty string, never `undefined` — a valueless <option> makes `select.value`
+            // fall back to the option TEXT, which is how a localized label once got persisted as
+            // `person.sex`. Same trap, same fix.
+            {
+              label: t('pages.participants.contactRelationship.unspecified'),
+              value: '',
+              selected: !values.contactRelationship,
+            },
+            ...CONTACT_RELATIONSHIPS.map((relationship) => ({
+              label: t(relationshipKey(relationship)),
+              value: relationship,
+              selected: values.contactRelationship === relationship,
+            })),
+          ],
+        },
+        {
+          // The contact's own name — "Ana Rivas", not the competitor's. Only meaningful once a
+          // relationship says the number belongs to someone else, which is why it arrives with it.
+          placeholder: t('pages.participants.editParticipant.contactNamePlaceholder'),
+          label: t('pages.participants.editParticipant.contactName'),
+          value: values.contactName || '',
+          field: 'contactName',
         },
         {
           // Records the person's consent to have THIS CONTACT shared publicly. It is not a promise that


### PR DESCRIPTION
Adopts factory [#4683](https://github.com/CourtHive/competition-factory/pull/4683) in TMX. CA 2026-08-22: *"shouldn't be blocked because I will publish factory before TMX gets released, so do it — TMX can use the local build."*

## 1. The GROUP contact person becomes first-class

It began as `extensions[{ name: 'contactPerson' }]` because CODES had no field for it — checked at the time, not assumed. #4683 added `Participant.contactParticipantIds`, which the engine **validates against membership on write** and **prunes on delete**; the extension was neither. The resolver now reads both and the modal writes only the new field.

The extension read stays. Groups created between #1324 and this change carry it and nothing migrates them in bulk — it can go once no record answers to it.

**The trap that shaped the write path.** Because the resolver falls back to the extension when the first-class field resolves to nothing, clearing the contact on a pre-migration group would have **resurrected the old pointer** on the next read. So the extension is removed in the same `executionQueue` whenever the group still carries one.

That is also why `hasContactPersonExtension` is deliberately **not** membership-checked, unlike the resolver: a pointer at a non-member is exactly the kind that most needs removing, since re-adding that member would otherwise revive a designation nobody asked for.

## 2. `Contact.relationship` reaches the drawer

A minor's number is routinely a parent's, a guardian's or a travelling chaperone's, and a contact could carry only a `name` — so "Ana Rivas, +33…" was ambiguous between the competitor's own mobile and somebody else's. The contact's own name is now enterable beside it, which is what makes the relationship meaningful.

Defaults to **unspecified, never SELF**. Defaulting would assert something nobody entered, on the field that decides who a director may ring at 9pm about a minor.

**A regression the existing suite caught before it shipped:** `name` is now an edited field, so `{ ...primaryContact, name }` with an absent input erased a stored contact name. *keeps fields the drawer does not edit* went red. `relationship` and `name` are now applied only when their inputs are **present** — an absent input and an emptied one are different instructions.

## Why the vocabulary is a local list

TMX CI **strips the `link:../factory` override** and installs the published pin (`ci.yml` → "Strip link: overrides for CI"), currently 6.29.1. `ContactRelationshipEnum` does not exist there, so importing it would pass locally against the rebuilt dist and fail CI on both type-check and runtime — the exact divergence `link:` overrides hide.

So `src/constants/contactRelationships.ts` carries the six values with an explicit expiry: swap for the factory enum once the publish and the bump land. Tracked in Mentat `TASKS.md`. A hand-copied vocabulary that outlives its reason is how SCOREKEEPER and TIMEKEEPER stayed missing from the Staff view for months — this one is scheduled to die.

For the same reason the tests assert **what TMX dispatches**, not what the factory persists, so they hold against the published pin.

## Falsification

| reverted | red |
|---|---|
| first-class read | *resolves the first-class field*, *PREFERS…over a disagreeing extension*, *takes the first RESOLVABLE member* |
| extension fallback | *resolves a pointer to a current member*, *FALLS BACK…*, *falls back when…points at a non-member* |
| conditional `name` | *leaves a stored name ALONE…*, *keeps fields the drawer does not edit* |

## Gates

lint · check-types (src + e2e + electron) · format:check · **1255 tests** (baseline 1240) · i18n-audit `0 new` · attr-audit exit 0.

Also drops `ADD_PARTICIPANT_EXTENSION`, which I added two commits ago and which nothing now uses.

## Ordering

Do not deploy TMX before factory 6.30.0 publishes and consumers are bumped — `contactParticipantIds` and `relationship` are written through untyped mutation params, so against 6.29.1 they run and silently do not persist.
