### PR TITLE
fix(deps): update pdf-factory to 0.8.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.19",
+    "pdf-factory": "0.8.20",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",


### PR DESCRIPTION
Follows the pdf-factory 0.8.20 and @courthive/scoring-visualizations 0.2.16 releases.

## Only pdf-factory changes, and that is the whole finding

TMX carries the two libraries differently:

| dep | TMX declares | published | needs a change? |
|---|---|---|---|
| `pdf-factory` | `0.8.19` — **exact pin** | 0.8.20 | **yes** — an exact pin admits nothing else |
| `@courthive/scoring-visualizations` | `^0.2.9` — caret | 0.2.16 | **no** |

`^0.2.9` on a 0.x package means `>=0.2.9 <0.3.0`. 0.9 → 0.2.16 is a **patch** gap inside the same minor, so the caret already admits it — TMX's CI has been resolving the newest 0.2.x all along.

Verified rather than reasoned about: `npm view "@courthive/scoring-visualizations@^0.2.9" version` lists `0.2.14`, `0.2.15`, `0.2.16`. Raising the floor to `^0.2.16` would be pure churn — 0.2.16 contains only a factory devDependency bump, no new API, so nothing here uses anything the current caret excludes.

The landmine in this ecosystem is a 0.x **minor** gap on a linked sibling, because the `link:` override makes local builds compile against the sibling's working tree while CI resolves from the registry per the caret. That is not the case here; both releases are dep-bump-only.

## Gates

lint · check-types · **1328 tests** (126 files).

Only `package.json` changes: both libraries have `link:` overrides in `pnpm-workspace.yaml`, so the lockfile records `link:../pdf-factory` and the pin never reaches it. CI strips the overrides and installs from `package.json`.
