### PR TITLE
fix(deps): update courthive-components to 3.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.14.3",
+    "courthive-components": "3.15.0",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.21",
     "dexie": "4.4.5",

--- a/src/constants/contactRelationships.test.ts
+++ b/src/constants/contactRelationships.test.ts
@@ -1,0 +1,30 @@
+import { CONTACT_RELATIONSHIPS, relationshipKey } from 'constants/contactRelationships';
+import { ContactRelationshipEnum } from 'tods-competition-factory';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * This list was briefly hand-written, because CI installs the PUBLISHED factory pin and 6.29.1 had no
+ * `ContactRelationshipEnum`. Now that the pin is 6.30.0 it is derived — and this file is the guard
+ * that a literal list could never provide.
+ */
+
+describe('CONTACT_RELATIONSHIPS is derived from the factory enum', () => {
+  it('covers every member the factory defines', () => {
+    // If CODES gains a relationship, this fails rather than silently offering a director an
+    // incomplete dropdown. A hand-copied list drifts in exactly this way — it is how SCOREKEEPER and
+    // TIMEKEEPER stayed missing from the Staff view for months.
+    expect([...CONTACT_RELATIONSHIPS].sort()).toEqual(Object.values(ContactRelationshipEnum).sort());
+  });
+
+  it('leads with SELF rather than the enum ordering', () => {
+    // The enum is alphabetical, which would put CHAPERONE at the top of the dropdown. Ordering here is
+    // a UI decision: the common case first, then people answering for someone else, then catch-alls.
+    expect(CONTACT_RELATIONSHIPS[0]).toEqual(ContactRelationshipEnum.SELF);
+  });
+
+  it('maps each value to a lowercase i18n key', () => {
+    expect(relationshipKey(ContactRelationshipEnum.GUARDIAN)).toEqual(
+      'pages.participants.contactRelationship.guardian',
+    );
+  });
+});

--- a/src/constants/contactRelationships.ts
+++ b/src/constants/contactRelationships.ts
@@ -1,3 +1,5 @@
+import { ContactRelationshipEnum } from 'tods-competition-factory';
+
 /**
  * Whose number a contact is — `Contact.relationship`, added to CODES by factory #4683.
  *
@@ -5,23 +7,24 @@
  * previously carry only a `name`. `SELF` earns its place because without it "the competitor's own
  * mobile" and "an unlabelled number" are the same state.
  *
- * ## Why this is a local list and not `ContactRelationshipEnum` from the factory
+ * Derived from the factory enum, never hand-copied. This file briefly held a literal list because CI
+ * strips the `link:../factory` override and installs the PUBLISHED pin, which was 6.29.1 and had no
+ * such symbol — importing it would have passed locally against the rebuilt dist and failed CI. With
+ * the pin now at 6.30.0 the duplication has served its purpose and is gone. Verified in the published
+ * 6.30.0 tarball, not merely through the local symlink.
  *
- * TMX CI strips the `link:../factory` override and installs the PUBLISHED pin (`ci.yml` — "Strip link:
- * overrides for CI"), currently 6.29.1. `ContactRelationshipEnum` does not exist there, so importing it
- * would fail the type-check gate and throw at runtime in CI while passing locally against the rebuilt
- * dist — the exact class of divergence that `link:` overrides hide.
- *
- * This is therefore a DELIBERATE, TEMPORARY duplication with a defined end: once the factory publishes
- * and TMX's pin is bumped, replace the array below with
- *
- *     const { ContactRelationshipEnum } = require('tods-competition-factory');
- *
- * and delete this comment. Tracked in `Mentat/TASKS.md` under "TMX: adopt the CODES contact model".
- * A hand-copied vocabulary that outlives its reason is how SCOREKEEPER and TIMEKEEPER stayed missing
- * from the Staff view for months — this one is scheduled to die.
+ * Ordered deliberately rather than alphabetically: SELF first because it is the common case, then the
+ * people who answer for someone else, then the catch-alls. The enum's own member order is alphabetical
+ * and would put CHAPERONE at the top of a director's dropdown.
  */
-export const CONTACT_RELATIONSHIPS = ['SELF', 'PARENT', 'GUARDIAN', 'CHAPERONE', 'EMERGENCY', 'OTHER'] as const;
+export const CONTACT_RELATIONSHIPS = [
+  ContactRelationshipEnum.SELF,
+  ContactRelationshipEnum.PARENT,
+  ContactRelationshipEnum.GUARDIAN,
+  ContactRelationshipEnum.CHAPERONE,
+  ContactRelationshipEnum.EMERGENCY,
+  ContactRelationshipEnum.OTHER,
+] as const;
 
 export type ContactRelationship = (typeof CONTACT_RELATIONSHIPS)[number];
 


### PR DESCRIPTION
TMX's half of the components 3.15.0 fan-out, plus the deferred cleanup that 6.30.0 unblocked.

`bump-components-consumers.sh` could not include TMX — the shared checkout is on another session's branch (`feat/inspector-participant-rest`) and preflight aborts rather than switch it. courthive-public, epixodic and courthive-ams/client were bumped and pushed directly; that script has no `--skip`, so those three were done by hand against its exact target list (`package.json`, and `client/package.json` for AMS).

Only `package.json` changes in each: every one of these repos carries a `link:` override for courthive-components, so `pnpm-lock.yaml` records `link:../courthive-components` and the pin never reaches the lockfile. CI strips the override and installs the published version from `package.json`.

## The relationship vocabulary is now derived, not copied

`src/constants/contactRelationships.ts` held a hand-written list of the six values. That was deliberate and dated: CI installs the **published** pin, 6.29.1 had no `ContactRelationshipEnum`, and importing it would have passed locally against the rebuilt dist while failing CI — the exact divergence a `link:` override hides. #1329 moved the pin to 6.30.0, so the reason expired.

**Verified in the published tarball, not through the symlink.** `npm pack tods-competition-factory@6.30.0` and requiring `dist/tods-competition-factory.development.cjs.js` reports `CHAPERONE,EMERGENCY,GUARDIAN,OTHER,PARENT,SELF`. The local symlink was the thing that could have lied about this, so it was not the evidence used.

`contactRelationships.test.ts` is the guard a literal list could never provide:

- the exported list covers **every** member the enum defines — a future CODES addition now fails a test instead of quietly leaving a director an incomplete dropdown;
- the UI ordering is pinned separately (SELF first, not the enum's alphabetical CHAPERONE), so "what values exist" and "what order to show them" stay independent.

## Gates

lint · check-types · format:check · **1269 tests** (baseline 1246).
