### PR TITLE
fix(overview): keep groups off the contact card

### DIFF
--- a/src/pages/tournament/tabs/overviewTab/contactCardInsert.test.ts
+++ b/src/pages/tournament/tabs/overviewTab/contactCardInsert.test.ts
@@ -1,0 +1,61 @@
+import { isContactCardPersonnel } from './contactCardInsert';
+import { participantRoles } from 'tods-competition-factory';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The overview contact card filtered on ROLE alone: `participantRole && participantRole !== COMPETITOR`.
+ *
+ * `getParticipants` is called with no `participantFilters`, so GROUPs arrive — and every GROUP the UI
+ * creates carries a role, because the group role select offers OTHER / COACH / MEDICAL / PHYSIO /
+ * TRAINER. A GROUP has no `person`, so the name fell through to `participantName` and a row appeared
+ * that read as a person named "Transport Van A" with a role and no contact details.
+ *
+ * The exact inverse of factory #4684, where the entry gate tested type and forgot role.
+ */
+
+const { COACH, COMPETITOR, OFFICIAL, PHYSIO } = participantRoles;
+
+const individual = (participantRole?: string) => ({
+  participantId: 'p1',
+  participantType: 'INDIVIDUAL',
+  participantRole,
+});
+
+describe('isContactCardPersonnel', () => {
+  it('admits staff and officials', () => {
+    expect(isContactCardPersonnel(individual(OFFICIAL))).toBe(true);
+    expect(isContactCardPersonnel(individual(PHYSIO))).toBe(true);
+  });
+
+  it('REJECTS a role-bearing GROUP — the bug', () => {
+    // "Transport Van A": a group carrying a role, no person, rendered as a human being.
+    const group = {
+      participantId: 'g1',
+      participantType: 'GROUP',
+      participantRole: COACH,
+      participantName: 'Transport Van A',
+    };
+    expect(isContactCardPersonnel(group)).toBe(false);
+  });
+
+  it('rejects a TEAM and a PAIR, which also carry roles and no person', () => {
+    expect(isContactCardPersonnel({ participantType: 'TEAM', participantRole: COMPETITOR })).toBe(false);
+    expect(isContactCardPersonnel({ participantType: 'PAIR', participantRole: COMPETITOR })).toBe(false);
+  });
+
+  it('rejects competitors — the card is for personnel', () => {
+    expect(isContactCardPersonnel(individual(COMPETITOR))).toBe(false);
+  });
+
+  it('rejects an individual with no role', () => {
+    // Deliberately the OPPOSITE of the competitor-facing filters elsewhere. Those ask "is this a
+    // player?", where an absent role means yes. This asks "is this personnel?", where an absent role
+    // means there is nothing to put in the role column — the card renders a role label per row.
+    expect(isContactCardPersonnel(individual(undefined))).toBe(false);
+  });
+
+  it('tolerates malformed entries without throwing', () => {
+    expect(isContactCardPersonnel(undefined)).toBe(false);
+    expect(isContactCardPersonnel({})).toBe(false);
+  });
+});

--- a/src/pages/tournament/tabs/overviewTab/contactCardInsert.ts
+++ b/src/pages/tournament/tabs/overviewTab/contactCardInsert.ts
@@ -1,7 +1,25 @@
-import { participantRoles } from 'tods-competition-factory';
+import { participantConstants, participantRoles } from 'tods-competition-factory';
 import { tournamentEngine } from 'services/factory/engine';
 
 const { COMPETITOR } = participantRoles;
+const { INDIVIDUAL } = participantConstants;
+
+/**
+ * Personnel worth showing on the overview contact card.
+ *
+ * BOTH tests are load-bearing. The role test alone — "has a role and it is not COMPETITOR" — let
+ * **GROUPs** through: `getParticipants` is called with no `participantFilters`, and every GROUP the UI
+ * creates carries a role (the group select offers OTHER / COACH / MEDICAL / PHYSIO / TRAINER). A GROUP
+ * has no `person`, so the name fell through to `participantName` and the card rendered a row that read
+ * as a person named e.g. "Transport Van A", with a role and no way to reach them.
+ *
+ * The exact inverse of the entry-gate bug in factory #4684, which tested type and forgot role. Type
+ * says WHAT a participant is; role says WHAT THEY DO. Personnel needs both.
+ */
+export function isContactCardPersonnel(participant: any): boolean {
+  if (participant?.participantType !== INDIVIDUAL) return false;
+  return !!participant.participantRole && participant.participantRole !== COMPETITOR;
+}
 
 const ROLE_LABELS: Record<string, string> = {
   DIRECTOR: 'Tournament Director',
@@ -35,7 +53,7 @@ function extractContacts(): ContactInfo[] {
   if (!participants?.length) return [];
 
   return participants
-    .filter((p: any) => p.participantRole && p.participantRole !== COMPETITOR)
+    .filter(isContactCardPersonnel)
     .map((p: any) => {
       const person = p.person || {};
       const name =


### PR DESCRIPTION
Third of the three "counted people, meant competitors" sites, and the one that is **visible in the UI today**.

`contactCardInsert.ts` filtered on **role alone**:

```ts
.filter((p: any) => p.participantRole && p.participantRole !== COMPETITOR)
```

`getParticipants` is called with no `participantFilters`, so GROUPs arrive — and every GROUP the UI creates carries a role, because the group role select offers OTHER / COACH / MEDICAL / PHYSIO / TRAINER. A GROUP has no `person`, so the name falls through to `participantName` and the overview renders a row reading as a person named e.g. **"Transport Van A"**, with a role and no way to reach them.

The exact inverse of the entry-gate bug in factory #4684, which tested type and forgot role. **Type says what a participant is; role says what they do.** Personnel needs both.

## One deliberate asymmetry, called out

This predicate treats an **absent role as "not personnel"** — the opposite of the competitor-facing filters shipped elsewhere today (CFS's public route, courthive-public's Players tab, arena's roster), which treat an absent role as "player".

That is not an inconsistency to reconcile later. Those ask *"is this a player?"*, where absent means yes. This asks *"is this personnel?"*, where absent means there is nothing to put in the role column the card renders on every row.

## Falsification

Dropping the type check reddens **exactly one** test — *REJECTS a role-bearing GROUP* — and nothing else. Which is precisely why a test seeding a role-bearing GROUP was the one that had to be written: a fixture with a role-less group, or with no group at all, passes against the broken code.

## Gates

lint · check-types · format:check · **1246 tests** · i18n-audit `0 new` · attr-audit — all exit 0, checked without piping through `tail`.
