### PR TITLE
fix(deps): update tods-competition-factory to 6.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.29.1",
+    "tods-competition-factory": "6.30.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
TMX's half of the 6.30.0 fan-out. The `bump-factory-consumers.sh` run could not include TMX — the checkout was on another session's branch (`feat/inspector-participant-rest`), and preflight aborts rather than switch it. TMX is in the script's `PR_REQUIRED_REPOS` anyway, so this is the same delivery it would have made.

Nine other consumers were synced and pushed directly: courthive-public, courthive-ams, courthive-rankings, courthive-facilities, courthive-components, epixodic, competition-factory-server, pdf-factory, scoringVisualizations. `courthive-ingest` was skipped (uncommitted work in progress) and still needs a follow-up run.

## Only package.json changes, and that is correct

`pnpm install --lockfile-only` produced no lockfile diff. `pnpm-lock.yaml:118` records the specifier as `link:../factory`, not the pinned version, because `pnpm-workspace.yaml` carries the sibling override — so the pin never appears in the lockfile. CI strips those overrides and installs the **published** version from `package.json`, which is exactly what this changes.

## What this unblocks

TMX [#1327](https://github.com/CourtHive/TMX/pull/1327) writes `contactParticipantIds` and `Contact.relationship`, both added in factory #4683. Against the 6.29.1 pin those run through untyped mutation params and **silently do not persist**. With this merged they work.

After this and #1327 land, `src/constants/contactRelationships.ts` can be deleted in favour of importing `ContactRelationshipEnum` from the factory — it exists in 6.30.0. That swap is tracked in Mentat `TASKS.md`.
