### PR TITLE
feat(participants): call sheet + multi-contact editing

### DIFF
--- a/e2e/journeys/104-participants-call-sheet.spec.ts
+++ b/e2e/journeys/104-participants-call-sheet.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { seedTournament, PROFILE_EMPTY_TOURNAMENT } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 100 — the call sheet, and the multi-contact drawer behind it.
+ *
+ * This journey carries more weight than most, because TMX has **no jsdom**: the unit suite runs in
+ * the vitest `node` environment, so the pure logic (`collectContacts`, `buildCallSheet`,
+ * `contactLinks`) is unit-tested and the DOM shell that renders it has no other coverage at all.
+ * Everything asserted here is a thing only a browser can answer — that the `tel:` / `sms:` hrefs
+ * reach the DOM, that the drawer grows a block per stored contact, and that a private contact is
+ * MARKED rather than hidden.
+ *
+ * That last one is decision **D3 (CA, 2026-08-23)**: the TD surface does not respect
+ * `contact.isPublic`. A director sees every contact. `isPublic` governs public surfaces only, and
+ * `getTournamentInfo` still filters `tournamentContacts` on it — untouched by this work. The
+ * assertion below is written so that HIDING a private contact would fail it, which is the
+ * regression D3 exists to prevent.
+ */
+
+const ROWS = `${S.TOURNAMENT_PARTICIPANTS} .tabulator-row`;
+const PHYSIO_MOBILE = '+1 555 0100';
+const PHYSIO_EMERGENCY = '+1 555 0200';
+
+/**
+ * Give the first two participants a STAFF role and contact details.
+ *
+ * Written through the engine rather than the UI because the UI path is what the rest of the journey
+ * exercises; seeding it by hand here would make a failure ambiguous between "cannot enter" and
+ * "cannot display".
+ */
+async function seedPersonnel(page: Page): Promise<void> {
+  await page.evaluate(
+    async ({ mobile, emergency }) => {
+      const engine = dev.factory.tournamentEngine;
+      const { participants } = engine.getParticipants({
+        participantFilters: { participantTypes: ['INDIVIDUAL'] },
+      });
+
+      engine.modifyParticipant({
+        participant: {
+          participantId: participants[0].participantId,
+          participantRole: 'PHYSIO',
+          person: {
+            ...participants[0].person,
+            contacts: [
+              { mobileTelephone: mobile, emailAddress: 'physio@example.org', relationship: 'SELF', isPublic: true },
+              { mobileTelephone: emergency, name: 'Night line', relationship: 'EMERGENCY' },
+            ],
+          },
+        },
+      });
+
+      // A second staff member with NO contact details — the third state the call sheet has to
+      // distinguish, and the one a summary that only counts reachable people would hide.
+      engine.modifyParticipant({
+        participant: { participantId: participants[1].participantId, participantRole: 'TRANSPORT' },
+      });
+
+      await dev.load(dev.getTournament());
+    },
+    { mobile: PHYSIO_MOBILE, emergency: PHYSIO_EMERGENCY },
+  );
+}
+
+async function gotoStaff(page: Page, tournamentId: string): Promise<void> {
+  const tournament = new TournamentPage(page);
+  await tournament.goto(tournamentId);
+  // The Staff view is its own route (`/participants/:participantView`), so it is reached by URL
+  // rather than by the Participants nav tab, which lands on the Competitors view.
+  await page.goto(`/#/tournament/${tournamentId}/participants/STAFF`);
+  await page.waitForSelector(ROWS, { timeout: 15_000 });
+}
+
+test.describe('Journey 100 — participants call sheet', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('the staff row carries tappable tel: and sms: affordances', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+    await seedPersonnel(page);
+    await gotoStaff(page, tournamentId);
+
+    const cell = page.locator(`${ROWS} .tmx-contact-cell`).first();
+    await expect(cell).toBeVisible({ timeout: 10_000 });
+
+    // The dial string, not the text as typed. A `tel:` carrying "+1 555 0100" verbatim does not dial.
+    await expect(cell.locator('a[href^="tel:"]')).toHaveAttribute('href', 'tel:+15550100');
+    await expect(cell.locator('a[href^="sms:"]')).toHaveAttribute('href', 'sms:+15550100');
+    await expect(cell.locator('a[href^="mailto:"]')).toHaveAttribute('href', 'mailto:physio@example.org');
+
+    // The second contact is not rendered in the row — it is announced by the +n marker.
+    await expect(cell.locator('.tmx-contact-more')).toHaveText('+1');
+  });
+
+  test('the call sheet lists every contact and MARKS the private one (D3)', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+    await seedPersonnel(page);
+    await gotoStaff(page, tournamentId);
+
+    await page.getByRole('button', { name: 'Actions' }).click();
+    await page.getByText('Call sheet', { exact: false }).first().click();
+
+    const sheet = page.locator('.tmx-call-sheet');
+    await expect(sheet).toBeVisible({ timeout: 10_000 });
+
+    // BOTH contacts, not just the primary. This is what the multi-contact half of the work bought.
+    const contactLines = sheet.locator('.tmx-call-sheet-contact');
+    await expect(contactLines).toHaveCount(2);
+    await expect(contactLines.nth(1)).toContainText(PHYSIO_EMERGENCY);
+
+    // D3, stated as an assertion. The private contact is PRESENT and MARKED. A regression that
+    // hid it would fail the count above; one that dropped the marker fails here.
+    await expect(sheet.locator('.tmx-contact-private-mark')).toHaveCount(1);
+
+    // The person with no contact details still appears — a sheet that omits them claims the roster
+    // is complete — and reads as an outstanding task rather than a row to act on.
+    await expect(sheet.locator('.tmx-call-sheet-entry.is-muted')).toHaveCount(1);
+    await expect(sheet.locator('.tmx-call-sheet-summary')).toContainText('1 without contact details');
+  });
+
+  test('the drawer renders one block per stored contact, plus a spare', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_EMPTY_TOURNAMENT);
+    await seedPersonnel(page);
+    await gotoStaff(page, tournamentId);
+
+    await page.locator(`${ROWS} .fa-ellipsis-vertical`).first().click();
+    await page.getByText('Edit Participant', { exact: false }).first().click();
+
+    // Two stored contacts → two blocks → plus the blank spare that IS the add affordance.
+    //
+    // Counted, never asserted VISIBLE: `is-checkradio` hides the real <input> and paints the label,
+    // so `toBeVisible` reports "hidden" for a checkbox the director can plainly see and click.
+    const drawer = page.locator(S.TMX_DRAWER);
+    await expect(drawer.locator('input[id^="contactIsPublic"]')).toHaveCount(3, { timeout: 10_000 });
+
+    // The stored values reach their own block rather than all collapsing onto the primary.
+    await expect(drawer.locator('#mobileTelephone')).toHaveValue(PHYSIO_MOBILE);
+    await expect(drawer.locator('#mobileTelephone_1')).toHaveValue(PHYSIO_EMERGENCY);
+    await expect(drawer.locator('#mobileTelephone_2')).toHaveValue('');
+
+    // With more than one stored contact the primary picker appears — reorder is how the primary is
+    // set, because the primary is positional (`contacts[0]`) and not a stored marker.
+    await expect(drawer.locator('#primaryContact input[type="radio"]')).toHaveCount(2);
+  });
+});

--- a/src/components/modals/buildCallSheet.test.ts
+++ b/src/components/modals/buildCallSheet.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The call sheet's data layer.
+ *
+ * The assertions that matter most here are the negative ones. A bulk "text these six" that silently
+ * reaches four is worse than one that refuses, because the director has no way to see the difference
+ * — so every action reports who it will not reach, and that is asserted rather than assumed.
+ */
+import { callSheetPdfRows, emailRecipients, smsRecipients, buildCallSheet, allNumbers } from './buildCallSheet';
+import { describe, expect, it } from 'vitest';
+
+const MOBILE = '+1 555 0100';
+const OTHER_MOBILE = '+1 555 0200';
+const LANDLINE = '+1 555 1111';
+const EMAIL = 'ana@example.org';
+
+const row = (overrides: any = {}) => ({
+  participantType: 'INDIVIDUAL',
+  participantName: 'Ana Rivas',
+  participantId: 'p1',
+  ...overrides,
+});
+
+describe('buildCallSheet', () => {
+  it('splits the population into reachable and unreachable', () => {
+    const sheet = buildCallSheet([
+      row({ participantId: 'p1', contacts: [{ mobileTelephone: MOBILE }] }),
+      row({ participantId: 'p2', participantName: 'Raj Patel', contacts: [] }),
+    ]);
+    expect(sheet.entries.map((e) => e.participantId)).toEqual(['p1']);
+    expect(sheet.unreachable.map((e) => e.participantId)).toEqual(['p2']);
+  });
+
+  it('counts a name-only contact as unreachable', () => {
+    // A director cannot ring a name. This is the state the participants table already distinguishes
+    // from "no contact at all", and collapsing them would hide that a number was never collected.
+    const sheet = buildCallSheet([row({ contacts: [{ name: 'desk' }] })]);
+    expect(sheet.entries).toHaveLength(0);
+    expect(sheet.unreachable).toHaveLength(1);
+  });
+
+  it('preserves the table order rather than re-sorting', () => {
+    // The director sorted the table. A printed sheet that disagrees with the screen it came from is
+    // a sheet nobody trusts.
+    const sheet = buildCallSheet([
+      row({ participantId: 'z', participantName: 'Zoe', contacts: [{ mobileTelephone: MOBILE }] }),
+      row({ participantId: 'a', participantName: 'Abe', contacts: [{ mobileTelephone: OTHER_MOBILE }] }),
+    ]);
+    expect(sheet.entries.map((e) => e.participantName)).toEqual(['Zoe', 'Abe']);
+  });
+
+  it('skips groupings, which have no person and therefore no contacts', () => {
+    // A GROUP names its contact PERSON through `contactParticipantIds`; that person is on the sheet
+    // in their own right. Reporting the group as "unreachable" would be a false alarm on every sheet.
+    const sheet = buildCallSheet([
+      row({ participantType: 'GROUP', participantName: 'Transport Van A' }),
+      row({ participantType: 'TEAM', participantName: 'Team Blue' }),
+    ]);
+    expect(sheet.entries).toHaveLength(0);
+    expect(sheet.unreachable).toHaveLength(0);
+  });
+
+  it('tolerates a row with no participantType, since not every caller sets one', () => {
+    const sheet = buildCallSheet([{ participantName: 'Ana Rivas', contacts: [{ mobileTelephone: MOBILE }] }]);
+    expect(sheet.entries).toHaveLength(1);
+  });
+
+  it('tolerates a non-array input', () => {
+    expect(buildCallSheet(undefined as any)).toEqual({ entries: [], unreachable: [] });
+  });
+});
+
+describe('smsRecipients', () => {
+  it('sends ONE message per person, to their first mobile', () => {
+    // Not every contact they hold: a competitor with a guardian, a chaperone and their own mobile
+    // would otherwise get three copies of the same delay notice.
+    const sheet = buildCallSheet([
+      row({
+        contacts: [
+          { mobileTelephone: MOBILE, relationship: 'SELF' },
+          { mobileTelephone: OTHER_MOBILE, relationship: 'GUARDIAN' },
+        ],
+      }),
+    ]);
+    expect(smsRecipients(sheet).values).toEqual([MOBILE]);
+  });
+
+  it('falls through to a later contact when the primary has no mobile', () => {
+    const sheet = buildCallSheet([row({ contacts: [{ emailAddress: EMAIL }, { mobileTelephone: OTHER_MOBILE }] })]);
+    expect(smsRecipients(sheet).values).toEqual([OTHER_MOBILE]);
+  });
+
+  it('reports the people it will NOT reach, including the ones with a landline only', () => {
+    // The silent-partial-send failure. A director who texts six and reaches four has no way to see
+    // which two missed it unless the action says so.
+    const sheet = buildCallSheet([
+      row({ participantId: 'p1', contacts: [{ mobileTelephone: MOBILE }] }),
+      row({ participantId: 'p2', participantName: 'Raj Patel', contacts: [{ telephone: LANDLINE }] }),
+      row({ participantId: 'p3', participantName: 'Sam Cole', contacts: [] }),
+    ]);
+    const { values, missing } = smsRecipients(sheet);
+    expect(values).toEqual([MOBILE]);
+    expect(missing.map((e) => e.participantId).sort((a, b) => (a as string).localeCompare(b as string))).toEqual([
+      'p2',
+      'p3',
+    ]);
+  });
+
+  it('treats a whitespace-only number as missing', () => {
+    const sheet = buildCallSheet([row({ contacts: [{ mobileTelephone: '   ', emailAddress: EMAIL }] })]);
+    expect(smsRecipients(sheet).values).toEqual([]);
+    expect(smsRecipients(sheet).missing).toHaveLength(1);
+  });
+});
+
+describe('emailRecipients', () => {
+  it('sends one message per person and reports the rest', () => {
+    const sheet = buildCallSheet([
+      row({ participantId: 'p1', contacts: [{ emailAddress: EMAIL }] }),
+      row({ participantId: 'p2', participantName: 'Raj Patel', contacts: [{ mobileTelephone: MOBILE }] }),
+    ]);
+    const { values, missing } = emailRecipients(sheet);
+    expect(values).toEqual([EMAIL]);
+    expect(missing.map((e) => e.participantId)).toEqual(['p2']);
+  });
+});
+
+describe('allNumbers', () => {
+  it('collects every number on the sheet for the clipboard fallback', () => {
+    const sheet = buildCallSheet([
+      row({ contacts: [{ mobileTelephone: MOBILE }, { telephone: LANDLINE }] }),
+      row({ participantId: 'p2', participantName: 'Raj Patel', contacts: [{ mobileTelephone: OTHER_MOBILE }] }),
+    ]);
+    expect(allNumbers(sheet)).toEqual([MOBILE, LANDLINE, OTHER_MOBILE]);
+  });
+});
+
+describe('callSheetPdfRows', () => {
+  it('emits one row per person with contacts stacked and aligned', () => {
+    // The third line of Mobile must belong to the third line of Whose, or the printed sheet
+    // attributes a number to the wrong person.
+    const sheet = buildCallSheet([
+      row({
+        participantRole: 'PHYSIO',
+        contacts: [
+          { name: 'Ana', mobileTelephone: MOBILE, isPublic: true },
+          { relationship: 'EMERGENCY', mobileTelephone: OTHER_MOBILE },
+        ],
+      }),
+    ]);
+    const [printed] = callSheetPdfRows(sheet);
+    expect(printed.participantName).toEqual('Ana Rivas');
+    expect(printed.participantRole).toEqual('PHYSIO');
+    expect(printed.whose).toEqual('Ana\nEMERGENCY');
+    expect(printed.mobileTelephone).toEqual(`${MOBILE}\n${OTHER_MOBILE}`);
+    expect(printed.isPublic).toEqual('Y\nN');
+  });
+
+  it('marks a missing value rather than leaving a cell that looks intentional', () => {
+    const sheet = buildCallSheet([row({ contacts: [{ mobileTelephone: MOBILE }] })]);
+    const [printed] = callSheetPdfRows(sheet);
+    expect(printed.emailAddress).toEqual('—');
+    expect(printed.telephone).toEqual('—');
+  });
+
+  it('prints the unreachable people too, with empty contact cells', () => {
+    // A sheet that silently omits the volunteer whose number nobody collected is a sheet that
+    // claims the roster is complete.
+    const sheet = buildCallSheet([
+      row({ participantId: 'p1', contacts: [{ mobileTelephone: MOBILE }] }),
+      row({ participantId: 'p2', participantName: 'Raj Patel', contacts: [] }),
+    ]);
+    const printed = callSheetPdfRows(sheet);
+    expect(printed).toHaveLength(2);
+    expect(printed[1].participantName).toEqual('Raj Patel');
+    expect(printed[1].mobileTelephone).toEqual('');
+  });
+
+  it('records consent per contact, matching what the factory will publish', () => {
+    const sheet = buildCallSheet([
+      row({
+        contacts: [
+          { mobileTelephone: MOBILE, isPublic: false },
+          { mobileTelephone: OTHER_MOBILE, isPublic: true },
+        ],
+      }),
+    ]);
+    expect(callSheetPdfRows(sheet)[0].isPublic).toEqual('N\nY');
+  });
+});

--- a/src/components/modals/buildCallSheet.ts
+++ b/src/components/modals/buildCallSheet.ts
@@ -1,0 +1,152 @@
+/**
+ * The call sheet's data layer — who is on it, how to reach them, and who cannot be reached.
+ *
+ * Pure and DOM-free, because TMX's unit suite runs in the vitest `node` environment with no jsdom.
+ * Every decision the call sheet makes lives here so it can be tested; `callSheet.ts` is the shell.
+ *
+ * **The population is the table's own rows**, passed in by the caller. Nothing here re-derives which
+ * participants count as personnel. The participants table is already role-filtered per view, and the
+ * factory's `STAFF_CONTACT_ROLES` — the list that decides who appears in `tournamentContacts` — is a
+ * module-local const in `getTournamentInfo`, not exported. Copying it would make a fifth hand-written
+ * role array in this codebase, which is exactly the drift that hid SCOREKEEPER and TIMEKEEPER from
+ * the Staff view for months. It would also be the WRONG list: it deliberately excludes COACH,
+ * CAPTAIN and VOLUNTEER because publishing them would turn the tournament's public contact list into
+ * a roster — and those are precisely the people a director needs to ring at 6am.
+ */
+import { isPublicContact, reachableContacts, primaryNumber } from 'services/contact/contactLinks';
+
+import type { ContactLike } from 'services/contact/contactLinks';
+
+export interface CallSheetRow {
+  individualParticipantIds?: string[];
+  participantName?: string;
+  participantRole?: string;
+  participantType?: string;
+  participantId?: string;
+  contacts?: ContactLike[];
+}
+
+export interface CallSheetEntry {
+  contacts: ContactLike[];
+  participantName: string;
+  participantRole?: string;
+  participantId?: string;
+}
+
+export interface CallSheet {
+  /** People carrying at least one contact a director can act on, in the order the table showed them. */
+  entries: CallSheetEntry[];
+  /** People on the sheet with no reachable contact at all. Reported, never silently dropped. */
+  unreachable: CallSheetEntry[];
+}
+
+/** A bulk action's recipients, plus the people it will NOT reach. */
+export interface Recipients {
+  missing: CallSheetEntry[];
+  values: string[];
+}
+
+const entryFrom = (row: CallSheetRow): CallSheetEntry => ({
+  participantName: row.participantName?.trim() || '',
+  participantRole: row.participantRole,
+  participantId: row.participantId,
+  contacts: reachableContacts(row.contacts),
+});
+
+/**
+ * Build the sheet from table rows.
+ *
+ * Row order is preserved rather than re-sorted: the director sorted the table, and a printed sheet
+ * that disagrees with the screen it was printed from is a sheet nobody trusts.
+ */
+export function buildCallSheet(rows: CallSheetRow[]): CallSheet {
+  const entries: CallSheetEntry[] = [];
+  const unreachable: CallSheetEntry[] = [];
+
+  for (const row of Array.isArray(rows) ? rows : []) {
+    // A GROUP or TEAM row has no `person` and therefore no contacts of its own. It is not a mistake
+    // for one to appear — `contactParticipantIds` names a group's contact PERSON, who is an
+    // INDIVIDUAL already on the sheet in their own right — so it is skipped rather than reported.
+    if (row.participantType && row.participantType !== 'INDIVIDUAL') continue;
+    const entry = entryFrom(row);
+    if (!entry.participantName) continue;
+    if (entry.contacts.length) entries.push(entry);
+    else unreachable.push(entry);
+  }
+
+  return { entries, unreachable };
+}
+
+/**
+ * One mobile per person — the first contact of theirs that has one.
+ *
+ * Not every contact they hold. A competitor with a guardian, a chaperone and their own mobile would
+ * otherwise receive three copies of "courts are wet, play delayed 30 minutes", which is how a useful
+ * feature teaches people to ignore it. The per-row affordances and the sheet's own per-contact links
+ * are how a director reaches one specific number.
+ */
+export function smsRecipients(sheet: CallSheet): Recipients {
+  const values: string[] = [];
+  const missing: CallSheetEntry[] = [];
+
+  for (const entry of sheet.entries) {
+    const mobile = entry.contacts.map((contact) => contact.mobileTelephone).find((value) => !!value?.trim());
+    if (mobile) values.push(mobile);
+    else missing.push(entry);
+  }
+
+  // The people the sheet already knows are unreachable are missing from every action, not just this
+  // one. Reporting them here keeps "who will not get this message" a single, complete answer.
+  return { values, missing: [...missing, ...sheet.unreachable] };
+}
+
+/** One address per person, same rule as {@link smsRecipients}. */
+export function emailRecipients(sheet: CallSheet): Recipients {
+  const values: string[] = [];
+  const missing: CallSheetEntry[] = [];
+
+  for (const entry of sheet.entries) {
+    const email = entry.contacts.map((contact) => contact.emailAddress).find((value) => !!value?.trim());
+    if (email) values.push(email);
+    else missing.push(entry);
+  }
+
+  return { values, missing: [...missing, ...sheet.unreachable] };
+}
+
+/** Every number on the sheet, for the clipboard fallback. */
+export function allNumbers(sheet: CallSheet): string[] {
+  return sheet.entries.flatMap((entry) =>
+    entry.contacts.map(primaryNumber).filter((value): value is string => !!value),
+  );
+}
+
+/**
+ * Rows for the printed sheet — one per PERSON, with their contacts stacked inside the cells.
+ *
+ * One row per contact would have been easier and reads worse: a director scanning for a name would
+ * find it two or three times, and the columns that repeat (name, role) carry no information on the
+ * second appearance. `jspdf-autotable` renders `\n` as a line break, so the stacked cells stay
+ * aligned with each other — the third line of the Mobile column belongs to the third line of the
+ * Contact column.
+ *
+ * `unreachable` people are included, with empty contact cells. A call sheet that silently omits the
+ * volunteer whose number nobody collected is a call sheet that says the roster is complete.
+ */
+export function callSheetPdfRows(sheet: CallSheet): Record<string, string>[] {
+  const stack = (values: (string | undefined)[]) => values.map((value) => value?.trim() || '—').join('\n');
+
+  const toRow = (entry: CallSheetEntry): Record<string, string> => ({
+    participantName: entry.participantName,
+    participantRole: entry.participantRole ?? '',
+    whose: stack(entry.contacts.map((contact) => contact.name || contact.relationship)),
+    mobileTelephone: stack(entry.contacts.map((contact) => contact.mobileTelephone)),
+    telephone: stack(entry.contacts.map((contact) => contact.telephone)),
+    emailAddress: stack(entry.contacts.map((contact) => contact.emailAddress)),
+    // D3 in print. A director holding the sheet needs to know which of these numbers the person
+    // agreed could be shared, because the sheet itself leaves the room.
+    isPublic: stack(entry.contacts.map((contact) => (isPublicContact(contact) ? 'Y' : 'N'))),
+  });
+
+  return [...sheet.entries.map(toRow), ...sheet.unreachable.map(toRow)];
+}

--- a/src/components/modals/callSheet.ts
+++ b/src/components/modals/callSheet.ts
@@ -1,0 +1,234 @@
+/**
+ * The call sheet — reach the people on the participants table.
+ *
+ * Everything before this made personnel *correct*; this makes them *reachable*. A referee needs the
+ * physio at 9pm and a director needs the transport driver at 6am, and until now neither number was
+ * anywhere in the UI even though TMX could record it.
+ *
+ * **D3 (CA, 2026-08-23): this surface does not respect `contact.isPublic`.** A director sees every
+ * contact. Private ones carry a visible marker rather than being hidden — silently ignoring a privacy
+ * flag is indefensible, and hiding a mobile from the referee at 9pm is unusable. `isPublic` continues
+ * to govern PUBLIC surfaces only: the factory's `getTournamentInfo` still filters `tournamentContacts`
+ * on `isPublic === true`, untouched by this work.
+ *
+ * The decisions live in `buildCallSheet`; this file is the shell that renders them.
+ */
+import { callSheetPdfRows, emailRecipients, smsRecipients, buildCallSheet, allNumbers } from './buildCallSheet';
+import { isPublicContact, contactNumbers, mailtoHref, smsHref } from 'services/contact/contactLinks';
+import { contactAffordances } from 'components/tables/common/formatters/contactFormatter';
+import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { tournamentEngine } from 'services/factory/engine';
+import { generateReportPDF } from 'pdf-factory';
+import { openModal } from './baseModal/baseModal';
+import { t } from 'i18n';
+
+import type { CallSheet, CallSheetEntry, CallSheetRow, Recipients } from './buildCallSheet';
+
+const WARNING = 'is-warning';
+
+/**
+ * Follow a `tel:` / `sms:` / `mailto:` URI.
+ *
+ * Through a synthesised anchor rather than `location.href =`. Assigning to `location` asks the SPA to
+ * unload; browsers that do not handle the scheme leave the app in a half-navigated state, and TMX
+ * holds unsaved table selection at exactly the moment this is used.
+ */
+function followUri(href: string): void {
+  const anchor = document.createElement('a');
+  anchor.rel = 'noopener';
+  anchor.href = href;
+  anchor.click();
+}
+
+/** Report who an action will not reach. Never let a partial send look like a complete one. */
+function reportMissing(missing: CallSheetEntry[]): void {
+  if (!missing.length) return;
+  const names = missing.map((entry) => entry.participantName).join(', ');
+  tmxToast({
+    message: `${t('modals.callSheet.notReached', { count: missing.length })}: ${names}`,
+    intent: WARNING,
+    duration: 6000,
+  });
+}
+
+/** A bulk action: follow the URI if there is one, and say who it missed either way. */
+function dispatchBulk(recipients: Recipients, href: string | undefined, emptyMessage: string): void {
+  if (!href) {
+    tmxToast({ message: emptyMessage, intent: WARNING });
+    return;
+  }
+  followUri(href);
+  reportMissing(recipients.missing);
+}
+
+function contactLine(contact: any): HTMLElement {
+  const line = document.createElement('div');
+  line.className = 'tmx-call-sheet-contact';
+
+  const whose = document.createElement('span');
+  whose.className = 'tmx-call-sheet-whose';
+  // `relationship` says whose number it is — SELF vs an unlabelled number are different states, which
+  // is the distinction factory #4683 added the field for.
+  whose.textContent = contact.name || contact.relationship || '';
+  line.appendChild(whose);
+
+  const numbers = document.createElement('span');
+  numbers.className = 'tmx-call-sheet-value';
+  numbers.textContent = [...contactNumbers(contact), contact.emailAddress].filter(Boolean).join(' · ');
+  line.appendChild(numbers);
+
+  for (const { href, icon, title } of contactAffordances(contact)) {
+    const anchor = document.createElement('a');
+    anchor.className = 'tmx-contact-link';
+    anchor.title = title;
+    anchor.href = href;
+    anchor.innerHTML = `<i class="fa-solid ${icon}"></i>`;
+    line.appendChild(anchor);
+  }
+
+  if (!isPublicContact(contact)) {
+    const mark = document.createElement('i');
+    mark.className = 'fa-solid fa-lock tmx-contact-private-mark';
+    mark.title = t('tables.participants.contactPrivateMark');
+    line.appendChild(mark);
+  }
+
+  return line;
+}
+
+function entryBlock(entry: CallSheetEntry, muted: boolean): HTMLElement {
+  const block = document.createElement('div');
+  block.className = muted ? 'tmx-call-sheet-entry is-muted' : 'tmx-call-sheet-entry';
+
+  const heading = document.createElement('div');
+  heading.className = 'tmx-call-sheet-name';
+  heading.textContent = entry.participantName;
+  if (entry.participantRole) {
+    const badge = document.createElement('span');
+    badge.className = 'tmx-role-badge';
+    badge.textContent = entry.participantRole;
+    heading.appendChild(badge);
+  }
+  block.appendChild(heading);
+
+  if (entry.contacts.length) {
+    for (const contact of entry.contacts) block.appendChild(contactLine(contact));
+  } else {
+    const none = document.createElement('div');
+    none.className = 'tmx-call-sheet-none';
+    none.textContent = t('modals.callSheet.noContact');
+    block.appendChild(none);
+  }
+
+  return block;
+}
+
+function sheetContent(sheet: CallSheet): HTMLElement {
+  const container = document.createElement('div');
+  container.className = 'tmx-call-sheet';
+
+  const summary = document.createElement('div');
+  summary.className = 'tmx-call-sheet-summary';
+  // Both halves, always. "12 reachable" alone reads as a complete roster; the second number is what
+  // tells a director there is data still to collect.
+  summary.textContent = `${t('modals.callSheet.reachable', { count: sheet.entries.length })} · ${t(
+    'modals.callSheet.withoutContact',
+    { count: sheet.unreachable.length },
+  )}`;
+  container.appendChild(summary);
+
+  for (const entry of sheet.entries) container.appendChild(entryBlock(entry, false));
+  for (const entry of sheet.unreachable) container.appendChild(entryBlock(entry, true));
+
+  return container;
+}
+
+/**
+ * A function rather than a module-level constant so the titles are localized at PRINT time. Evaluated
+ * at import time they would resolve against whatever locale had loaded by then — and would never
+ * change again when the director switches language.
+ *
+ * `emailAddress` carries no `width`, which is deliberate: `generateReportPDF` lets exactly one column
+ * absorb the table's spare width, and an address is the value that most wants it.
+ */
+const pdfColumns = () => [
+  { key: 'participantName', title: t('modals.callSheet.columns.name'), width: 160 },
+  { key: 'participantRole', title: t('modals.callSheet.columns.role'), fitData: true },
+  { key: 'whose', title: t('modals.callSheet.columns.contact'), width: 110 },
+  { key: 'mobileTelephone', title: t('modals.callSheet.columns.mobile'), width: 130 },
+  { key: 'telephone', title: t('modals.callSheet.columns.telephone'), width: 130 },
+  { key: 'emailAddress', title: t('modals.callSheet.columns.email') },
+  { key: 'isPublic', title: t('modals.callSheet.columns.public'), fitData: true },
+];
+
+function generate(sheet: CallSheet, subtitle: string, action: 'open' | 'download'): void {
+  const { tournamentInfo } = tournamentEngine.getTournamentInfo() as any;
+  const doc = generateReportPDF(pdfColumns(), callSheetPdfRows(sheet), {
+    header: {
+      tournamentName: tournamentInfo?.tournamentName || '',
+      startDate: tournamentInfo?.startDate,
+      endDate: tournamentInfo?.endDate,
+      subtitle,
+    },
+  });
+
+  if (action === 'open') openPDF({ doc });
+  else savePDF({ doc, filename: 'call-sheet.pdf' });
+}
+
+function copyNumbers(sheet: CallSheet): void {
+  const numbers = allNumbers(sheet);
+  if (!numbers.length) {
+    tmxToast({ message: t('modals.callSheet.noNumbers'), intent: WARNING });
+    return;
+  }
+  // The escape hatch for every platform this cannot address directly — a desk phone, a radio, a
+  // third-party messaging app. `clipboard` is absent over plain HTTP, so the failure is reported.
+  navigator.clipboard
+    ?.writeText(numbers.join('\n'))
+    .then(() =>
+      tmxToast({ message: t('modals.callSheet.numbersCopied', { count: numbers.length }), intent: 'is-success' }),
+    )
+    .catch(() => tmxToast({ message: t('modals.callSheet.copyFailed'), intent: 'is-danger' }));
+}
+
+/**
+ * Open the call sheet over a set of participants table rows.
+ *
+ * `rows` is whatever the caller chose — the selected rows, or every row the current filters leave
+ * visible. Nothing here re-derives who counts as personnel; see `buildCallSheet` for why that matters.
+ */
+export function callSheet({ rows, subtitle }: { rows: CallSheetRow[]; subtitle: string }): void {
+  const sheet = buildCallSheet(rows);
+  const sms = smsRecipients(sheet);
+  const email = emailRecipients(sheet);
+
+  const buttons = [
+    { label: t('common.close'), intent: 'none', close: true },
+    {
+      label: `<i class="fa-solid fa-copy"></i> ${t('modals.callSheet.copyNumbers')}`,
+      onClick: () => copyNumbers(sheet),
+      intent: 'none',
+    },
+    {
+      label: `<i class="fa-solid fa-print"></i> ${t('modals.callSheet.print')}`,
+      onClick: () => generate(sheet, subtitle, 'open'),
+      intent: 'none',
+    },
+    {
+      label: `<i class="fa-solid fa-envelope"></i> ${t('modals.callSheet.emailAll', { count: email.values.length })}`,
+      onClick: () => dispatchBulk(email, mailtoHref(email.values), t('modals.callSheet.noEmails')),
+      disabled: !email.values.length,
+      intent: 'is-info',
+    },
+    {
+      label: `<i class="fa-solid fa-comment-sms"></i> ${t('modals.callSheet.textAll', { count: sms.values.length })}`,
+      onClick: () => dispatchBulk(sms, smsHref(sms.values), t('modals.callSheet.noMobiles')),
+      disabled: !sms.values.length,
+      intent: 'is-primary',
+    },
+  ];
+
+  openModal({ title: t('modals.callSheet.title'), content: sheetContent(sheet), buttons });
+}

--- a/src/components/tables/common/formatters/contactFormatter.ts
+++ b/src/components/tables/common/formatters/contactFormatter.ts
@@ -1,0 +1,91 @@
+/**
+ * The tappable half of the call sheet: `tel:` / `sms:` / `mailto:` affordances on a participant row.
+ *
+ * Renders the participant's PRIMARY contact only. A row is one line high and a person can hold
+ * several contacts; stacking them would make the personnel views unreadable for the case that matters
+ * least. The full list — every contact, with its relationship and its consent state — is what the call
+ * sheet modal is for, and the `+n` marker here is the affordance that says it exists.
+ *
+ * **D3 (CA, 2026-08-23): the TD surface does not respect `contact.isPublic`.** A director sees every
+ * number, and a contact without consent carries a visible marker rather than being hidden. Silently
+ * dropping a number the director needs at 9pm would be unusable; showing it without saying it is
+ * private would be indefensible. `isPublic` continues to govern public surfaces only — the factory's
+ * `getTournamentInfo` still filters `tournamentContacts` on `isPublic === true`, untouched.
+ */
+import {
+  isPublicContact,
+  primaryNumber,
+  looksLikeEmail,
+  mailtoHref,
+  telHref,
+  smsHref,
+} from 'services/contact/contactLinks';
+import { t } from 'i18n';
+
+import type { ContactLike } from 'services/contact/contactLinks';
+
+/** One rendered affordance: an href plus the icon and tooltip that describe it. */
+export interface ContactAffordance {
+  title: string;
+  href: string;
+  icon: string;
+}
+
+/**
+ * The affordances a single contact supports, in the order a director reaches for them: text first
+ * (least intrusive, and the "text these six" action's unit), then call, then email.
+ *
+ * `sms:` is offered only for a MOBILE. Texting a landline silently does nothing on every platform,
+ * and an affordance that looks live and is not is the failure this module exists to avoid.
+ */
+export function contactAffordances(contact?: ContactLike): ContactAffordance[] {
+  const affordances: ContactAffordance[] = [];
+
+  const sms = smsHref([contact?.mobileTelephone]);
+  if (sms) affordances.push({ href: sms, icon: 'fa-comment-sms', title: t('tables.participants.contactText') });
+
+  const tel = telHref(primaryNumber(contact));
+  if (tel) affordances.push({ href: tel, icon: 'fa-phone', title: t('tables.participants.contactCall') });
+
+  const mail = looksLikeEmail(contact?.emailAddress) ? mailtoHref([contact?.emailAddress]) : undefined;
+  if (mail) affordances.push({ href: mail, icon: 'fa-envelope', title: t('tables.participants.contactEmail') });
+
+  return affordances;
+}
+
+/**
+ * The cell's markup for a participant's contact list.
+ *
+ * `stopPropagation` on the anchor matters: the row's own click handlers select the row, and a
+ * director tapping a phone number on a tablet would otherwise toggle the selection they are about to
+ * act on.
+ */
+export function contactCellMarkup(contacts?: ContactLike[]): string {
+  const list = Array.isArray(contacts) ? contacts : [];
+  const primary = list[0];
+  const affordances = contactAffordances(primary);
+  if (!affordances.length) return '';
+
+  const links = affordances
+    .map(
+      ({ href, icon, title }) =>
+        `<a class="tmx-contact-link" href="${href}" title="${title}" onclick="event.stopPropagation()"><i class="fa-solid ${icon}"></i></a>`,
+    )
+    .join('');
+
+  // The private marker (D3) and the "there are more" marker are separate facts and read separately.
+  const privacy = isPublicContact(primary)
+    ? ''
+    : `<i class="fa-solid fa-lock tmx-contact-private-mark" title="${t('tables.participants.contactPrivateMark')}"></i>`;
+  const extra =
+    list.length > 1
+      ? `<span class="tmx-contact-more" title="${t('tables.participants.contactMore')}">+${list.length - 1}</span>`
+      : '';
+
+  return `<span class="tmx-contact-cell">${links}${privacy}${extra}</span>`;
+}
+
+/** Tabulator cell formatter over the row's `contacts` array. */
+export function contactFormatter(cell: any): string {
+  return contactCellMarkup(cell.getValue());
+}

--- a/src/components/tables/participantsTable/createParticipantsTable.ts
+++ b/src/components/tables/participantsTable/createParticipantsTable.ts
@@ -34,6 +34,17 @@ export function createParticipantsTable({ view }: { view?: string } = {}): {
   replaceTableData: () => void;
   teamParticipants: any[];
   groupParticipants: any[];
+  /**
+   * The rows the table was seeded with.
+   *
+   * Returned because `table.getDataCount()` answers **0** until Tabulator fires `tableBuilt`, which
+   * is after this function returns. Callers gating a control on "are there any participants?" were
+   * therefore reading zero on every first render: the Actions menu hid *Sign out unapproved*,
+   * *Edit ratings* and *Call sheet* on a table that was visibly showing rows, and only revealed them
+   * after some later re-render happened to rebuild the control bar. Found by journey 100, whose page
+   * snapshot showed the header reading "Staff (2)" beside a menu missing all three.
+   */
+  data: any[];
 } {
   let table: any;
   let groupParticipants: any[] = [];
@@ -202,7 +213,7 @@ export function createParticipantsTable({ view }: { view?: string } = {}): {
 
   render(data);
 
-  return { table, replaceTableData, teamParticipants, groupParticipants };
+  return { table, replaceTableData, teamParticipants, groupParticipants, data };
 }
 
 interface ScalingsHeaderHandle {

--- a/src/components/tables/participantsTable/getParticipantColumns.ts
+++ b/src/components/tables/participantsTable/getParticipantColumns.ts
@@ -7,6 +7,7 @@ import { participantProfileModal } from 'components/modals/participantProfileMod
 import { formatParticipant } from '../common/formatters/participantFormatter';
 import { genderConstants, participantRoles } from 'tods-competition-factory';
 import { arrayLengthFormatter } from '../common/formatters/arrayLength';
+import { contactFormatter } from '../common/formatters/contactFormatter';
 import { participantSorter } from '../common/sorters/participantSorter';
 import { participantActions } from '../../popovers/participantActions';
 import { eventsFormatter } from '../common/formatters/eventsFormatter';
@@ -75,6 +76,7 @@ export function getParticipantColumns({
     {
       headerMenu: headerMenu({
         signedIn: 'Sign In Status',
+        contacts: 'Contact',
         contactPublic: 'Public contact',
         sex: 'Gender',
       }),
@@ -231,6 +233,25 @@ export function getParticipantColumns({
       hozAlign: LEFT,
       tooltip: false,
       width: 40,
+    },
+    {
+      // The call sheet, one row at a time — `tel:` / `sms:` / `mailto:` on the participant's primary
+      // contact. Same default as the public-contact column beside it: shown for personnel, in the
+      // header menu everywhere, because a director chasing an alternate wants it on competitors too.
+      //
+      // Not sortable. Sorting people by the shape of their phone number answers no question, and a
+      // header sort arrow that produces an arbitrary order reads as a broken column.
+      title: `<div class='fa-solid fa-address-book' style='color: var(--tmx-text-secondary)' />`,
+      headerTooltip: t('tables.participants.contactActions'),
+      formatter: contactFormatter,
+      visible: isPersonnelView,
+      headerHozAlign: CENTER,
+      field: 'contacts',
+      hozAlign: CENTER,
+      headerSort: false,
+      resizable: false,
+      tooltip: false,
+      width: 92,
     },
     {
       // Whether this person's primary contact carries consent to be shared publicly.

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1648,6 +1648,38 @@
       },
       "contactPerson": "Contact person",
       "contactPersonNone": "None"
+    },
+    "callSheet": {
+      "title": "Call sheet",
+      "contactSelected": "Contact selected",
+      "reachable_one": "{{count}} reachable",
+      "reachable_other": "{{count}} reachable",
+      "withoutContact_one": "{{count}} without contact details",
+      "withoutContact_other": "{{count}} without contact details",
+      "noContact": "No contact details recorded",
+      "textAll_one": "Text {{count}}",
+      "textAll_other": "Text {{count}}",
+      "emailAll_one": "Email {{count}}",
+      "emailAll_other": "Email {{count}}",
+      "copyNumbers": "Copy numbers",
+      "print": "Print",
+      "notReached_one": "{{count}} person will not receive this",
+      "notReached_other": "{{count}} people will not receive this",
+      "noMobiles": "Nobody on this sheet has a mobile number",
+      "noEmails": "Nobody on this sheet has an email address",
+      "noNumbers": "No numbers to copy",
+      "numbersCopied_one": "{{count}} number copied",
+      "numbersCopied_other": "{{count}} numbers copied",
+      "copyFailed": "Could not copy to the clipboard",
+      "columns": {
+        "name": "Name",
+        "role": "Role",
+        "contact": "Contact",
+        "mobile": "Mobile",
+        "telephone": "Telephone",
+        "email": "Email",
+        "public": "Public"
+      }
     }
   },
   "dashboard": {
@@ -1931,7 +1963,13 @@
       "nickname": "Nickname",
       "contactPublic": "Public contact",
       "contactPublicYes": "Contact may be shared publicly",
-      "contactPublicNo": "Contact is not shared publicly"
+      "contactPublicNo": "Contact is not shared publicly",
+      "contactActions": "Contact",
+      "contactCall": "Call",
+      "contactText": "Send a text message",
+      "contactEmail": "Send an email",
+      "contactPrivateMark": "Not shared publicly",
+      "contactMore": "More contacts on the call sheet"
     },
     "bracket": {
       "participant": "Participant",
@@ -2257,7 +2295,12 @@
         "contactIsPublic": "Contact may be shared publicly",
         "contactRelationship": "Contact is",
         "contactName": "Contact name",
-        "contactNamePlaceholder": "Name of the contact, if not the participant"
+        "contactNamePlaceholder": "Name of the contact, if not the participant",
+        "primaryContact": "Primary contact",
+        "additionalContact": "Contact",
+        "telephone": "Telephone",
+        "telephonePlaceholder": "Landline or desk number",
+        "whichPrimary": "Which contact is primary?"
       },
       "newTeam": "New team",
       "newGroup": "New group",
@@ -2299,7 +2342,8 @@
         "nicknamePlaceholder": "Nickname / abbreviation",
         "preferNickname": "Prefer nickname in draws",
         "nameTooShort": "Please enter a name of at least 3 characters"
-      }
+      },
+      "selected": "selected"
     }
   },
   "overlays": {

--- a/src/pages/tournament/tabs/participantTab/collectContacts.test.ts
+++ b/src/pages/tournament/tabs/participantTab/collectContacts.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The multi-contact harvest.
+ *
+ * `modifyParticipant` REPLACES `person.contacts`, so this function's failure mode is data loss rather
+ * than a wrong render. The single-contact version of this logic lived inline in the drawer and was
+ * covered through `editIndividualParticipant.test.ts`; those tests still pass unchanged and remain the
+ * integration-level guard. These cover the N-row generalisation directly, including the cases a
+ * one-row form could not reach.
+ */
+import { collectContacts } from './collectContacts';
+import { describe, expect, it } from 'vitest';
+
+const MOBILE = '+1 555 0100';
+const OTHER_MOBILE = '+1 555 9999';
+const LANDLINE = '+1 555 1111';
+
+/** A fully-offered row — every field the editor renders was present in the DOM. */
+const row = (overrides: any = {}) => ({
+  relationshipOffered: true,
+  nameOffered: true,
+  ...overrides,
+});
+
+describe('rule 1 — undefined leaves the stored list alone, [] clears it', () => {
+  it('returns undefined when nothing was entered and nothing is stored', () => {
+    // `[]` would instruct the factory to clear. A participant with no phone number must not carry an
+    // instruction to wipe a list.
+    expect(collectContacts({ rows: [row({})], existing: [] })).toBeUndefined();
+  });
+
+  it('returns [] when everything stored was cleared', () => {
+    // Distinct from the case above: here the director deliberately emptied the only contact, and that
+    // has to be expressible or a contact can never be removed.
+    expect(collectContacts({ rows: [row({})], existing: [{ mobileTelephone: MOBILE }] })).toEqual([]);
+  });
+});
+
+describe('rule 2 — emptiness is decided by the reachable fields', () => {
+  it('drops a row that carries only a relationship and a name', () => {
+    const result = collectContacts({
+      rows: [row({ relationship: 'GUARDIAN', name: 'Ana Rivas' })],
+      existing: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('keeps a row reachable by email alone', () => {
+    const result = collectContacts({ rows: [row({ emailAddress: 'ana@example.org' })], existing: [] });
+    expect(result).toHaveLength(1);
+    expect(result?.[0].emailAddress).toEqual('ana@example.org');
+  });
+
+  it('keeps a stored landline the form preserved rather than offered', () => {
+    // The form shows mobile + email. Clearing both must not silently discard a landline that arrived
+    // by import and that the row never rendered — that is rule 3 applied to reachability.
+    const result = collectContacts({
+      rows: [{ mobileTelephone: '', emailAddress: '' }],
+      existing: [{ telephone: LANDLINE, name: 'desk' }],
+    });
+    expect(result).toEqual([
+      { telephone: LANDLINE, name: 'desk', mobileTelephone: '', emailAddress: '', isPublic: false },
+    ]);
+  });
+
+  it('drops a row whose landline the form DID offer and the director cleared', () => {
+    // The inverse. Once the field is on screen, emptying it is an instruction.
+    const result = collectContacts({
+      rows: [row({ telephoneOffered: true, telephone: '', mobileTelephone: '', emailAddress: '' })],
+      existing: [{ telephone: LANDLINE }],
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('rule 3 — an absent row is preserved untouched', () => {
+  it('keeps rows the form never rendered, byte for byte', () => {
+    // The data-loss case, at N rows. A reduced form must not delete contacts it did not show.
+    const emergency = { name: 'emergency', mobileTelephone: OTHER_MOBILE };
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: MOBILE })],
+      existing: [{ name: 'primary', mobileTelephone: '+1 555 0000' }, emergency],
+    });
+    expect(result).toHaveLength(2);
+    expect(result?.[1]).toBe(emergency);
+  });
+
+  it('preserves fields the row does not carry', () => {
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: MOBILE, nameOffered: false, relationshipOffered: false })],
+      existing: [{ name: 'desk', telephone: LANDLINE, notes: 'ring twice', relationship: 'SELF' }],
+    });
+    expect(result?.[0].name).toEqual('desk');
+    expect(result?.[0].notes).toEqual('ring twice');
+    expect(result?.[0].telephone).toEqual(LANDLINE);
+    expect(result?.[0].relationship).toEqual('SELF');
+  });
+
+  it('clears a field the row DID offer and left empty', () => {
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: MOBILE, relationship: undefined, name: undefined })],
+      existing: [{ mobileTelephone: '+1 555 0000', relationship: 'PARENT', name: 'Dad' }],
+    });
+    expect(result?.[0].relationship).toBeUndefined();
+    expect(result?.[0].name).toBeUndefined();
+  });
+});
+
+describe('adding and removing rows', () => {
+  it('appends a contact entered in the spare row', () => {
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: MOBILE }), row({ mobileTelephone: OTHER_MOBILE, name: 'emergency' })],
+      existing: [{ mobileTelephone: MOBILE }],
+    });
+    expect(result).toHaveLength(2);
+    expect(result?.[1].mobileTelephone).toEqual(OTHER_MOBILE);
+    expect(result?.[1].name).toEqual('emergency');
+  });
+
+  it('removes a middle contact without disturbing the ones around it', () => {
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: 'a1' }), row({ mobileTelephone: '' }), row({ mobileTelephone: 'c3' })],
+      existing: [{ mobileTelephone: 'a1' }, { mobileTelephone: 'b2' }, { mobileTelephone: 'c3' }],
+    });
+    expect(result?.map((c) => c.mobileTelephone)).toEqual(['a1', 'c3']);
+  });
+
+  it('records consent per contact, not per person', () => {
+    // The factory gates publication per contact (`getTournamentInfo` filters on `isPublic === true`),
+    // so a single flag for the person would collapse a distinction the model already makes.
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: MOBILE, isPublic: true }), row({ mobileTelephone: OTHER_MOBILE, isPublic: false })],
+      existing: [],
+    });
+    expect(result?.map((c) => c.isPublic)).toEqual([true, false]);
+  });
+});
+
+describe('the primary is positional', () => {
+  it('promotes the selected row to index 0', () => {
+    // Positional rather than an `isPrimary` marker: every existing reader — getTournamentInfo, the
+    // participants table columns, the group contact-person row — reads `contacts[0]`, and a marker
+    // would be a second source of truth for what the array order already says.
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: 'a1' }), row({ mobileTelephone: 'b2' })],
+      existing: [],
+      primaryIndex: 1,
+    });
+    expect(result?.map((c) => c.mobileTelephone)).toEqual(['b2', 'a1']);
+  });
+
+  it('preserves stored order when no primary was selected', () => {
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: 'a1' }), row({ mobileTelephone: 'b2' })],
+      existing: [],
+    });
+    expect(result?.map((c) => c.mobileTelephone)).toEqual(['a1', 'b2']);
+  });
+
+  it('leaves the order alone when the selected row was removed in the same save', () => {
+    // Marking a row primary and clearing it are contradictory instructions. The removal wins, and the
+    // remaining order is untouched rather than arbitrarily rotated.
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: 'a1' }), row({ mobileTelephone: '' }), row({ mobileTelephone: 'c3' })],
+      existing: [],
+      primaryIndex: 1,
+    });
+    expect(result?.map((c) => c.mobileTelephone)).toEqual(['a1', 'c3']);
+  });
+
+  it('promotes a row that the form did not render', () => {
+    // Reorder must work on stored contacts the editor is only listing, not editing.
+    const result = collectContacts({
+      rows: [row({ mobileTelephone: 'a1' })],
+      existing: [{ mobileTelephone: 'a1' }, { mobileTelephone: 'b2' }],
+      primaryIndex: 1,
+    });
+    expect(result?.map((c) => c.mobileTelephone)).toEqual(['b2', 'a1']);
+  });
+});
+
+describe('input guards', () => {
+  it('tolerates a non-array stored value', () => {
+    expect(collectContacts({ rows: [row({})], existing: undefined as any })).toBeUndefined();
+  });
+
+  it('keeps every stored contact when the form rendered no rows at all', () => {
+    const existing = [{ mobileTelephone: MOBILE }, { mobileTelephone: OTHER_MOBILE }];
+    expect(collectContacts({ rows: [], existing })).toEqual(existing);
+  });
+});

--- a/src/pages/tournament/tabs/participantTab/collectContacts.ts
+++ b/src/pages/tournament/tabs/participantTab/collectContacts.ts
@@ -1,0 +1,111 @@
+/**
+ * Turning a drawer full of contact rows into the `person.contacts` array to persist.
+ *
+ * `modifyParticipant` **replaces** `person.contacts` rather than merging it (deliberately, so a
+ * contact can be removed), which makes this the most dangerous function in the participant drawer: a
+ * mistake here does not render wrong, it deletes a number nobody can recover from the UI.
+ *
+ * Three rules carry over verbatim from the single-contact version and are the reason this is a pure
+ * function with its own tests rather than logic inline in the drawer:
+ *
+ * 1. **`undefined` means "leave the stored list alone"; `[]` means "clear it".** A participant who
+ *    simply has no phone number must not carry an instruction to wipe a list.
+ * 2. **Emptiness is decided by the REACHABLE fields alone.** A relationship or a name with no number
+ *    and no address is not a contact; keeping it alive would persist a shell that renders as a blank
+ *    row and would make "remove this contact" inexpressible.
+ * 3. **An absent input and an emptied one are different instructions.** Emptied means clear; absent
+ *    means the drawer never offered the field and must not speak for it. This is what generalises
+ *    safely to N rows: a row the form did not render is preserved untouched, so a reduced form can
+ *    never delete the contacts it did not show.
+ */
+import { isReachable } from 'services/contact/contactLinks';
+
+import type { ContactLike } from 'services/contact/contactLinks';
+
+/**
+ * One row of the contact editor, already read out of the DOM.
+ *
+ * `relationshipOffered` / `nameOffered` record whether the form rendered those inputs at all — rule 3
+ * above. They are separate from the values because `undefined` on the value means "the user cleared
+ * it", which is a real instruction the field must be able to express.
+ */
+export interface ContactRowInput {
+  relationshipOffered?: boolean;
+  telephoneOffered?: boolean;
+  mobileTelephone?: string;
+  relationship?: string;
+  emailAddress?: string;
+  nameOffered?: boolean;
+  isPublic?: boolean;
+  telephone?: string;
+  name?: string;
+}
+
+export interface CollectContactsParams {
+  /** One entry per row the form rendered. `undefined` at an index means "this row was not offered". */
+  rows: (ContactRowInput | undefined)[];
+  /** `person.contacts` as stored. Index i corresponds to row i. */
+  existing: ContactLike[];
+  /** Index of the row the user marked primary, if the form offered the choice. */
+  primaryIndex?: number;
+}
+
+/** An entry plus where it came from, so the primary selection can be resolved after filtering. */
+interface CollectedEntry {
+  contact: ContactLike;
+  originIndex: number;
+}
+
+/** Apply one row's edits over the contact it was rendered from, preserving fields the form omits. */
+function applyRowEdits(row: ContactRowInput, stored: ContactLike | undefined): ContactLike {
+  // Spread the stored entry FIRST so `fax`, `notes` and any extension survive an edit made through a
+  // form that never showed them.
+  const edits: ContactLike = {
+    mobileTelephone: row.mobileTelephone,
+    emailAddress: row.emailAddress,
+    isPublic: !!row.isPublic,
+  };
+  if (row.relationshipOffered) edits.relationship = row.relationship;
+  if (row.telephoneOffered) edits.telephone = row.telephone;
+  if (row.nameOffered) edits.name = row.name;
+  return { ...stored, ...edits };
+}
+
+export function collectContacts({ rows, existing, primaryIndex }: CollectContactsParams): ContactLike[] | undefined {
+  const stored = Array.isArray(existing) ? existing : [];
+  const rowCount = Math.max(rows.length, stored.length);
+  const collected: CollectedEntry[] = [];
+
+  for (let index = 0; index < rowCount; index++) {
+    const row = rows[index];
+
+    // Rule 3. The form did not render this row, so it has no opinion about it. Keep the stored entry
+    // exactly as it is — same object, so a caller comparing by value sees nothing changed.
+    if (!row) {
+      const untouched = stored[index];
+      if (untouched) collected.push({ contact: untouched, originIndex: index });
+      continue;
+    }
+
+    // Rule 2. Cleared of everything reachable, so the entry is being removed. Reachability is judged
+    // on the MERGED entry, so a landline the form preserved rather than offered still counts — the
+    // alternative silently discards a stored number because two unrelated fields were emptied.
+    const edited = applyRowEdits(row, stored[index]);
+    if (isReachable(edited)) collected.push({ contact: edited, originIndex: index });
+  }
+
+  // The primary is positional — `contacts[0]`. Storing an explicit "isPrimary" marker instead would
+  // be a second source of truth for a fact the array order already carries, and every existing reader
+  // (`getTournamentInfo`, the participants table columns, the group contact-person row) reads index 0.
+  const promoted = collected.findIndex((entry) => entry.originIndex === primaryIndex);
+  if (promoted > 0) {
+    const [entry] = collected.splice(promoted, 1);
+    collected.unshift(entry);
+  }
+
+  const contacts = collected.map((entry) => entry.contact);
+
+  // Rule 1. Nothing entered and nothing stored — send no `contacts` key at all.
+  if (!contacts.length && !stored.length) return undefined;
+  return contacts;
+}

--- a/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/editIndividualParticipant.ts
@@ -6,15 +6,46 @@ import { participantConstants, participantRoles, fixtures, tools } from 'tods-co
 import { validators, renderButtons, renderForm } from 'courthive-components';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tmxToast } from 'services/notifications/tmxToast';
+import { primaryNumber } from 'services/contact/contactLinks';
+import { collectContacts } from './collectContacts';
 import { isFunction } from 'functions/typeOf';
 import { context } from 'services/context';
 import { t, i18next } from 'i18n';
 
-// constants
+// constants and types
 import { ADD_PARTICIPANTS, MODIFY_PARTICIPANT } from 'constants/mutationConstants';
 import { CONTACT_RELATIONSHIPS, relationshipKey } from 'constants/contactRelationships';
+import type { ContactRowInput } from './collectContacts';
 import { RIGHT, STAFF, SUCCESS } from 'constants/tmxConstants';
 import { STAFF_ROLES } from 'constants/staffRoles';
+
+/**
+ * Form field names per contact index.
+ *
+ * Index 0 keeps the **unsuffixed** names the single-contact drawer used. That is not nostalgia: those
+ * names are the contract the drawer's existing tests assert against, and — more importantly — index 0
+ * IS the primary contact, so `mobileTelephone` continues to mean exactly what it always meant. Rows
+ * beyond the first take an `_<index>` suffix.
+ */
+const CONTACT_FIELDS = {
+  relationship: 'contactRelationship',
+  mobileTelephone: 'mobileTelephone',
+  emailAddress: 'emailAddress',
+  telephone: 'contactTelephone',
+  isPublic: 'contactIsPublic',
+  name: 'contactName',
+} as const;
+
+type ContactFieldKey = keyof typeof CONTACT_FIELDS;
+
+const contactFieldName = (key: ContactFieldKey, index: number): string =>
+  index ? `${CONTACT_FIELDS[key]}_${index}` : CONTACT_FIELDS[key];
+
+const primaryRadioField = (index: number): string => `primaryContact_${index}`;
+
+/** How a stored contact is identified in the "which one is primary" picker. */
+const contactRowLabel = (contact: any, index: number): string =>
+  contact?.name?.trim() || primaryNumber(contact) || contact?.emailAddress?.trim() || `${index + 1}`;
 
 const { COMPETITOR, OFFICIAL } = participantRoles;
 const { INDIVIDUAL } = participantConstants;
@@ -49,27 +80,31 @@ export function editIndividualParticipant({
   const isStaffView = view === STAFF;
 
   /**
-   * The contact this drawer edits — the participant's FIRST, treated as their primary.
+   * Every contact the participant carries, each editable in its own block, plus one blank spare.
    *
-   * The rest of the array is preserved untouched on save. `modifyParticipant` replaces
-   * `person.contacts` rather than merging (deliberately, so a contact can be removed), which means a
-   * drawer that edited one contact and dispatched `[thatContact]` would silently DELETE every other
-   * contact on an imported record that carries several. See `submittedContacts`.
+   * The spare row IS the "add a contact" affordance. `renderForm` has no button item type and renders
+   * once, statically, so an Add control would have meant either a component change (publish cascade)
+   * or hand-rolled DOM inside `content` — and `content` is handed a bare object by the drawer's own
+   * tests, so appending to it would couple the form to a live DOM it does not otherwise need.
+   * Removal needs no control either: clearing a row's reachable fields already means "drop this
+   * entry", which is the semantics the single-contact drawer shipped with and which
+   * `collectContacts` preserves.
+   *
+   * `modifyParticipant` REPLACES `person.contacts` rather than merging, so what this drawer chooses
+   * not to send is deleted. See `collectContacts` for the three rules that keep that safe.
    */
   const existingContacts: any[] = Array.isArray(participant?.person?.contacts) ? participant.person.contacts : [];
-  const primaryContact = existingContacts[0] ?? {};
+  const contactRowCount = existingContacts.length + 1;
+  // Only worth asking once there is a real choice to make. With one stored contact plus the spare,
+  // whichever the director fills in first is the primary and a picker would just be noise.
+  const offerPrimaryChoice = existingContacts.length > 1;
 
   const values = {
     participantRole: participant?.participantRole || defaultRoleForView(view),
     nationalityCode: participant?.person?.nationalityCode,
     firstName: participant?.person?.standardGivenName,
     lastName: participant?.person?.standardFamilyName,
-    mobileTelephone: primaryContact.mobileTelephone,
-    contactRelationship: primaryContact.relationship,
-    emailAddress: primaryContact.emailAddress,
-    contactName: primaryContact.name,
     nickname: participant?.participantOtherName,
-    contactIsPublic: primaryContact.isPublic === true,
     birthDate: participant?.person?.birthDate,
     sex: participant?.person?.sex,
   };
@@ -86,43 +121,56 @@ export function editIndividualParticipant({
     (isStaffView && inputs.participantRole?.value) || values.participantRole;
 
   /**
+   * Read one contact block back out of the form.
+   *
+   * Returns `undefined` when the form rendered NO reachable input for that index — which is how a
+   * reduced form (or a test driving the drawer with a subset of inputs) tells `collectContacts` "I
+   * have no opinion about this row, leave it alone" rather than "the director emptied it".
+   */
+  const readContactRow = (index: number): ContactRowInput | undefined => {
+    const mobileInput = inputs[contactFieldName('mobileTelephone', index)];
+    const telephoneInput = inputs[contactFieldName('telephone', index)];
+    const emailInput = inputs[contactFieldName('emailAddress', index)];
+    const relationshipInput = inputs[contactFieldName('relationship', index)];
+    const nameInput = inputs[contactFieldName('name', index)];
+    const publicInput = inputs[contactFieldName('isPublic', index)];
+
+    if (!mobileInput && !telephoneInput && !emailInput) return undefined;
+
+    return {
+      mobileTelephone: mobileInput?.value?.trim() || undefined,
+      relationshipOffered: !!relationshipInput,
+      telephone: telephoneInput?.value?.trim() || undefined,
+      emailAddress: emailInput?.value?.trim() || undefined,
+      relationship: relationshipInput?.value || undefined,
+      name: nameInput?.value?.trim() || undefined,
+      telephoneOffered: !!telephoneInput,
+      isPublic: !!publicInput?.checked,
+      nameOffered: !!nameInput,
+    };
+  };
+
+  /** Which row the director marked primary, or `undefined` when the picker was not rendered. */
+  const submittedPrimaryIndex = (): number | undefined => {
+    for (let index = 0; index < contactRowCount; index++) {
+      if (inputs[primaryRadioField(index)]?.checked) return index;
+    }
+    return undefined;
+  };
+
+  /**
    * The full `person.contacts` array to persist, or `undefined` to leave it untouched.
    *
-   * `undefined` matters: the factory treats an omitted `contacts` as "leave alone" and an empty array as
-   * "clear". Returning `[]` for a participant who simply has no contact details would wipe an imported
-   * list the moment someone edited their name.
+   * `undefined` matters: the factory treats an omitted `contacts` as "leave alone" and an empty array
+   * as "clear". Returning `[]` for a participant who simply has no contact details would wipe an
+   * imported list the moment someone edited their name.
    */
-  const submittedContacts = (): any[] | undefined => {
-    const mobileTelephone = inputs.mobileTelephone?.value?.trim() || undefined;
-    const emailAddress = inputs.emailAddress?.value?.trim() || undefined;
-    const relationship = inputs.contactRelationship?.value || undefined;
-    const name = inputs.contactName?.value?.trim() || undefined;
-    const isPublic = !!inputs.contactIsPublic?.checked;
-
-    // Nothing entered and nothing stored — send no `contacts` key at all.
-    if (!mobileTelephone && !emailAddress && !existingContacts.length) return undefined;
-
-    // Emptiness is still decided by the REACHABLE fields alone. A relationship or a name with no number
-    // and no address is not a contact — keeping the entry alive for them would persist a shell that
-    // renders as a blank row, and would make "clear this contact" impossible without also clearing
-    // fields the user never touched.
-    const primaryIsEmpty = !mobileTelephone && !emailAddress;
-    const rest = existingContacts.slice(1);
-    if (primaryIsEmpty) return rest;
-
-    // Spread the existing entry first so fields this drawer does not edit — `telephone`, `fax`,
-    // `notes`, extensions — survive.
-    //
-    // `relationship` and `name` are applied only when their inputs are actually PRESENT. An absent
-    // input and an emptied one are different instructions: emptied means clear, absent means the
-    // drawer never offered the field and must not speak for it. Spreading `name: undefined`
-    // unconditionally would erase a stored contact name for any caller rendering a reduced form.
-    const edits: any = { mobileTelephone, emailAddress, isPublic };
-    if (inputs.contactRelationship) edits.relationship = relationship;
-    if (inputs.contactName) edits.name = name;
-
-    return [{ ...primaryContact, ...edits }, ...rest];
-  };
+  const submittedContacts = (): any[] | undefined =>
+    collectContacts({
+      rows: Array.from({ length: contactRowCount }, (_, index) => readContactRow(index)),
+      primaryIndex: submittedPrimaryIndex(),
+      existing: existingContacts,
+    });
 
   const nationalityCodeValue = (value: string) => (values.nationalityCode = value);
 
@@ -170,6 +218,129 @@ export function editIndividualParticipant({
       control: 'nickname',
     },
   ];
+
+  /**
+   * One contact block. Index 0 renders exactly the fields the single-contact drawer rendered, under
+   * the same field names, so the primary contact's form is unchanged for the overwhelmingly common
+   * case of a participant with zero or one contact.
+   */
+  const contactRowItems = (index: number): any[] => {
+    const contact = existingContacts[index] ?? {};
+    const heading =
+      index === 0
+        ? t('pages.participants.editParticipant.primaryContact')
+        : `${t('pages.participants.editParticipant.additionalContact')} ${index + 1}`;
+
+    return [
+      // Only label the blocks once there is more than one of them to tell apart.
+      ...(contactRowCount > 1 ? [{ divider: true }, { text: heading, header: true }] : []),
+      {
+        placeholder: t('pages.participants.editParticipant.mobilePlaceholder'),
+        label: t('pages.participants.editParticipant.mobile'),
+        field: contactFieldName('mobileTelephone', index),
+        id: contactFieldName('mobileTelephone', index),
+        value: contact.mobileTelephone || '',
+      },
+      // Rendered only where one is already stored. `Contact.telephone` arrives by import and the call
+      // sheet displays it, so leaving it off the form entirely would show a director a number they
+      // could not correct — the gap this increment exists to close. Adding it unconditionally would
+      // put a sixth field on every block of the longest form in the app for a value almost nobody
+      // types by hand.
+      ...(contact.telephone
+        ? [
+            {
+              placeholder: t('pages.participants.editParticipant.telephonePlaceholder'),
+              label: t('pages.participants.editParticipant.telephone'),
+              field: contactFieldName('telephone', index),
+              id: contactFieldName('telephone', index),
+              value: contact.telephone,
+            },
+          ]
+        : []),
+      {
+        placeholder: t('pages.participants.editParticipant.emailPlaceholder'),
+        label: t('pages.participants.editParticipant.email'),
+        field: contactFieldName('emailAddress', index),
+        id: contactFieldName('emailAddress', index),
+        value: contact.emailAddress || '',
+      },
+      {
+        // Whose number this is. Defaults to UNSET rather than to SELF: defaulting would assert
+        // something nobody entered, on a field that decides who a director may ring at 9pm about a
+        // minor. An unlabelled contact stays unlabelled until someone says otherwise.
+        label: t('pages.participants.editParticipant.contactRelationship'),
+        field: contactFieldName('relationship', index),
+        options: [
+          // Explicit empty string, never `undefined` — a valueless <option> makes `select.value`
+          // fall back to the option TEXT, which is how a localized label once got persisted as
+          // `person.sex`. Same trap, same fix.
+          {
+            label: t('pages.participants.contactRelationship.unspecified'),
+            selected: !contact.relationship,
+            value: '',
+          },
+          ...CONTACT_RELATIONSHIPS.map((relationship) => ({
+            selected: contact.relationship === relationship,
+            label: t(relationshipKey(relationship)),
+            value: relationship,
+          })),
+        ],
+      },
+      {
+        // The contact's own name — "Ana Rivas", not the competitor's. Only meaningful once a
+        // relationship says the number belongs to someone else, which is why it arrives with it.
+        placeholder: t('pages.participants.editParticipant.contactNamePlaceholder'),
+        label: t('pages.participants.editParticipant.contactName'),
+        field: contactFieldName('name', index),
+        id: contactFieldName('name', index),
+        value: contact.name || '',
+      },
+      {
+        // Records the person's consent to have THIS CONTACT shared publicly — per contact, not per
+        // person, because the factory gates publication per contact (`getTournamentInfo` filters on
+        // `isPublic === true`). It is not a promise that the contact appears anywhere:
+        // `tournamentContacts` publishes only for the staff roles the factory lists, so ticking it
+        // for a competitor stores consent that no current surface acts on. Keeping the label about
+        // the contact rather than about a destination is what keeps it honest — and it spares TMX
+        // from duplicating the factory's role list, which is how SCOREKEEPER and TIMEKEEPER went
+        // missing from the Staff view for months.
+        label: t('pages.participants.editParticipant.contactIsPublic'),
+        field: contactFieldName('isPublic', index),
+        id: contactFieldName('isPublic', index),
+        checked: contact.isPublic === true,
+        checkbox: true,
+      },
+    ];
+  };
+
+  /**
+   * Which contact is the primary — expressed as a position, not a stored marker.
+   *
+   * `contacts[0]` is what every existing reader treats as primary: `getTournamentInfo`'s published
+   * contact, the participants table's `hasContact` / `contactPublic` columns, the group
+   * contact-person row. An `isPrimary` field would be a second source of truth for a fact the array
+   * order already carries, and the two would drift the first time anything wrote one without the
+   * other. So the picker reorders on save.
+   */
+  const primaryContactPicker = (): any[] => {
+    if (!offerPrimaryChoice) return [];
+    return [
+      { divider: true },
+      {
+        label: t('pages.participants.editParticipant.whichPrimary'),
+        field: 'primaryContact',
+        id: 'primaryContact',
+        radio: true,
+        options: existingContacts.map((contact: any, index: number) => ({
+          // `text` doubles as the radio's DOM value in `renderField`, so the selection is read back
+          // through the per-option `field` and `.checked` — never by comparing the displayed text.
+          text: contactRowLabel(contact, index),
+          field: primaryRadioField(index),
+          checked: index === 0,
+        })),
+      },
+    ];
+  };
 
   const content = (elem: HTMLElement) => {
     inputs = renderForm(
@@ -246,61 +417,11 @@ export function editIndividualParticipant({
         // competitor at least as urgently as an official — an ALTERNATE who might get into the draw is
         // the case that makes it obvious. Before this, TMX could display `person.contacts` in one place
         // and could not enter them anywhere; they arrived only via CSV/Sheets import.
-        {
-          placeholder: t('pages.participants.editParticipant.mobilePlaceholder'),
-          label: t('pages.participants.editParticipant.mobile'),
-          value: values.mobileTelephone || '',
-          field: 'mobileTelephone',
-        },
-        {
-          placeholder: t('pages.participants.editParticipant.emailPlaceholder'),
-          label: t('pages.participants.editParticipant.email'),
-          value: values.emailAddress || '',
-          field: 'emailAddress',
-        },
-        {
-          // Whose number this is. Defaults to UNSET rather than to SELF: defaulting would assert
-          // something nobody entered, on a field that decides who a director may ring at 9pm about a
-          // minor. An unlabelled contact stays unlabelled until someone says otherwise.
-          label: t('pages.participants.editParticipant.contactRelationship'),
-          field: 'contactRelationship',
-          options: [
-            // Explicit empty string, never `undefined` — a valueless <option> makes `select.value`
-            // fall back to the option TEXT, which is how a localized label once got persisted as
-            // `person.sex`. Same trap, same fix.
-            {
-              label: t('pages.participants.contactRelationship.unspecified'),
-              value: '',
-              selected: !values.contactRelationship,
-            },
-            ...CONTACT_RELATIONSHIPS.map((relationship) => ({
-              label: t(relationshipKey(relationship)),
-              value: relationship,
-              selected: values.contactRelationship === relationship,
-            })),
-          ],
-        },
-        {
-          // The contact's own name — "Ana Rivas", not the competitor's. Only meaningful once a
-          // relationship says the number belongs to someone else, which is why it arrives with it.
-          placeholder: t('pages.participants.editParticipant.contactNamePlaceholder'),
-          label: t('pages.participants.editParticipant.contactName'),
-          value: values.contactName || '',
-          field: 'contactName',
-        },
-        {
-          // Records the person's consent to have THIS CONTACT shared publicly. It is not a promise that
-          // the contact appears anywhere: `tournamentContacts` publishes public contacts only for the
-          // staff roles the factory lists, so ticking it for a competitor stores consent that no current
-          // surface acts on. Keeping the label about the contact rather than about a destination is what
-          // keeps it honest — and it spares TMX from duplicating the factory's role list, which is how
-          // SCOREKEEPER and TIMEKEEPER went missing from the Staff view for months.
-          label: t('pages.participants.editParticipant.contactIsPublic'),
-          checked: values.contactIsPublic,
-          field: 'contactIsPublic',
-          id: 'contactIsPublic',
-          checkbox: true,
-        },
+        //
+        // One block per stored contact, plus a blank spare to add the next one. A participant with no
+        // contacts sees exactly one block — the form the single-contact drawer rendered.
+        ...Array.from({ length: contactRowCount }, (_, index) => index).flatMap(contactRowItems),
+        ...primaryContactPicker(),
       ],
       relationships,
     );

--- a/src/pages/tournament/tabs/participantTab/mapParticipant.ts
+++ b/src/pages/tournament/tabs/participantTab/mapParticipant.ts
@@ -4,6 +4,7 @@
  * Dynamically collects all ratings present in participant data.
  */
 import { getClub, getCountry, getEvents } from 'pages/tournament/tabs/participantTab/getters';
+import { isPublicContact, reachableContacts } from 'services/contact/contactLinks';
 import { factoryConstants, fixtures } from 'tods-competition-factory';
 import camelcase from 'camelcase';
 
@@ -39,14 +40,22 @@ export const mapParticipant = (participant: any, derivedEventInfo: any): any => 
     }
   }
 
-  // The primary contact drives two columns: whether the person is reachable at all, and whether that
-  // contact carries consent to be published. `isPublic === true` deliberately — absent means not public,
-  // and nothing writes the flag on imported records, so a truthy check would read them all as consenting.
-  const primaryContact = person?.contacts?.[0];
-  const contactPublic = primaryContact?.isPublic === true;
-  const hasContact = !!(primaryContact?.mobileTelephone || primaryContact?.telephone || primaryContact?.emailAddress);
+  // Contacts drive three columns: the tappable affordances, whether the person is reachable at all,
+  // and whether anything about them carries consent to be published.
+  //
+  // Both summaries read the WHOLE list rather than `contacts[0]`. The factory publishes every contact
+  // marked `isPublic` — not just the primary — so "the primary consented" was a less accurate answer
+  // to "what will appear publicly" than "some contact consented", and it under-reported reachability
+  // for an imported record whose first entry is a name with no number.
+  //
+  // `isPublic === true` deliberately: absent means not public. Nothing wrote the flag before factory
+  // #4680, so a truthy check would read every imported contact as consenting.
+  const contacts = reachableContacts(person?.contacts);
+  const contactPublic = contacts.some(isPublicContact);
+  const hasContact = contacts.length > 0;
 
   return {
+    contacts,
     searchText: [participantName, standardGivenName, standardFamilyName, participant.participantOtherName]
       .filter(Boolean)
       .join(' ')

--- a/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
+++ b/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
@@ -20,6 +20,7 @@ import { getSexFilter } from 'components/tables/common/filters/sexFilter';
 import { editIndividualParticipant } from './editIndividualParticipant';
 import { signInParticipants } from './controlBar/signInParticipants';
 import { printPlayerList } from 'components/modals/printPlayerList';
+import { callSheet } from 'components/modals/callSheet';
 import { signOutUnapproved } from './controlBar/signOutUnapproved';
 import { getLoginState } from 'services/authentication/loginState';
 import { editRegistrationLink as sheetsLink } from './sheetsLink';
@@ -33,7 +34,7 @@ import { controlBar } from 'courthive-components';
 import { t } from 'i18n';
 
 // Constants
-import { PARTICIPANT_CONTROL, OVERLAY, RIGHT, LEFT } from 'constants/tmxConstants';
+import { PARTICIPANT_CONTROL, OVERLAY, STAFF, RIGHT, LEFT } from 'constants/tmxConstants';
 import { context } from 'services/context';
 
 const { INDIVIDUAL, GROUP } = participantConstants;
@@ -42,7 +43,7 @@ const { OFFICIAL } = participantRoles;
 const isPrimary = 'is-primary';
 
 export function renderIndividuals({ view }: { view: string }): void {
-  const { table, replaceTableData, teamParticipants, groupParticipants } = createParticipantsTable({ view });
+  const { table, replaceTableData, teamParticipants, groupParticipants, data } = createParticipantsTable({ view });
   context.refreshActiveTable = replaceTableData;
 
   const setSearchFilter = createSearchFilter(table, { persistKey: 'search', filterContext: 'participantFilters' });
@@ -107,6 +108,30 @@ export function renderIndividuals({ view }: { view: string }): void {
 
   const editRegistrationLink = () => sheetsLink({ callback: replaceTableData });
 
+  const viewLabel =
+    view === OFFICIAL
+      ? t('pages.participants.officials')
+      : view === STAFF
+        ? t('pages.participants.staff')
+        : t('pages.participants.title');
+
+  /**
+   * Open the call sheet.
+   *
+   * Selection wins when there is one — "text these six" means the six the director just ticked. With
+   * nothing selected the sheet covers every row the current filters leave visible, which is what the
+   * Actions-menu entry means. `getRows('active')` rather than `getData()` deliberately: `getData()`
+   * returns the unfiltered set, so a director who filtered to the medical team and pressed Print
+   * would get the whole tournament.
+   */
+  const openCallSheet = () => {
+    const selected = table?.getSelectedData?.() ?? [];
+    const visible = (table?.getRows('active') ?? []).map((row: any) => row.getData());
+    const rows = selected.length ? selected : visible;
+    const subtitle = selected.length ? `${viewLabel} (${t('pages.participants.selected')})` : viewLabel;
+    callSheet({ rows, subtitle });
+  };
+
   const synchronizePlayers = () => {
     (updateRegisteredPlayers as any)({
       callback: () => {
@@ -117,7 +142,10 @@ export function renderIndividuals({ view }: { view: string }): void {
     });
   };
 
-  const hasParticipants = table?.getDataCount() > 0;
+  // From the seeded data array, NOT `table.getDataCount()` — Tabulator answers 0 until `tableBuilt`
+  // fires, which is after `createParticipantsTable` returns. Reading the table here hid three Actions
+  // items on every first render of a table that was visibly showing rows.
+  const hasParticipants = data.length > 0;
   const isLoggedIn = !!state;
 
   const actionOptions: any[] = [
@@ -143,6 +171,14 @@ export function renderIndividuals({ view }: { view: string }): void {
     {
       onClick: () => printPlayerList({}),
       label: '<i class="fa-solid fa-print"></i> Print Player List',
+      close: true,
+    },
+    {
+      // Available from every view, not personnel alone. The population is whatever the table is
+      // showing, so on the Competitors view this is the alternates list a director works from.
+      onClick: openCallSheet,
+      label: `<i class="fa-solid fa-address-book"></i> ${t('modals.callSheet.title')}`,
+      hide: !hasParticipants,
       close: true,
     },
     { divider: true } as any,
@@ -240,6 +276,15 @@ export function renderIndividuals({ view }: { view: string }): void {
       intent: isPrimary,
       location: OVERLAY,
       label: t('pages.participants.signIn'),
+    },
+    {
+      // "Text these six." The selection overlay is where a director already stands after ticking
+      // rows, so the reach-them action belongs beside Sign In rather than three clicks away in the
+      // Actions menu.
+      onClick: openCallSheet,
+      label: t('modals.callSheet.contactSelected'),
+      location: OVERLAY,
+      intent: 'none',
     },
     {
       onClick: () => deleteSelectedParticipants(table),

--- a/src/services/contact/contactLinks.test.ts
+++ b/src/services/contact/contactLinks.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The call sheet's dial-string layer.
+ *
+ * These are the decisions that turn stored contact text into a tappable href, and every one of them
+ * has a failure mode that is invisible on screen: a `tel:` link with no digits behind it looks live
+ * and does nothing, and a `mailto:` that addresses fifteen people in `to:` discloses fifteen personal
+ * addresses to fifteen people. Both are asserted in the negative direction as well as the positive.
+ */
+import {
+  isPublicContact,
+  reachableContacts,
+  contactNumbers,
+  looksLikeEmail,
+  primaryNumber,
+  mailtoHref,
+  dialNumber,
+  isReachable,
+  smsHref,
+  telHref,
+} from './contactLinks';
+import { describe, expect, it } from 'vitest';
+
+const MOBILE = '+1 (555) 010-0100';
+const LANDLINE = '555.0199';
+const EMAIL = 'ana@example.org';
+const MAILTO_EMAIL = `mailto:${EMAIL}`;
+
+describe('dialNumber', () => {
+  it('strips everything a dialler will not accept, keeping a leading +', () => {
+    expect(dialNumber(MOBILE)).toEqual('+15550100100');
+    expect(dialNumber(LANDLINE)).toEqual('5550199');
+    expect(dialNumber('  +44 20 7946 0958 ')).toEqual('+442079460958');
+  });
+
+  it('never returns a + with no digits behind it', () => {
+    // The failure this guards: `tel:+` renders as a live link and dials nothing.
+    expect(dialNumber('+')).toBeUndefined();
+    expect(dialNumber('   ')).toBeUndefined();
+    expect(dialNumber('n/a')).toBeUndefined();
+    expect(dialNumber('')).toBeUndefined();
+    expect(dialNumber(undefined)).toBeUndefined();
+  });
+
+  it('does not invent a + that was not typed', () => {
+    expect(dialNumber('5550100')).toEqual('5550100');
+  });
+});
+
+describe('telHref', () => {
+  it('builds a dialable href', () => {
+    expect(telHref(MOBILE)).toEqual('tel:+15550100100');
+  });
+
+  it('returns undefined rather than a bare tel:', () => {
+    expect(telHref('ext. 4')).toEqual('tel:4');
+    expect(telHref('n/a')).toBeUndefined();
+    expect(telHref(undefined)).toBeUndefined();
+  });
+});
+
+describe('smsHref', () => {
+  it('addresses several recipients with one comma-separated href', () => {
+    expect(smsHref([MOBILE, '+1 555 010 0200'])).toEqual('sms:+15550100100,+15550100200');
+  });
+
+  it('de-duplicates by dial string, not by the text as typed', () => {
+    // "+1 (555) 010-0100" and "+15550100100" are the same phone. Texting it twice is a bug the
+    // director sees only in their sent messages.
+    expect(smsHref([MOBILE, '+15550100100'])).toEqual('sms:+15550100100');
+  });
+
+  it('drops unusable entries instead of emitting an empty recipient', () => {
+    expect(smsHref([MOBILE, undefined, '', 'no number'])).toEqual('sms:+15550100100');
+  });
+
+  it('returns undefined when nobody is reachable', () => {
+    expect(smsHref([])).toBeUndefined();
+    expect(smsHref([undefined, 'n/a'])).toBeUndefined();
+  });
+
+  it('carries no body parameter', () => {
+    // Deliberate: iOS wants `&body=`, Android wants `?body=`, and one href cannot be both. Asserted
+    // so a later "helpful" addition has to come with a platform branch and a test per platform.
+    expect(smsHref([MOBILE])).not.toContain('body');
+  });
+});
+
+describe('mailtoHref', () => {
+  it('addresses a single recipient directly', () => {
+    expect(mailtoHref([EMAIL])).toEqual(MAILTO_EMAIL);
+  });
+
+  it('BCCs several recipients so nobody learns the others addresses', () => {
+    // The disclosure the director never chose to make. Asserted as an absence of `to=` as well as a
+    // presence of `bcc=`, because a `to:` that also carried a bcc would still leak.
+    const href = mailtoHref([EMAIL, 'raj@example.org']) as string;
+    expect(href).toContain('bcc=');
+    expect(href).toEqual(`mailto:?bcc=${EMAIL},raj@example.org`);
+    expect(href).not.toContain('to=');
+  });
+
+  it('escapes a plus-addressed recipient in the query string', () => {
+    // A bare `+` in a query string means SPACE. `ana+tmx@example.org` would arrive as
+    // `ana tmx@example.org` and bounce.
+    const href = mailtoHref(['ana+tmx@example.org', 'raj@example.org']) as string;
+    expect(href).toContain('ana%2Btmx@example.org');
+    expect(href).not.toContain('ana+tmx@example.org');
+  });
+
+  it('drops entries that are not addresses', () => {
+    expect(mailtoHref(['not-an-address', EMAIL])).toEqual(MAILTO_EMAIL);
+    expect(mailtoHref(['@example.org', 'ana@'])).toBeUndefined();
+    expect(mailtoHref([])).toBeUndefined();
+  });
+});
+
+describe('looksLikeEmail', () => {
+  it('accepts an ordinary address and rejects the shapes a mailto cannot use', () => {
+    expect(looksLikeEmail(EMAIL)).toBe(true);
+    expect(looksLikeEmail('ana@')).toBe(false);
+    expect(looksLikeEmail('@example.org')).toBe(false);
+    expect(looksLikeEmail('ana example@org')).toBe(false);
+    expect(looksLikeEmail(undefined)).toBe(false);
+  });
+});
+
+describe('contact shape helpers', () => {
+  it('puts the mobile first, because only a mobile can receive an SMS', () => {
+    const contact = { telephone: LANDLINE, mobileTelephone: MOBILE };
+    expect(contactNumbers(contact)).toEqual([MOBILE, LANDLINE]);
+    expect(primaryNumber(contact)).toEqual(MOBILE);
+  });
+
+  it('falls back to the landline when there is no mobile', () => {
+    expect(primaryNumber({ telephone: LANDLINE })).toEqual(LANDLINE);
+  });
+
+  it('treats a name-only contact as unreachable', () => {
+    // A director cannot ring a name. This is the third state the participants table already
+    // distinguishes: has no contact at all.
+    expect(isReachable({ name: 'desk' })).toBe(false);
+    expect(isReachable({ name: 'desk', mobileTelephone: MOBILE })).toBe(true);
+    expect(isReachable({ emailAddress: EMAIL })).toBe(true);
+    expect(isReachable(undefined)).toBe(false);
+  });
+
+  it('treats whitespace as absent', () => {
+    expect(isReachable({ mobileTelephone: '   ', emailAddress: '  ' })).toBe(false);
+  });
+
+  it('requires isPublic === true, so absent and false both withhold', () => {
+    // Nothing wrote this flag before factory #4680, so a truthy check reads every imported contact
+    // as having consented to publication.
+    expect(isPublicContact({ isPublic: true })).toBe(true);
+    expect(isPublicContact({ isPublic: false })).toBe(false);
+    expect(isPublicContact({})).toBe(false);
+    expect(isPublicContact(undefined)).toBe(false);
+  });
+
+  it('filters a stored list down to the actionable entries, preserving order', () => {
+    const contacts = [{ name: 'desk' }, { mobileTelephone: MOBILE }, { emailAddress: EMAIL }];
+    expect(reachableContacts(contacts)).toEqual([contacts[1], contacts[2]]);
+    expect(reachableContacts(undefined)).toEqual([]);
+  });
+});

--- a/src/services/contact/contactLinks.ts
+++ b/src/services/contact/contactLinks.ts
@@ -1,0 +1,118 @@
+/**
+ * Turning a stored `Contact` into something a director can actually tap.
+ *
+ * A phone number that cannot be dialled from the device holding it is not a call sheet, and
+ * `person.contacts[]` stores numbers as a human typed them — "+1 (555) 010-0100", "555 0100 ext 2".
+ * `tel:` / `sms:` want a dial string, the table wants the original. Both are produced here so no
+ * caller invents its own normalisation.
+ *
+ * Everything in this module is pure and DOM-free: TMX's unit suite runs in the vitest `node`
+ * environment with no jsdom, so the decisions live here and the rendering stays a thin shell.
+ */
+
+export interface ContactLike {
+  mobileTelephone?: string;
+  emailAddress?: string;
+  relationship?: string;
+  telephone?: string;
+  isPublic?: boolean;
+  notes?: string;
+  name?: string;
+  fax?: string;
+}
+
+/**
+ * A number reduced to what a dialler will accept: an optional leading `+` and digits.
+ *
+ * Returns `undefined` rather than an empty string for anything with no digits in it, so a caller
+ * cannot emit a bare `tel:` href. That distinction is the whole point — `tel:` with nothing after it
+ * is a link that looks live and does nothing.
+ */
+export function dialNumber(value?: string): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const digits = trimmed.replaceAll(/\D/g, '');
+  if (!digits) return undefined;
+  return trimmed.startsWith('+') ? `+${digits}` : digits;
+}
+
+/**
+ * Deliberately minimal. This is not validation — nothing here rejects a contact — it only decides
+ * whether an address is worth putting behind a `mailto:`. A stricter pattern would silently drop
+ * addresses a mail client would have accepted, which is the failure mode that matters on this surface.
+ */
+export function looksLikeEmail(value?: string): boolean {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  const at = trimmed.indexOf('@');
+  return at > 0 && at < trimmed.length - 1 && !/\s/.test(trimmed);
+}
+
+/** The numbers on one contact, mobile first — a mobile can receive an SMS and a landline cannot. */
+export function contactNumbers(contact?: ContactLike): string[] {
+  return [contact?.mobileTelephone, contact?.telephone].filter((value): value is string => !!value?.trim());
+}
+
+/** The one number to ring for this contact, or `undefined`. */
+export function primaryNumber(contact?: ContactLike): string | undefined {
+  return contactNumbers(contact)[0];
+}
+
+/** A contact carries something a director can act on. A `name` alone is not reachable. */
+export function isReachable(contact?: ContactLike): boolean {
+  return !!(primaryNumber(contact) || contact?.emailAddress?.trim());
+}
+
+/**
+ * Consent to publish THIS contact. `=== true` deliberately: absent and `false` both withhold.
+ *
+ * Mirrors `publishableContacts` in the factory's `getTournamentInfo` rather than re-deciding the rule.
+ * Nothing in the ecosystem wrote this flag before factory #4680, so a truthy check would read every
+ * imported contact as having consented.
+ */
+export function isPublicContact(contact?: ContactLike): boolean {
+  return contact?.isPublic === true;
+}
+
+/** Only contacts a director can act on, in stored order (index 0 is the primary). */
+export function reachableContacts(contacts?: ContactLike[]): ContactLike[] {
+  return Array.isArray(contacts) ? contacts.filter(isReachable) : [];
+}
+
+export function telHref(value?: string): string | undefined {
+  const dial = dialNumber(value);
+  return dial ? `tel:${dial}` : undefined;
+}
+
+/**
+ * `sms:` for one or many recipients, de-duplicated by dial string.
+ *
+ * **No `body` parameter, on purpose.** RFC 5724 gives comma-separated recipients, which iOS and
+ * Android both accept — but they disagree on how a prefilled body is attached (`&body=` on iOS,
+ * `?body=` on Android), so a single href cannot carry one correctly for both. A message that arrives
+ * prefilled on one phone and mangled on the other is worse than an empty compose window, and the
+ * director is about to type anyway. If a body is ever wanted, it needs a platform branch and a test
+ * per platform, not a guess here.
+ */
+export function smsHref(values: (string | undefined)[]): string | undefined {
+  const recipients = [...new Set(values.map(dialNumber).filter(Boolean))];
+  return recipients.length ? `sms:${recipients.join(',')}` : undefined;
+}
+
+/**
+ * `mailto:` addressed to everyone.
+ *
+ * Recipients go in **bcc** when there is more than one. A call sheet is a list of people's personal
+ * addresses; putting fifteen of them in `to:` hands every recipient the other fourteen, which is a
+ * disclosure the director never chose to make and cannot take back.
+ */
+export function mailtoHref(values: (string | undefined)[]): string | undefined {
+  const recipients = [...new Set(values.filter(looksLikeEmail).map((value) => (value as string).trim()))];
+  if (!recipients.length) return undefined;
+  if (recipients.length === 1) return `mailto:${encodeURIComponent(recipients[0]).replaceAll('%40', '@')}`;
+  return `mailto:?bcc=${recipients
+    .map((r) => encodeURIComponent(r))
+    .join(',')
+    .replaceAll('%40', '@')}`;
+}

--- a/src/styles/tmx.css
+++ b/src/styles/tmx.css
@@ -1343,3 +1343,109 @@ img {
   color: var(--tmx-text-secondary);
   opacity: 0.7;
 }
+
+/* ── Call sheet: contact affordances ─────────────────────────────────── */
+/*
+ * The tappable half of the participants table and the call sheet modal.
+ *
+ * D3 (CA, 2026-08-23): the TD surface shows every contact and MARKS the private ones rather than
+ * hiding them. `.tmx-contact-private-mark` is that marker, and it is deliberately quiet — it is a
+ * statement about consent, not a warning. `isPublic` still gates the public surfaces; nothing here
+ * changes what `getTournamentInfo` publishes.
+ *
+ * Tokens for both themes, per the light+dark rule. The link colour needs its own token rather than
+ * borrowing `--tmx-accent-blue`, because the icons sit on the table's row-hover ground where the
+ * shared accent loses contrast in dark mode.
+ */
+:root {
+  --tmx-contact-link-fg: #1f5fa8;
+  --tmx-contact-link-hover-fg: #14406f;
+  --tmx-contact-mark-fg: #8a6d1f;
+  --tmx-contact-more-fg: #5b6470;
+  --tmx-contact-more-bg: rgba(91, 100, 112, 0.12);
+  --tmx-call-sheet-divider: #e0e0e0;
+}
+[data-theme='dark'] {
+  --tmx-contact-link-fg: #9ec5ff;
+  --tmx-contact-link-hover-fg: #d3e5ff;
+  --tmx-contact-mark-fg: #e3c46a;
+  --tmx-contact-more-fg: #b3bcc7;
+  --tmx-contact-more-bg: rgba(179, 188, 199, 0.16);
+  --tmx-call-sheet-divider: #3a3a3a;
+}
+
+.tmx-contact-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+}
+.tmx-contact-link {
+  color: var(--tmx-contact-link-fg);
+  text-decoration: none;
+}
+.tmx-contact-link:hover,
+.tmx-contact-link:focus-visible {
+  color: var(--tmx-contact-link-hover-fg);
+  text-decoration: none;
+}
+.tmx-contact-private-mark {
+  color: var(--tmx-contact-mark-fg);
+  font-size: 0.75em;
+}
+.tmx-contact-more {
+  color: var(--tmx-contact-more-fg);
+  background: var(--tmx-contact-more-bg);
+  border-radius: 3px;
+  padding: 0 0.35em;
+  font-size: 0.75em;
+  line-height: 1.5;
+}
+
+/* ── Call sheet modal ────────────────────────────────────────────────── */
+.tmx-call-sheet {
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 0.25em 0.5em;
+}
+.tmx-call-sheet-summary {
+  color: var(--tmx-text-secondary);
+  font-size: 0.85em;
+  padding-bottom: 0.5em;
+}
+.tmx-call-sheet-entry {
+  border-top: 1px solid var(--tmx-call-sheet-divider);
+  padding: 0.5em 0;
+}
+/* People with no contact details still appear — a sheet that omits them claims the roster is
+   complete — but they read as an outstanding task rather than as a row to act on. */
+.tmx-call-sheet-entry.is-muted {
+  opacity: 0.65;
+}
+.tmx-call-sheet-name {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  font-weight: 600;
+  color: var(--tmx-text-primary);
+}
+.tmx-call-sheet-contact {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding-top: 0.2em;
+  font-size: 0.9em;
+}
+.tmx-call-sheet-whose {
+  color: var(--tmx-text-secondary);
+  min-width: 6em;
+  font-size: 0.85em;
+}
+.tmx-call-sheet-value {
+  color: var(--tmx-text-primary);
+}
+.tmx-call-sheet-none {
+  color: var(--tmx-text-secondary);
+  font-size: 0.85em;
+  font-style: italic;
+  padding-top: 0.2em;
+}


### PR DESCRIPTION
P3 of `Mentat/planning/TMX_PARTICIPANTS_PERSONNEL_AND_GROUPS.md` — the call sheet — landed together with the **multi-contact editing** item from `TASKS.md`. CA chose "sequence them together": a sheet that renders every contact while the drawer can only correct the first one shows a director a number they cannot fix.

## What this adds

- **`tel:` / `sms:` / `mailto:` affordances** on participant rows, via a new contacts column. Shown by default for personnel, in the header menu everywhere — a director chasing an alternate wants it on competitors too.
- **Call sheet modal** over the table's rows: the selection when there is one, otherwise every row the current filters leave visible (`getRows('active')`, not `getData()`, so a filtered view prints what it shows).
- **Bulk actions** — text all / email all / copy numbers. Each **reports who it will not reach, by name**. Email BCCs when there is more than one recipient, so a call sheet does not hand fifteen people each other's addresses.
- **Printable call sheet** through pdf-factory's existing `generateReportPDF`. **No pdf-factory change**, so no publish cascade.
- **Multi-contact drawer** — one block per stored contact plus a blank spare, with a positional primary picker.

## D3 is decided (CA, 2026-08-23)

The TD surface does **not** respect `contact.isPublic`. A director sees every contact; private ones carry a visible marker rather than being hidden. `isPublic` continues to govern **public** surfaces only — the factory's `getTournamentInfo` still filters `tournamentContacts` on `isPublic === true`, untouched by this PR.

## Design notes

- **TMX has no jsdom**, so every decision lives in a pure function with its own tests (`contactLinks`, `collectContacts`, `buildCallSheet`) and the DOM shell stays thin. Journey 104 is the DOM-layer evidence.
- **`renderForm` has no button item type** and renders once. So "add" is an always-present spare row, "remove" is clearing the reachable fields (semantics the single-contact drawer already shipped), and "reorder" is a radio group. **No courthive-components change.**
- **Contact index 0 keeps the unsuffixed field names.** Index 0 *is* the primary, so `mobileTelephone` still means what it always meant — and the 26 existing drawer tests pass **unchanged**.
- The primary is **positional**, not a stored marker: every existing reader (`getTournamentInfo`, the table columns, the group contact-person row) reads `contacts[0]`, and a marker would be a second source of truth.
- Nothing re-derives which roles count as personnel. The population is the table's own rows — the factory's `STAFF_CONTACT_ROLES` is module-local, and copying it would make a fifth hand-written role array *and* be the wrong list (it excludes COACH, CAPTAIN, VOLUNTEER, who are exactly who a director rings at 6am).

## One pre-existing bug fixed

`hasParticipants` read `table.getDataCount()` immediately after `new Tabulator(...)`, which answers **0** until `tableBuilt` fires. *Sign out unapproved*, *Edit ratings* and the new *Call sheet* were hidden on every first render of a table that was visibly showing rows. `createParticipantsTable` now returns its seeded `data` and the gate reads `data.length`.

## Verification

`lint` 0 · `format:check` clean · `check-types` 0 · `i18n-audit --ci` 0 · `attr-audit --ci` 0 · **1393 unit tests pass** (baseline 1330) · journeys 104 / 91 / 101 / 74 / 93 / 95 green.

**11 falsification probes**, each a two-run pair (feature on → green, feature off → red), covering the preserve-untouched-rows rule, primary promotion, the `mailto:` BCC guard, the bare-`tel:` guard, the not-reached report, the grouping skip, whole-list reachability, and — through the browser — the D3 marker and the dial-string normalisation. Notably, breaking the preserve rule turns the **existing, unmodified** `PRESERVES other contacts` test red, which is the evidence that the N-row generalisation is what keeps it passing.