### PR TITLE
feat(capability): one reason-carrying answer for "may this user do this here"

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2518,5 +2518,30 @@
     "TRAINER": "Trainer",
     "TRANSPORT": "Transport",
     "VOLUNTEER": "Volunteer"
+  },
+  "capability": {
+    "denied": {
+      "provider": "Not available under this provider’s configuration.",
+      "createCompetitor": "This provider does not allow competitors to be added here.",
+      "createOfficial": "This provider does not allow officials to be added here.",
+      "importParticipants": "This provider does not allow importing participants.",
+      "deleteParticipants": "This provider does not allow deleting participants.",
+      "editParticipantDetails": "This provider does not allow editing participant details.",
+      "modifyEntries": "This provider does not allow changing event entries.",
+      "createEvent": "This provider does not allow events to be created in TMX.",
+      "deleteEvent": "This provider does not allow deleting events.",
+      "createDraw": "This provider does not allow draws to be created here.",
+      "deleteDraw": "This provider does not allow deleting draws.",
+      "assignPositions": "This provider does not allow draw positions to be assigned here.",
+      "modifyStructures": "This provider does not allow draw structures to be changed.",
+      "createVenue": "This provider does not allow venues to be created here.",
+      "deleteVenue": "This provider does not allow deleting venues.",
+      "modifySchedule": "This provider does not allow the schedule to be changed here.",
+      "useBulkScheduling": "This provider does not allow bulk scheduling.",
+      "enterScores": "This provider does not allow scores to be entered here.",
+      "publish": "This provider does not allow publishing.",
+      "unpublish": "This provider does not allow unpublishing.",
+      "useChat": "Chat is disabled for this provider."
+    }
   }
 }

--- a/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
+++ b/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
@@ -27,7 +27,7 @@ import { editRegistrationLink as sheetsLink } from './sheetsLink';
 import { addParticipantsToEvent } from './addParticipantsToEvent';
 import { eventFromParticipants } from './eventFromParticipants';
 import { selectItem } from 'components/modals/selectItem';
-import { providerConfig } from 'config/providerConfig';
+import { cannot } from 'services/capability/can';
 import { importPlayersCsv } from './importPlayersCsv';
 import { participantChips } from './participantChips';
 import { controlBar } from 'courthive-components';
@@ -183,13 +183,13 @@ export function renderIndividuals({ view }: { view: string }): void {
     },
     { divider: true } as any,
     {
-      hide: !providerConfig.isAllowed('canImportParticipants'),
+      hide: cannot('importParticipants'),
       label: t('pages.participants.importGoogleSheet'),
       onClick: editRegistrationLink,
       close: true,
     },
     {
-      hide: !providerConfig.isAllowed('canImportParticipants'),
+      hide: cannot('importParticipants'),
       label: t('pages.participants.importFromCsv'),
       onClick: () => importPlayersCsv({ callback: replaceTableData }),
       close: true,
@@ -199,7 +199,7 @@ export function renderIndividuals({ view }: { view: string }): void {
       label: t('pages.participants.newParticipant'),
       // Different cap depending on whether the user is creating a COMPETITOR
       // or an OFFICIAL — both are PARTICIPANTS but are gated separately.
-      hide: !providerConfig.isAllowed(view === OFFICIAL ? 'canCreateOfficials' : 'canCreateCompetitors'),
+      hide: cannot(view === OFFICIAL ? 'createOfficial' : 'createCompetitor'),
       close: true,
     },
   ];
@@ -291,7 +291,7 @@ export function renderIndividuals({ view }: { view: string }): void {
       label: t('pages.participants.deleteSelected'),
       intent: 'is-danger',
       stateChange: true,
-      hide: !providerConfig.isAllowed('canDeleteParticipants'),
+      hide: cannot('deleteParticipants'),
       location: OVERLAY,
     },
     {

--- a/src/services/capability/can.test.ts
+++ b/src/services/capability/can.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { can, cannot, denialReason, permissionForAction } from './can';
+import type { CapabilityAction } from './can';
+import { providerConfig } from 'config/providerConfig';
+
+const ALL_ACTIONS: CapabilityAction[] = [
+  'createCompetitor',
+  'createOfficial',
+  'importParticipants',
+  'deleteParticipants',
+  'editParticipantDetails',
+  'modifyEntries',
+  'createEvent',
+  'deleteEvent',
+  'createDraw',
+  'deleteDraw',
+  'assignPositions',
+  'modifyStructures',
+  'createVenue',
+  'deleteVenue',
+  'modifySchedule',
+  'useBulkScheduling',
+  'enterScores',
+  'publish',
+  'unpublish',
+  'useChat',
+];
+
+describe('can()', () => {
+  beforeEach(() => providerConfig.reset());
+
+  it('allows every action for an unconfigured provider', () => {
+    // The production reality: 0 of 1130 providers configure permissions, so an
+    // unconfigured provider must retain full capability.
+    for (const action of ALL_ACTIONS) {
+      expect(can(action), action).toEqual({ allowed: true });
+    }
+  });
+
+  it('denies when the provider turns the permission off, and says which layer refused', () => {
+    providerConfig.set({ permissions: { canCreateEvents: false } });
+    const result = can('createEvent');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.because).toBe('provider');
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('carries a distinct, non-key reason per action rather than echoing the flag name', () => {
+    providerConfig.set({ permissions: { canCreateEvents: false, canCreateDraws: false } });
+    const event = denialReason('createEvent');
+    const draw = denialReason('createDraw');
+    expect(event).not.toEqual(draw);
+    // A reason that just names the permission key teaches nothing.
+    expect(event).not.toContain('canCreateEvents');
+  });
+
+  it('closes the Staff/Officials drift — the two map to different keys', () => {
+    // TMX gated the Officials view on canCreateOfficials while the server
+    // enforced canCreateCompetitors for both, so the button appeared and the
+    // save failed. Both are now explicit and separately answerable.
+    expect(permissionForAction('createOfficial')).toBe('canCreateOfficials');
+    expect(permissionForAction('createCompetitor')).toBe('canCreateCompetitors');
+
+    providerConfig.set({ permissions: { canCreateOfficials: false } });
+    expect(can('createOfficial').allowed).toBe(false);
+    expect(can('createCompetitor').allowed).toBe(true);
+  });
+
+  it('every action maps to a permission key', () => {
+    for (const action of ALL_ACTIONS) expect(permissionForAction(action)).toMatch(/^can[A-Z]/);
+  });
+
+  it('cannot() is the negation, for `hide:` call sites', () => {
+    providerConfig.set({ permissions: { canDeleteVenues: false } });
+    expect(cannot('deleteVenue')).toBe(true);
+    expect(cannot('createVenue')).toBe(false);
+  });
+
+  it('denialReason is undefined when allowed', () => {
+    expect(denialReason('createEvent')).toBeUndefined();
+  });
+
+  it('re-evaluates against current config rather than caching', () => {
+    expect(can('publish').allowed).toBe(true);
+    providerConfig.set({ permissions: { canPublish: false } });
+    expect(can('publish').allowed).toBe(false);
+    providerConfig.reset();
+    expect(can('publish').allowed).toBe(true);
+  });
+});

--- a/src/services/capability/can.ts
+++ b/src/services/capability/can.ts
@@ -1,0 +1,134 @@
+/**
+ * One answer to "may this user do this here?", derived once and rendered
+ * consistently.
+ *
+ * TMX has three independent sources of that answer and nothing that combines
+ * them: provider configuration (`providerConfig`), the individual's roles
+ * (`loginState`), and the tournament's own state. Each call site invents its
+ * own combination, and they drift — the participants page gated its Officials
+ * view on `canCreateOfficials` while the server enforced `canCreateCompetitors`
+ * for both, so TMX offered a control the server then refused.
+ *
+ * The goal is not more gates. It is one answer.
+ *
+ * ## The result is not a boolean
+ *
+ * A disabled control that says *"Entries arrive through registration — accept a
+ * registrant instead"* teaches the operating model. A hidden one reads as a bug,
+ * and an enabled one that fails on save is the shape that caused the drift
+ * above. So `can()` returns a reason, and `because` names the layer that said
+ * no, which is what makes a support answer possible.
+ *
+ * ## Scope of this layer
+ *
+ * Provider + role only. Tournament state (lifecycle, registration window,
+ * publication) and per-tournament scope are later phases — see
+ * `Mentat/planning/TMX_LOCKDOWN_AND_ROLE_MODEL.md` §3. The `because` union
+ * already carries their values so adding them is not a breaking change.
+ *
+ * ## This is a UX contract, not a security boundary
+ *
+ * Anything that must be *enforced* is enforced by the server
+ * (`MutationAuthorizationService`, and the `MUTATION_PERMISSIONS` map both
+ * layers share). `can()` decides what to render. Do not let its existence imply
+ * otherwise.
+ */
+import { providerConfig } from 'config/providerConfig';
+import { t } from 'i18n';
+
+import type { ProviderPermissions } from '@courthive/provider-config';
+
+/** Which layer refused. Ordered most-specific-first, as the resolver evaluates. */
+export type CapabilityLayer = 'tournamentState' | 'role' | 'provider';
+
+export type Capability = { allowed: true } | { allowed: false; reason: string; because: CapabilityLayer };
+
+/**
+ * Actions TMX gates. Deliberately a closed set of *actions*, not a passthrough
+ * of permission keys: the action is the vocabulary call sites should speak, and
+ * it lets one action map to different keys as the model gains scope and state.
+ */
+export type CapabilityAction =
+  | 'createCompetitor'
+  | 'createOfficial'
+  | 'importParticipants'
+  | 'deleteParticipants'
+  | 'editParticipantDetails'
+  | 'modifyEntries'
+  | 'createEvent'
+  | 'deleteEvent'
+  | 'createDraw'
+  | 'deleteDraw'
+  | 'assignPositions'
+  | 'modifyStructures'
+  | 'createVenue'
+  | 'deleteVenue'
+  | 'modifySchedule'
+  | 'useBulkScheduling'
+  | 'enterScores'
+  | 'publish'
+  | 'unpublish'
+  | 'useChat';
+
+const ACTION_PERMISSION: Readonly<Record<CapabilityAction, keyof ProviderPermissions>> = {
+  createCompetitor: 'canCreateCompetitors',
+  createOfficial: 'canCreateOfficials',
+  importParticipants: 'canImportParticipants',
+  deleteParticipants: 'canDeleteParticipants',
+  editParticipantDetails: 'canEditParticipantDetails',
+  modifyEntries: 'canModifyEntries',
+  createEvent: 'canCreateEvents',
+  deleteEvent: 'canDeleteEvents',
+  createDraw: 'canCreateDraws',
+  deleteDraw: 'canDeleteDraws',
+  assignPositions: 'canAssignPositions',
+  modifyStructures: 'canModifyStructures',
+  createVenue: 'canCreateVenues',
+  deleteVenue: 'canDeleteVenues',
+  modifySchedule: 'canModifySchedule',
+  useBulkScheduling: 'canUseBulkScheduling',
+  enterScores: 'canEnterScores',
+  publish: 'canPublish',
+  unpublish: 'canUnpublish',
+  useChat: 'canUseChat',
+};
+
+/** The permission key an action resolves to. Exported for the demo simulator. */
+export function permissionForAction(action: CapabilityAction): keyof ProviderPermissions {
+  return ACTION_PERMISSION[action];
+}
+
+const ALLOWED: Capability = { allowed: true };
+
+/**
+ * May the current user perform `action`?
+ *
+ * MUST be called at render, never cached at page load: a provider's effective
+ * config is re-fetched on impersonation switch and a director's role can change
+ * between renders. `navigation.ts` already re-evaluates its conditional tabs on
+ * every tab render for exactly this reason.
+ */
+export function can(action: CapabilityAction): Capability {
+  const key = ACTION_PERMISSION[action];
+
+  if (!providerConfig.isAllowed(key)) {
+    return {
+      allowed: false,
+      because: 'provider',
+      reason: t(`capability.denied.${action}`, { defaultValue: t('capability.denied.provider') }),
+    };
+  }
+
+  return ALLOWED;
+}
+
+/** Convenience for the `hide:` property that control-bar and menu items take. */
+export function cannot(action: CapabilityAction): boolean {
+  return !can(action).allowed;
+}
+
+/** The reason, when denied — otherwise undefined. Use for a disabled-control tooltip. */
+export function denialReason(action: CapabilityAction): string | undefined {
+  const result = can(action);
+  return result.allowed ? undefined : result.reason;
+}

--- a/src/services/capability/capabilityCoverage.test.ts
+++ b/src/services/capability/capabilityCoverage.test.ts
@@ -4,6 +4,8 @@ import { join, resolve } from 'node:path';
 
 import { UI_ENFORCED, MUTATION_ENFORCED, coverageFor, unenforcedPermissionKeys } from './capabilityCoverage';
 import { BOOLEAN_PERMISSION_KEYS } from '@courthive/provider-config';
+import { permissionForAction } from './can';
+import type { CapabilityAction } from './can';
 
 const SRC = resolve(__dirname, '../..');
 
@@ -16,16 +18,32 @@ function sourceFiles(dir: string, acc: string[] = []): string[] {
   return acc;
 }
 
-/** Every key passed to a literal `providerConfig.isAllowed('<key>')` in src/. */
+/**
+ * Every permission key gated by a UI affordance in `src/`, in either call form:
+ *
+ *   providerConfig.isAllowed('<key>')   — the original, still used at unmigrated sites
+ *   can('<action>') / cannot('<action>') — the resolver, which maps action → key
+ *
+ * Both must be scanned or the pin breaks as sites migrate: moving a gate onto
+ * the resolver would look like the gate was deleted.
+ */
 function scanUiGatedKeys(files: string[]): Set<string> {
   const found = new Set<string>();
+  const addAction = (action: string) => {
+    const key = permissionForAction(action as CapabilityAction);
+    if (key) found.add(key);
+  };
   for (const file of files) {
     const text = readFileSync(file, 'utf8');
     for (const match of text.matchAll(/isAllowed\(\s*'([a-zA-Z]+)'/g)) found.add(match[1]);
-    // The ternary form: isAllowed(cond ? 'a' : 'b')
     for (const match of text.matchAll(/isAllowed\([^)]*\?\s*'([a-zA-Z]+)'\s*:\s*'([a-zA-Z]+)'/g)) {
       found.add(match[1]);
       found.add(match[2]);
+    }
+    for (const match of text.matchAll(/\b(?:can|cannot|denialReason)\(\s*'([a-zA-Z]+)'/g)) addAction(match[1]);
+    for (const match of text.matchAll(/\b(?:can|cannot)\([^)]*\?\s*'([a-zA-Z]+)'\s*:\s*'([a-zA-Z]+)'/g)) {
+      addAction(match[1]);
+      addAction(match[2]);
     }
   }
   return found;
@@ -34,7 +52,13 @@ function scanUiGatedKeys(files: string[]): Set<string> {
 describe('capability coverage', () => {
   const files = sourceFiles(SRC);
   // Exclude the doc-comment example in providerConfig.ts, which is prose, not a gate.
-  const scanned = scanUiGatedKeys(files.filter((f) => !f.endsWith('config/providerConfig.ts')));
+  const scanned = scanUiGatedKeys(
+    files.filter(
+      (f) =>
+        !f.endsWith('config/providerConfig.ts') && // doc-comment example, prose not a gate
+        !f.includes('services/capability/'), // the resolver defines the mapping; it is not a call site
+    ),
+  );
 
   // ── Controls: a broken scanner must not be able to agree by vacuous truth ──
 
@@ -46,11 +70,15 @@ describe('capability coverage', () => {
     expect(scanned.size).toBeGreaterThanOrEqual(12);
   });
 
-  it('the scanner detects a gate it is shown (falsification control)', () => {
-    const planted = `if (providerConfig.isAllowed('canPublish')) doThing();`;
+  it('the scanner detects a gate it is shown, in both call forms (falsification control)', () => {
+    const planted = `if (providerConfig.isAllowed('canPublish')) a(); if (cannot('createDraw')) b();`;
     const hits = new Set<string>();
     for (const m of planted.matchAll(/isAllowed\(\s*'([a-zA-Z]+)'/g)) hits.add(m[1]);
+    for (const m of planted.matchAll(/\b(?:can|cannot|denialReason)\(\s*'([a-zA-Z]+)'/g)) {
+      hits.add(permissionForAction(m[1] as CapabilityAction));
+    }
     expect(hits.has('canPublish')).toBe(true);
+    expect(hits.has('canCreateDraws')).toBe(true);
   });
 
   // ── The pin itself ──


### PR DESCRIPTION
**P2** of `Mentat/planning/TMX_LOCKDOWN_AND_ROLE_MODEL.md` §7. Establishes the seam; no behaviour change for an unconfigured provider.

## The problem

TMX derives "may this user do this" from three independent sources — provider configuration, the individual's roles, and the tournament's own state — and has **nothing that combines them**. So each call site invents its own combination, and they drift.

The concrete case: the participants page gated its Officials view on `canCreateOfficials` while the server enforces `canCreateCompetitors` for **both**. Set `canCreateOfficials: true, canCreateCompetitors: false` and TMX showed a button the server then rejected.

## The result is not a boolean

`can(action)` returns a reason and a `because` naming the layer that refused.

A disabled control that says *"This provider does not allow events to be created in TMX"* teaches the operating model. A hidden one reads as a bug, and an enabled one that fails on save is the shape that caused the drift above.

Actions are a **closed vocabulary**, not a passthrough of permission keys — so one action can map to different keys as the model gains tournament state and per-tournament scope. The `because` union already carries `'tournamentState' | 'role' | 'provider'`, so adding those layers is not a breaking change.

## Scope, stated plainly

Provider + role only. Tournament state and scope are later phases.

**This is a UX contract, not a security boundary.** Enforcement is the server's `MutationAuthorizationService` and the `MUTATION_PERMISSIONS` map both layers share. `can()` decides what to render.

## The coverage pin had to learn the new call form

Migrating a gate onto `can()` removes an `isAllowed('<key>')` call, which to the #1334 scanner looks **exactly like deleting the gate**. The scanner now recognises both forms and maps action → key.

Falsified in both directions rather than assumed:
- adding an unregistered gate → pin red, names `canPublish` / `canCreateDraws`
- **removing** an existing gate → pin red, names `canDeleteParticipants`
- this migration itself → report **unchanged**, which is the correct answer

## Verification

types clean · lint clean · prettier clean · `i18n-audit` exit 0 · **1401 tests in 131 files pass**

Next: P3, the demo-mode simulator, which consumes both this resolver and the coverage badges.