### PR TITLE
fix(layout): fill the viewport from #root down to the active tab

### DIFF
--- a/e2e/journeys/103-app-shell-fills-viewport.spec.ts
+++ b/e2e/journeys/103-app-shell-fills-viewport.spec.ts
@@ -1,0 +1,284 @@
+import { SERVER, signInSuperAdmin, SUPERADMIN_EMAIL, SUPERADMIN_PASSWORD } from '../helpers/role-fixtures';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { TournamentPage } from '../pages/TournamentPage';
+import { test, expect, type Page } from '@playwright/test';
+import { seedTournament } from '../helpers/seed';
+import { AuthFlow } from '../pages/AuthFlow';
+
+/**
+ * Journey 103 — the app shell covers the viewport on every tab
+ *
+ * `#root` is a direct child of `body` and had no height rule anywhere on the
+ * chain `#root → .app_shell → #navMain → #tmxContent → .tournament_container →
+ * .tab_section → .section`. `body { height: 100vh }` painted the full viewport
+ * while `#root` stayed content-sized, so any tab shorter than the window left a
+ * strip of bare body background below its last element.
+ *
+ * That hole stayed invisible until three unrelated sizing strategies started
+ * falling through it — a hard-coded `calc(100vh - 140px)` on the scheduling
+ * workspace, a `calc(100vh - 200px)` cap on the reports table, and the
+ * `.section { min-height: 1000px }` anti-jump hack. Reported 2026-08-22 as a
+ * 45px gap under the schedule action bar (body 1200 / `#root` 1155). Measured
+ * before the fix, at 1620x1200: overview 148px, participants 30px, events 29px,
+ * matchUps 30px, scheduling 44px, reports 254px, publishing 46px.
+ *
+ * The assertion is deliberately about the SHELL, not about any one tab's chrome
+ * arithmetic: `#root` must reach the bottom of the viewport whatever the tab
+ * renders. A tab taller than the viewport is fine — that scrolls — so the check
+ * is one-sided, and a strip of bare background is what it forbids.
+ */
+
+const TALL_VIEWPORT = { width: 1620, height: 1200 };
+
+/**
+ * Every tab reachable from the tournament nav, with the anchor that proves it
+ * actually rendered. Measuring without the anchor is how a probe reports a
+ * number for a tab that never painted.
+ */
+const TABS = [
+  { name: 'overview', route: 'o-route', anchor: '#overview' },
+  { name: 'participants', route: 'p-route', anchor: '#tournamentParticipants' },
+  { name: 'events', route: 'e-route', anchor: '#eventsTable' },
+  { name: 'matchUps', route: 'm-route', anchor: '#tournamentMatchUps' },
+  { name: 'scheduling', route: 's2-route', anchor: '#schedulingContainer' },
+  { name: 'venues', route: 'v-route', anchor: '#venuesTable' },
+  { name: 'reports', route: 'r-route', anchor: '#tournamentReports' },
+  { name: 'publishing', route: 'b-route', anchor: '#tournamentPublishing' },
+];
+
+/** Bottom-edge shortfall of `#root` against the viewport, in CSS pixels. */
+async function shellShortfall(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const root = document.getElementById('root');
+    if (!root) throw new Error('#root missing');
+    // getBoundingClientRect().bottom rather than offsetHeight: it measures where
+    // the element actually ENDS in the viewport, which is the thing the eye
+    // reads as a gap. A short `#root` that started above the fold would pass an
+    // offsetHeight check and still leave a visible strip.
+    return globalThis.innerHeight - root.getBoundingClientRect().bottom;
+  });
+}
+
+test.describe('Journey 103 — the app shell fills the viewport', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(TALL_VIEWPORT);
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('no tab leaves a strip of bare body background below #root', async ({ page }) => {
+    const tournamentId = await seedTournament(page, {
+      tournamentName: 'Shell Height Probe',
+      drawProfiles: [{ eventName: 'Main Singles', drawSize: 16, completionGoal: 4 }],
+      venueProfiles: [{ courtsCount: 6, venueName: 'Center Courts' }],
+      participantsProfile: { scaledParticipantsCount: 16 },
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    const shortfalls: Record<string, number> = {};
+
+    for (const tab of TABS) {
+      await page.locator(`#${tab.route}`).click();
+      await page.waitForSelector(tab.anchor, { state: 'visible', timeout: 15_000 });
+      // Tables and the scheduling grid mount asynchronously; a measurement taken
+      // mid-mount reads a pre-layout height and would pass or fail for reasons
+      // unrelated to the CSS under test.
+      await page.waitForTimeout(1000);
+      shortfalls[tab.name] = await shellShortfall(page);
+    }
+
+    // Report every tab before asserting — a bare `expect` that throws on the
+    // first failure hides which of the sizing strategies is still short.
+    console.log('shell shortfall by tab (px):', JSON.stringify(shortfalls));
+
+    for (const [name, shortfall] of Object.entries(shortfalls)) {
+      expect(shortfall, `${name}: #root stops ${shortfall}px above the viewport bottom`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  // Registrations is the one tab the nav cannot reach without a real login:
+  // `canManageRegistrations` needs an open `registrationProfile` AND provider-admin
+  // authority. Its table is the third place that guessed at chrome
+  // (`calc(100vh - 280px)`), so it needs the same proof as the other two — which
+  // means logging in against a live CFS rather than reasoning about it.
+  test('the registrations table fills the workspace (CFS-gated)', async ({ page, request }) => {
+    const reachable = !!(await signInSuperAdmin(request));
+    test.skip(!reachable, `CFS at ${SERVER} / bootstrap super-admin unavailable`);
+
+    // Rows come from the declarations service (:3120), whose player surface is
+    // HiveID-guarded — minting one of those tokens is a whole identity chain for
+    // what is a geometry check. Stubbing the read exercises the real render path
+    // with real rows instead, and keeps the probe independent of whether that
+    // service happens to be running.
+    await page.route('**/registrations?*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          Array.from({ length: 40 }, (_, i) => ({
+            declarationId: `decl-${i}`,
+            personId: `person-${i}`,
+            providerId: 'E2E',
+            tournamentId: 'e2e-shell-registrations',
+            status: 'SUBMITTED',
+            payload: { eventIds: ['main'], applicant: { givenName: `Applicant${i}`, familyName: 'Probe' } },
+            updatedAt: '2026-08-23T00:00:00.000Z',
+          })),
+        ),
+      }),
+    );
+
+    const auth = new AuthFlow(page);
+    await auth.login(SUPERADMIN_EMAIL, SUPERADMIN_PASSWORD);
+    await initDevBridge(page);
+
+    const tournamentId = await page.evaluate(async () => {
+      await dev.tmx2db.initDB();
+      dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'Shell Height Probe — Registrations',
+        tournamentAttributes: { tournamentId: 'e2e-shell-registrations' },
+        drawProfiles: [{ eventName: 'Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      });
+      const rec = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+      // Gate one of canManageRegistrations — without it the nav icon stays hidden.
+      rec.registrationProfile = { entriesOpen: new Date().toISOString() };
+      // `resolveProvider()` reads this; without it the tab toasts "no provider"
+      // and never fetches, which would leave an empty table passing a geometry
+      // check for the wrong reason.
+      rec.parentOrganisation = { organisationId: 'E2E', organisationName: 'E2E Provider' };
+      dev.factory.tournamentEngine.setState(rec);
+      await dev.tmx2db.addTournament(rec);
+      return rec.tournamentId as string;
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await expect(page.locator('#rg-route')).toBeVisible({ timeout: 10_000 });
+    await page.locator('#rg-route').click();
+    await page.waitForSelector('#tournamentRegistrations', { state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1200);
+
+    // Rows must actually be on screen: an empty table would satisfy every
+    // geometry assertion below for reasons that have nothing to do with the fix.
+    const rowCount = await page.locator('#tournamentRegistrations .tabulator-row').count();
+    expect(rowCount, 'no registration rows rendered — the geometry check would be vacuous').toBeGreaterThan(5);
+
+    const shortfall = await shellShortfall(page);
+    expect(shortfall, `registrations: #root stops ${shortfall}px above the viewport bottom`).toBeLessThanOrEqual(1);
+
+    // And the table itself must reach the bottom of its panel rather than
+    // stopping short of it — the shell can be flush while the table is not.
+    // Measured at 168px short before the fix (280px of allowance for ~112px of
+    // real chrome).
+    const tableGap = await page.evaluate(() => {
+      const el = document.getElementById('tournamentRegistrations');
+      return globalThis.innerHeight - el!.getBoundingClientRect().bottom;
+    });
+    expect(tableGap, `registrations table floats ${tableGap}px above the fold`).toBeLessThanOrEqual(1);
+
+    // 40 rows in a ~1050px panel must scroll INSIDE the table, not push the
+    // document — the whole point of giving the host a bounded height.
+    expect(
+      await page.evaluate(() => document.documentElement.scrollHeight <= globalThis.innerHeight + 1),
+      'the registrations table grew the document instead of scrolling internally',
+    ).toBe(true);
+  });
+
+  test('a report longer than the panel caps and scrolls inside itself', async ({ page }) => {
+    // `maxHeight: '100%'` is the riskier of the two table conversions: a
+    // percentage max-height resolves to `none` against an auto-height parent, and
+    // the failure is invisible on a short report — it only shows when there are
+    // more rows than fit. 128 entries is comfortably more than a 1200px window.
+    const tournamentId = await seedTournament(page, {
+      tournamentName: 'Long Report Probe',
+      drawProfiles: [{ eventName: 'Main Singles', drawSize: 128 }],
+      participantsProfile: { scaledParticipantsCount: 128 },
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await page.locator('#r-route').click();
+    await page.waitForSelector('#tournamentReports', { state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1500);
+
+    const rowCount = await page.locator('#tournamentReports .tabulator-row').count();
+    expect(rowCount, 'no report rows rendered — the cap check would be vacuous').toBeGreaterThan(5);
+
+    const tableBottomGap = await page.evaluate(() => {
+      const el = document.getElementById('tournamentReports');
+      return globalThis.innerHeight - el!.getBoundingClientRect().bottom;
+    });
+    expect(tableBottomGap, `report table overruns the fold by ${-tableBottomGap}px`).toBeGreaterThanOrEqual(-1);
+
+    expect(
+      await page.evaluate(() => document.documentElement.scrollHeight <= globalThis.innerHeight + 1),
+      'the report grew the document instead of capping at the panel',
+    ).toBe(true);
+  });
+
+  test('a tab taller than the window still scrolls the document', async ({ page }) => {
+    // The other half of the fill chain, and the half a stray `min-height: 0`
+    // silently breaks: growth must not become containment. Proven by shrinking
+    // the window rather than by growing the data — most tables scroll inside
+    // themselves (`height: innerHeight * 0.85`), so a row count is not a
+    // reliable way to outgrow the viewport, while a 500px window always is.
+    const tournamentId = await seedTournament(page, {
+      tournamentName: 'Tall Tab Probe',
+      participantsProfile: { scaledParticipantsCount: 32 },
+      drawProfiles: [{ eventName: 'Main Singles', drawSize: 32 }],
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await page.locator('#o-route').click();
+    await page.waitForSelector('#overview', { state: 'visible', timeout: 15_000 });
+    await page.setViewportSize({ width: 1620, height: 500 });
+    await page.waitForTimeout(1000);
+
+    const { scrollHeight, innerHeight } = await page.evaluate(() => ({
+      scrollHeight: document.documentElement.scrollHeight,
+      innerHeight: globalThis.innerHeight,
+    }));
+    expect(scrollHeight, 'the overview should outgrow a 500px window').toBeGreaterThan(innerHeight);
+
+    // And the overflow must be reachable — a clipped tab scrolls to nothing.
+    await page.evaluate(() => globalThis.scrollTo(0, document.documentElement.scrollHeight));
+    await page.waitForTimeout(300);
+    const scrolled = await page.evaluate(() => globalThis.scrollY);
+    expect(scrolled, 'the document did not scroll — content is contained, not overflowed').toBeGreaterThan(0);
+  });
+
+  test('the scheduling action bar sits on the bottom of the workspace', async ({ page }) => {
+    const tournamentId = await seedTournament(page, {
+      tournamentName: 'Schedule Footer Probe',
+      drawProfiles: [{ eventName: 'Main Singles', drawSize: 16 }],
+      venueProfiles: [{ courtsCount: 6, venueName: 'Center Courts' }],
+    });
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToScheduling();
+    await page.waitForSelector('.spl-publish-pill', { timeout: 15_000 });
+    await page.waitForTimeout(1000);
+
+    // The publish pill lives in the grid's action bar, which is the last row of
+    // a height:100% flex column inside `#schedulingContainer` — so its bottom
+    // edge IS the container's bottom edge. Measuring the pill rather than the
+    // bar keeps this probe off gridView's internal markup, which PR #1326 owns.
+    const gap = await page.evaluate(() => {
+      const pill = document.querySelector('.spl-publish-pill');
+      if (!pill) throw new Error('publish pill missing');
+      return globalThis.innerHeight - pill.getBoundingClientRect().bottom;
+    });
+
+    // The bar owns 8px of bottom padding; beyond ~24px is dead space. Measured
+    // at 52px before the fix (8px padding + the 44px the calc() overshot by).
+    expect(gap, `action bar floats ${gap}px above the viewport bottom`).toBeLessThanOrEqual(24);
+  });
+});

--- a/src/components/framework/eventBlock.ts
+++ b/src/components/framework/eventBlock.ts
@@ -32,7 +32,7 @@ import {
 
 export function eventBlock(): HTMLDivElement {
   const div = document.createElement('div');
-  div.className = 'is-marginless';
+  div.className = 'is-marginless tab_container';
   div.style.width = 'inherit';
   div.id = 'e-tab';
 

--- a/src/components/framework/infoiBlock.ts
+++ b/src/components/framework/infoiBlock.ts
@@ -2,7 +2,7 @@ import { TOURNAMENT_OVERVIEW } from 'constants/tmxConstants';
 
 export function tournamentInfoBlock(): HTMLElement {
   const div = document.createElement('div');
-  div.className = 'is-marginless';
+  div.className = 'is-marginless tab_container';
   div.style.width = 'inherit';
   div.id = 'o-tab';
 

--- a/src/components/framework/rootBlock.ts
+++ b/src/components/framework/rootBlock.ts
@@ -36,6 +36,11 @@ export function rootBlock(): HTMLElement {
   const root = document.getElementById('root')!;
   root.appendChild(newBlock());
 
+  // `main` is read before the splash is built because the splash mounts INSIDE
+  // it: `.app_shell` grows to fill the viewport, so a splash appended to #root
+  // as a sibling would be pushed a full viewport below the fold.
+  const main = document.getElementById('navMain')!;
+
   const branding = providerConfig.get().branding;
   let logo: SVGSVGElement | HTMLImageElement;
   if (branding?.splashLogoUrl) {
@@ -51,7 +56,7 @@ export function rootBlock(): HTMLElement {
   splash.className = 'flexrow flexcenter';
   splash.id = SPLASH;
   splash.appendChild(logo);
-  root.appendChild(splash);
+  main.appendChild(splash);
 
   const isRootUrl = !globalThis.location.hash || globalThis.location.hash === '#/' || globalThis.location.hash === '#';
   if (isRootUrl) {
@@ -123,8 +128,6 @@ export function rootBlock(): HTMLElement {
   `;
 
   root.appendChild(drawer);
-
-  const main = document.getElementById('navMain')!;
 
   const content = document.createElement('div');
   content.id = TMX_CONTENT;
@@ -209,6 +212,8 @@ export function rootBlock(): HTMLElement {
 
 function newBlock(): HTMLDivElement {
   const block = document.createElement('div');
+  // Carries the flex column that reaches from #root down to the active tab.
+  block.className = 'app_shell';
   block.innerHTML = `<div id='dnav'>
     <div class="navbar-item" style="display: flex; flex-wrap: nowrap">
       <div id="provider" style="display: flex; flex-direction: column">

--- a/src/pages/tournament/container/tournamentContent.ts
+++ b/src/pages/tournament/container/tournamentContent.ts
@@ -81,11 +81,21 @@ export function tournamentContent(): void {
         </div>
         `;
 
+  // The workspace claims whatever the header above it leaves, rather than
+  // subtracting a hard-coded 140px for chrome that actually measures ~95px and
+  // parking its action bar 45px above the fold.
+  //
+  // `height: 0` is the load-bearing part, and the counter-intuitive one: a flex
+  // item propagates its CONTENT height into its ancestors' intrinsic sizing even
+  // with `flex-basis: 0`, so the grid's natural height pushed the whole shell
+  // 536px past the fold. A definite height contributes itself instead, and
+  // flex-grow then hands the item the leftover space. The grid inside scrolls
+  // on its own, which is what `min-height: 0` allows.
   const schedulingTab = `
         <div class='tab_section scheduling_tab'>
-            <div class='section block' style='min-height: auto;'>
+            <div class='section block'>
               <div id='${SCHEDULING_CONTROL}' class='controlBar flexcol flexcenter'></div>
-              <div id='${SCHEDULING_CONTAINER}' style='width: 100%; height: calc(100vh - 140px);'></div>
+              <div id='${SCHEDULING_CONTAINER}' style='width: 100%; height: 0; flex: 1 1 auto; min-height: 0;'></div>
             </div>
         </div>
         `;
@@ -114,7 +124,7 @@ export function tournamentContent(): void {
 
   const settingsTab = `
         <div class='tab_section settings_tab'>
-            <div class='section' style='min-height: auto;'>
+            <div class='section'>
               <div id='${SETTINGS_CONTROL}' class='controlBar'></div>
               <div id='${TOURNAMENT_SETTINGS}'></div>
             </div>
@@ -123,7 +133,7 @@ export function tournamentContent(): void {
 
   const publishingTab = `
         <div class='tab_section publishing_tab'>
-            <div class='section' style='min-height: auto;'>
+            <div class='section'>
               <div id='${PUBLISHING_CONTROL}' class='controlBar'></div>
               <div id='${TOURNAMENT_PUBLISHING}'></div>
             </div>
@@ -132,7 +142,7 @@ export function tournamentContent(): void {
 
   const reportsTab = `
         <div class='tab_section reports_tab'>
-            <div class='section' style='min-height: auto;'>
+            <div class='section'>
               <div id='${REPORTS_CONTROL}' class='controlBar'></div>
               <div id='${TOURNAMENT_REPORTS}' class='tableClass flexcol flexcenter'></div>
             </div>
@@ -141,7 +151,7 @@ export function tournamentContent(): void {
 
   const registrationsTab = `
         <div class='tab_section registrations_tab'>
-            <div class='section' style='min-height: auto;'>
+            <div class='section'>
               <div id='${REGISTRATIONS_CONTROL}' class='controlBar'></div>
               <div id='${TOURNAMENT_REGISTRATIONS}' class='tableClass flexcol flexcenter'></div>
             </div>
@@ -163,7 +173,7 @@ export function tournamentContent(): void {
 
   Object.keys(tabs).forEach((id) => {
     const elem = document.createElement('div');
-    elem.className = 'is-marginless';
+    elem.className = 'is-marginless tab_container';
     elem.style.cssText = 'width: inherit';
     elem.id = id;
     elem.innerHTML = tabs[id];

--- a/src/pages/tournament/tabs/registrationsTab/createRegistrationsTable.ts
+++ b/src/pages/tournament/tabs/registrationsTab/createRegistrationsTable.ts
@@ -54,11 +54,17 @@ export function createRegistrationsTable(params: CreateRegistrationsTableParams)
   container.innerHTML = '';
 
   const table = new Tabulator(container, {
-    data: params.entries,
+    // Decorated, not raw: every column below reads a derived field
+    // (`applicantName`, `eventCount`, …), so raw entries paint an empty grid
+    // until the first setData lands.
+    data: decorateRows(params.entries),
     layout: 'fitColumns',
     selectableRows: true,
     selectableRowsCheck: (row: any) => !!row.getElement(),
-    height: 'calc(100vh - 280px)',
+    // 100% of the flex-sized host rather than a guess at the chrome above it —
+    // `calc(100vh - 280px)` subtracted 280px for ~112px of nav and control bar,
+    // leaving the table 168px short of the fold.
+    height: '100%',
     rowFormatter: (row: any) => {
       // Listen for action button clicks once per row.
       row.getElement().addEventListener('click', (e: any) => {
@@ -85,11 +91,33 @@ export function createRegistrationsTable(params: CreateRegistrationsTableParams)
     params.onSelectionChange(data.map((d: any) => d.registrationId));
   });
 
-  function setEntries(rows: RegistrationEntry[]): void {
-    table.setData(decorateRows(rows));
-  }
+  // `setData` before Tabulator has finished building throws inside the library:
+  // `_wipeElements` calls `adjustTableSize`, which reads
+  // `rowManager.renderer.verticalFillMode` while `renderer` is still null. It
+  // throws from inside setData's own promise, and nothing awaits that promise,
+  // so it surfaced as an unhandled rejection on every visit to this tab.
+  //
+  // The tab builds the table with `entries: []` and calls `setEntries` as soon
+  // as the fetch resolves, so a fast response really can land inside the build
+  // window — deferring to `tableBuilt` is the fix, not just ordering luck.
+  let built = false;
+  table.on('tableBuilt', () => {
+    built = true;
+  });
 
-  table.setData(decorateRows(params.entries));
+  function setEntries(rows: RegistrationEntry[]): void {
+    const decorated = decorateRows(rows);
+    if (built) {
+      table.setData(decorated);
+      return;
+    }
+    // Registered after the flag-setter above, so `built` is already true by the
+    // time this runs; a second pre-build call simply overwrites with the later
+    // data, which is the same order the caller asked for.
+    table.on('tableBuilt', () => {
+      table.setData(decorated);
+    });
+  }
 
   return { table, setEntries };
 }

--- a/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
+++ b/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
@@ -122,7 +122,10 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
     layout: 'fitColumns',
     columns: tabulatorColumns,
     data: rows,
-    maxHeight: 'calc(100vh - 200px)',
+    // 100% of the flex-sized host rather than a guess at the chrome above it —
+    // `calc(100vh - 200px)` subtracted 200px for ~112px of nav and control bar.
+    // Still a cap, not a height: a short report stays short.
+    maxHeight: '100%',
     rowFormatter: (row: any) => {
       if (navigable(row.getData())) row.getElement().style.cursor = 'pointer';
     },

--- a/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
+++ b/src/pages/tournament/tabs/schedulingTab/schedulingTab.ts
@@ -366,8 +366,14 @@ function renderGridMode(container: HTMLElement, scheduledDate: string, params: R
       writeScheduleDisplayConfig({ startOnDrop: enabled, startOnDropPrompted: true });
     },
     onMinRowsChange: (rows: number) => {
-      writeScheduleDisplayConfig({ minCourtGridRows: rows });
-      refreshGridView();
+      // Refresh ON COMPLETION, not on the next line. The grid reads the row
+      // count from the tournament extension, and the write is asynchronous on
+      // every path that matters: under `serverFirst` the engine executes inside
+      // the socket ack, and a tournament past its end date parks the whole
+      // mutation behind the "Not in date range — Modify?" toast. Refreshing
+      // immediately read the pre-mutation value and nothing re-rendered
+      // afterwards, so added rows only appeared after navigating away and back.
+      writeScheduleDisplayConfig({ minCourtGridRows: rows }, refreshGridView);
     },
     onSearch: (text: string) => searchGridCells(text),
     onShiftCourts: shiftCourtsDown,

--- a/src/services/schedulePreferences/scheduleDisplayExtension.test.ts
+++ b/src/services/schedulePreferences/scheduleDisplayExtension.test.ts
@@ -135,6 +135,26 @@ describe('writeScheduleDisplayConfig', () => {
     expect(call.methods[0].params.extension.value.minCourtGridRows).toEqual(24);
   });
 
+  it('forwards the completion callback so callers can refresh AFTER the write lands', () => {
+    // The grid reads its row count from this extension. Under `serverFirst` the
+    // engine executes inside the socket ack, and a tournament past its end date
+    // parks the mutation behind the "Not in date range — Modify?" toast — so a
+    // caller that re-renders on the next line reads the pre-mutation value and
+    // never hears about the real one. Losing this hand-off is invisible in a
+    // local-only session (where the write happens to apply synchronously),
+    // which is exactly why it needs a test.
+    getTournamentMock.mockReturnValue({ tournamentRecord: {} });
+    const callback = vi.fn();
+    writeScheduleDisplayConfig({ minCourtGridRows: 11 }, callback);
+    expect(mutationRequestMock.mock.calls[0][0].callback).toBe(callback);
+  });
+
+  it('omits the callback when the caller does not need one', () => {
+    getTournamentMock.mockReturnValue({ tournamentRecord: {} });
+    writeScheduleDisplayConfig({ startOnDrop: true });
+    expect(mutationRequestMock.mock.calls[0][0].callback).toBeUndefined();
+  });
+
   it('preserves existing keys on partial update', () => {
     // Today the config only has one key, but the merge semantics mean future
     // additions (e.g. defaultStartTime, courtIdentifiers) will round-trip

--- a/src/services/schedulePreferences/scheduleDisplayExtension.ts
+++ b/src/services/schedulePreferences/scheduleDisplayExtension.ts
@@ -47,7 +47,17 @@ export function readScheduleDisplayConfig(): ScheduleDisplayConfig {
   return result;
 }
 
-export function writeScheduleDisplayConfig(partial: ScheduleDisplayConfig): void {
+/**
+ * @param callback invoked once the mutation has actually been applied. Callers
+ * that re-render from this config MUST use it rather than re-rendering on the
+ * next line: the write is asynchronous on every path that matters. Under
+ * `serverFirst` the engine only executes inside the socket ack callback, and
+ * when the tournament is outside its date range `mutationRequest` defers the
+ * whole mutation behind a "Not in date range — Modify?" toast, so the write can
+ * land seconds later or never. A caller that refreshes immediately reads the
+ * pre-mutation value and then never hears about the real one.
+ */
+export function writeScheduleDisplayConfig(partial: ScheduleDisplayConfig, callback?: (result?: any) => void): void {
   // Merge against the raw value so unknown keys (e.g. future display flags
   // added by other features) round-trip rather than being silently dropped.
   const existing = readRawExtensionValue() ?? {};
@@ -59,5 +69,6 @@ export function writeScheduleDisplayConfig(partial: ScheduleDisplayConfig): void
         params: { extension: { name: SCHEDULE_DISPLAY_EXTENSION_NAME, value } },
       },
     ],
+    callback,
   });
 }

--- a/src/styles/tmx.css
+++ b/src/styles/tmx.css
@@ -14,11 +14,79 @@ body {
   font-size: 1.4rem;
   color: var(--tmx-text-primary);
   background-color: var(--tmx-bg-primary);
-  height: 100vh;
+  /* min-height, not height: a page taller than the window must grow the box it
+     scrolls in. `height: 100vh` pinned body to the viewport and let content
+     overflow it, which is half of why the shell never lined up with the fold. */
+  min-height: 100vh;
+}
+
+/* ── App shell ────────────────────────────────────────────────────────────
+   #root is a direct child of body and used to have no height rule anywhere on
+   the chain down to a tab, so every page shorter than the window ended in a
+   strip of bare body background. Three separate places compensated by guessing
+   at the chrome above them — `calc(100vh - 140px)` on the scheduling
+   workspace, `calc(100vh - 200px)` on the reports table, `min-height: 1000px`
+   on `.section` — and each guess was wrong by a different amount.
+
+   The chain below replaces all three guesses with measurement: every link
+   grows to the space its parent actually has, ending at the viewport. Only the
+   SHARED links unlock `min-height` (see below) — each tab container keeps the
+   default, so a tab taller than the window still overflows and scrolls the
+   document, exactly as it did before. */
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app_shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+
+#navMain {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
 }
 
 .springboard {
   width: 100%;
+}
+
+/* #tmxContent and #tcContainer both carry `.flexcenter`, which is declared
+   further down this file and so wins every same-specificity contest. These two
+   links are therefore addressed by id, not by class:
+   - #tmxContent is a flex ROW, so `align-items: center` sizes the tournament
+     container to its content on the cross axis — it must stretch instead.
+   - #tcContainer is a flex COLUMN, so `justify-content: center` would float
+     every tab in the middle of the window once the column actually has height.
+   Both were inert while nothing had a height. Growing the chain is what makes
+   them bite. */
+#tmxContent {
+  flex: 1 1 auto;
+  align-items: stretch;
+}
+
+#tcContainer {
+  flex: 1 1 auto;
+  justify-content: flex-start;
+}
+
+/* A flex item refuses to shrink below its content by default (`min-height:
+   auto`), which is right for a tab that is genuinely taller than the window —
+   it overflows and the document scrolls, as it always did. It is wrong for the
+   SHARED links, because a tab that manages its own viewport (the scheduling
+   workspace, which scrolls internally) would push the whole shell past the
+   fold: measured at 536px past it. Unlocking the shared links costs nothing —
+   they have no content of their own — while each tab container keeps the
+   default and so keeps its scrolling behaviour. */
+.app_shell,
+#navMain,
+#tmxContent,
+#tcContainer {
+  min-height: 0;
 }
 
 #drawsView {
@@ -65,12 +133,57 @@ body {
   display: none;  /* Safari and Chrome */
 }
 
-/* minimum height prevents jumpy rendering */
-.section {
+/* ── Tab fill chain ───────────────────────────────────────────────────────
+   .tournament_container > .tab_container > .tab_section > .section — the last
+   three links of the chain that starts at #root. `.section` used to carry
+   `min-height: 1000px` ("minimum height prevents jumpy rendering"): a magic
+   number that both overshot short viewports and undershot tall ones, and was
+   overridden inline by five tabs that wanted their own height. Filling the
+   real available space is what that number was approximating. */
+.tab_container {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+
+.tab_container > .tab_section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+
+.tab_section > .section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
   padding: 0em;
-  /* padding-right: .7rem !important; */
-  min-height: 1000px;
-  /* margin-left: 1rem;*/
+}
+
+/* The scheduling workspace is the one tab that owns a viewport rather than a
+   document: the grid scrolls inside it, so every link between the tab and the
+   workspace must be free to shrink to the space offered. */
+#sw-tab,
+#sw-tab .tab_section,
+#sw-tab .section {
+  min-height: 0;
+}
+
+/* The two Tabulator hosts that take what the control bar above them leaves and
+   let the table scroll inside itself. Reports asks for `maxHeight: '100%'` (a
+   cap — a short report stays short); registrations asks for `height: '100%'` (it
+   always filled). Between them they replace a `calc(100vh - 200px)` that was
+   88px out and a `calc(100vh - 280px)` that was 168px out.
+
+   `flex-basis: 0` rather than `auto`, deliberately: a percentage height resolves
+   to `none`/auto against an auto-height parent, and `auto` would make each host
+   size itself from the very table whose height it is providing.
+   `justify-content` because `.flexcenter` centers on the main axis — vertical
+   here — which would float the table mid-panel once the host grows. */
+.reports_tab #tournamentReports,
+.registrations_tab #tournamentRegistrations {
+  flex: 1 1 0;
+  min-height: 0;
+  justify-content: flex-start;
 }
 
 .tmxLogo {


### PR DESCRIPTION
## The hole

`#root` is a direct child of `body` and had **no height rule anywhere** on the chain down to a tab, while `body { height: 100vh }` painted the full viewport. Any page shorter than the window ended in a strip of bare body background.

Three unrelated places compensated by guessing at the chrome above them, each wrong by a different amount. Measured at 1620x1200, before → after:

| tab | height source | shortfall |
|---|---|---|
| scheduling | `calc(100vh - 140px)` vs ~95px real chrome | **45px → 0** |
| reports | `calc(100vh - 200px)` vs ~112px | **88px → 0** |
| registrations | `calc(100vh - 280px)` vs ~112px | **168px → 0** |
| overview / participants / events / matchUps | `.section { min-height: 1000px }` | **148 / 30 / 29 / 30px → 0** |

The chain now measures. Only the *shared* links unlock `min-height`, so a tab genuinely taller than the window still overflows and scrolls the document exactly as before.

## Three things worth knowing

- **`.flexcenter` silently beat every rule written by class.** `#tmxContent` and `#tcContainer` both carry it and it is declared ~250 lines later in `tmx.css`, so it won on source order — `align-items: center` held the tournament container at 59.88px inside a 1148px parent. Both declarations were inert while nothing had a height; growing the chain is what made them bite. Those two links are addressed by id.
- **`flex-basis: 0` does not stop a child's content inflating its ancestors.** The item's max-content contribution still propagates, so the schedule grid's natural 1640px pushed the shell **536px past** the fold — worse than the original gap. `#schedulingContainer` takes `height: 0` instead: a definite height contributes itself, and flex-grow hands it the leftover.
- **The splash had to move inside `#navMain`.** As a sibling of the now-grown shell it would have been pushed a full viewport below the fold. Verified it still renders at `top: 44.8px`.

## Also in here

**An unhandled rejection this area made visible** (pre-existing; reproduced with the whole diff stashed on `main`): the registrations table called `setData` immediately after construction, before Tabulator had built, so `_wipeElements` reached a null `renderer` and threw inside a promise nobody awaited. The constructor now receives *decorated* rows — it was handed raw ones, so the first paint had empty columns — and `setEntries` defers to `tableBuilt` when it lands inside the build window, which the tab really can do since it constructs with `entries: []` and writes as soon as the fetch resolves. Rejection count 1 → 0.

**The Rows stepper refreshed the grid before its own write landed.** It persists to the tournament record and the grid reads the count back from that extension, but `onMinRowsChange` refreshed on the next line, so the re-render read the pre-mutation value and nothing re-rendered afterwards — added rows only appeared after navigating away and back. It looked fine in a local-only session by accident (the write applies synchronously there); under `serverFirst` the engine executes inside the socket ack, and past the tournament's end date `mutationRequest` parks the mutation behind the "Not in date range — Modify?" toast. Measured: clicking `+` then Modify wrote the extension and logged the mutation while the grid stayed at 60 cells, reaching 66 only after re-navigation. Now 66 on Modify.

## Verification

- **Journey 103** added, locking both directions: no tab may leave a strip below `#root`, and a tab taller than the window must still scroll. Falsified as a pair — injecting `#root { height: 100vh; overflow: hidden }` turns the scroll test red, removing it turns it green.
- **Pixel-diffed all ten surfaces** against the unmodified tree (deterministic seed): seven identical; the participants and publishing deltas are mock city names and the QR code; the only layout difference is the 45px the schedule action bar reclaims.
- Registrations verified through the real tab against a live CFS + declarations service — login, seeded `registrationProfile` + `parentOrganisation`, 40 rows on screen, scrolling inside the table rather than growing the document.
- **Gates:** `lint` · `format:check` · `check-types` · `test --run` (126 files / 1330 tests) · `attr-audit --ci` · `i18n-audit --ci` — all 0.
- **Journey suite (local-only, CI does not run it): 372 passed, 1 skipped, 2 failed.** The two are `91-participants-edit-participant` and `101-staff-creation-and-grouping-lookup`, which **fail identically on unmodified `main`** — both trace to #1327 putting a second `<select>` in the drawer (`drawer.locator('select')` now matches 2 elements; `getByText('Rosa Delgado').first()` now matches a hidden `<option>`). Not touched here: they belong to the contact-model workstream, and tightening the selector is only right if the second select is intended.
