### PR TITLE
test(e2e): identify drawer controls by content, not by being the only one

### DIFF
--- a/e2e/journeys/101-staff-creation-and-grouping-lookup.spec.ts
+++ b/e2e/journeys/101-staff-creation-and-grouping-lookup.spec.ts
@@ -201,10 +201,17 @@ test.describe('Journey 101 — staff creation + grouping lookups', () => {
     // that is on screen — a false failure that says nothing about the feature.
     //
     // The member roster is the assertion that matters: an empty modal would pass a container check.
-    // Scoped to the open dialog, and using a member name that shares no substring with the GROUP name —
-    // an earlier version matched the group's own name in a hidden "Add to group" dropdown and reported
-    // "hidden" for a modal that was on screen.
-    await expect(page.locator('[role="dialog"]').getByText('Rosa Delgado').first()).toBeVisible({ timeout: 5_000 });
+    //
+    // Scoped to a ROSTER ROW, not to any text in the dialog. The roster is a Tabulator table, so
+    // `.tabulator-row` is the thing that means "she is listed as a member". A bare `getByText` keeps
+    // colliding with member names rendered into `<option>`s: first the group's own name in a hidden
+    // "Add to group" dropdown, and since TMX #1327 the contact-person picker, which lists every member
+    // by name (`groupProfileModal.ts:135-138`). Options are hidden, so each collision reports "hidden"
+    // for a modal that is on screen — a false failure saying nothing about the feature. Asserting on
+    // the row is immune to the next dropdown that happens to contain the same name.
+    await expect(
+      page.locator('[role="dialog"] .tabulator-row').filter({ hasText: 'Rosa Delgado' }).first(),
+    ).toBeVisible({ timeout: 5_000 });
 
     // The membership actions the chevron used to hide.
     await expect(page.getByRole('button', { name: /Add members/i }).first()).toBeVisible();

--- a/e2e/journeys/91-participants-edit-participant.spec.ts
+++ b/e2e/journeys/91-participants-edit-participant.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Locator, type Page } from '@playwright/test';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
 import { createMutationCollector } from '../helpers/mutation-collector';
@@ -54,6 +54,14 @@ async function openEditDrawer(page: Page, index: number) {
   const drawer = page.locator(S.TMX_DRAWER);
   await expect(drawer.getByPlaceholder('Given name')).toBeVisible({ timeout: 5_000 });
   return drawer;
+}
+
+/**
+ * The drawer's sex control, identified by the options it contains rather than by being the drawer's
+ * only `<select>` — which it stopped being at TMX #1327 (the contact-relationship picker).
+ */
+function sexSelect(drawer: Locator): Locator {
+  return drawer.locator('select').filter({ has: drawer.page().locator('option[value="FEMALE"]') });
 }
 
 /** The participant the new-participant test creates, or null until it lands. */
@@ -119,7 +127,13 @@ test.describe('Journey 91 — Edit Participant drawer', () => {
     await expect(drawer.getByPlaceholder('Family name')).toHaveValue('Sale');
     await expect(drawer.getByPlaceholder('Display name')).toHaveValue('Ginny');
     await expect(drawer.getByPlaceholder('Birthday')).toHaveValue('1994-03-17');
-    await expect(drawer.locator('select')).toHaveValue('FEMALE');
+    // Identify the sex control by the options it CONTAINS, not by being the only select in the drawer.
+    // It stopped being the only one at TMX #1327, which added the contact-relationship picker ("whose
+    // number this is") — a deliberate field, so the drawer legitimately carries several selects and a
+    // bare `locator('select')` is a strict-mode violation rather than a regression signal. The form
+    // helper only emits an `id` when the caller passes one and this drawer does not, so there is no
+    // id/label anchor to use; the MALE/FEMALE options are the stable identity.
+    await expect(sexSelect(drawer)).toHaveValue('FEMALE');
 
     // The regression: the country must arrive as the picker's own label — the
     // country *name* — not the stored IOC code. Matched loosely on the name and


### PR DESCRIPTION
Journeys **91** and **101** have been red on `main` since **#1327**, which added the contact-relationship picker (*"whose number this is"*) to the participant drawer and a contact-person picker to the group profile modal. Both are deliberate fields, so the drawer legitimately carries several `<select>`s now — and both specs were reporting their own staleness rather than a regression:

| journey | what broke |
|---|---|
| **91** | `drawer.locator('select')` resolves to **2 elements** → Playwright strict-mode violation, on an assertion that means "the sex field" |
| **101** | `[role="dialog"].getByText('Rosa Delgado').first()` resolves to `<option value="coach-ramirez">Rosa Delgado</option>` in the new member picker. Options are hidden, so it reports "hidden" for a modal that is on screen |

## Checked the premise before touching the specs

Tightening a selector is only right if the second select is *intended* — otherwise the specs are reporting a real regression and the fix belongs in the component. It is intended and documented at `editIndividualParticipant.ts:258-283`, defaulting to UNSET rather than SELF on purpose. Quieting a detector to green a board is the failure mode this repo names explicitly, so that question came first.

## The fixes

**91** identifies the sex control by the MALE/FEMALE options it carries. `renderField` only emits an `id` when the caller passes one and this drawer doesn't, so there is no id or label anchor available — the options are the stable identity. This is the same idiom **journey 101 already uses one test earlier** for the role select (`filter({ has: option[value="STRINGER"] })`), with a comment explaining that an index-based locator silently picks the sex field.

**101** asserts on a roster `.tabulator-row` rather than on any text in the dialog. The roster is what *"she is listed as a member"* actually means, and this spec had already been bitten once by a hidden dropdown carrying the same name — its comment records the group's own name in "Add to group". Asserting on the row is immune to the next dropdown that happens to contain it.

## Verification

- **Falsified both:** expecting `MALE`, and filtering for a name not in the roster, each turn the respective test red; restored, both green. Two-run pairs, not single green runs.
- **Full journey suite: 374 passed, 1 skipped, 0 failed** — the first green board since #1327. (Journeys are local-only; CI does not run them.)
- Gates: `lint` · `format:check` · `check-types` · `test --run` (126 files / 1330 tests) · `attr-audit --ci` · `i18n-audit --ci` — all 0.
