### PR TITLE
feat(demo): simulate any lockdown posture from the avatar menu

### DIFF
--- a/attr-audit.config.json
+++ b/attr-audit.config.json
@@ -1,6 +1,10 @@
 {
-  "src": ["src"],
-  "exclude": ["/scratch/"],
+  "src": [
+    "src"
+  ],
+  "exclude": [
+    "/scratch/"
+  ],
   "ignore": [
     "onchange",
     "oninput",
@@ -56,6 +60,7 @@
     "WITHDRAW",
     "registrationIds",
     "baseURI",
-    "participantNames"
+    "participantNames",
+    "scheduler"
   ]
 }

--- a/src/components/drawers/demoModeDrawer.ts
+++ b/src/components/drawers/demoModeDrawer.ts
@@ -1,0 +1,187 @@
+/**
+ * DEMO MODE — simulate any lockdown posture without touching the server.
+ *
+ * Reached from the avatar menu (`initLoginToggle`). Three tiers, top to bottom:
+ * a preset picker, the raw capability grid, and the honesty legend.
+ *
+ * The preset picker **sets the checkboxes** and is then done — it never becomes
+ * a second code path. Ticking any box afterwards flips the posture to `custom`.
+ *
+ * Every control writes through `demoState`, which composes inside
+ * `providerConfig`'s accessors — the same path production uses. There is no
+ * demo-only branch anywhere in the gating code (standard A1).
+ *
+ * ## Honesty
+ *
+ * Each row carries a coverage badge from `capabilityCoverage`. A key that gates
+ * nothing renders as `—` with a warning, because a checkbox that looks like it
+ * works while changing nothing would mislead whoever is being demonstrated to.
+ */
+import { BOOLEAN_PERMISSION_KEYS } from '@courthive/provider-config';
+
+import { clearDemoOverlay, getDemoOverlay, setDemoOverlay, setDemoPermission } from 'services/demoMode/demoState';
+import { DEMO_PRESET_IDS, overridesForPreset } from 'services/demoMode/demoPresets';
+import { coverageFor } from 'services/capability/capabilityCoverage';
+import { renderDemoAffordance } from 'services/demoMode/demoAffordance';
+import { context } from 'services/context';
+import { t } from 'i18n';
+
+import type { DemoPresetId } from 'services/demoMode/demoPresets';
+import type { ProviderPermissions } from '@courthive/provider-config';
+import { RIGHT } from 'constants/tmxConstants';
+
+type Key = keyof ProviderPermissions;
+
+/** Grouping mirrors the ProviderPermissions declaration order. */
+const GROUPS: { labelKey: string; keys: Key[] }[] = [
+  {
+    labelKey: 'participants',
+    keys: [
+      'canCreateCompetitors',
+      'canCreateOfficials',
+      'canDeleteParticipants',
+      'canImportParticipants',
+      'canEditParticipantDetails',
+      'canModifyEntries',
+      'canModifyRatings',
+    ],
+  },
+  { labelKey: 'events', keys: ['canCreateEvents', 'canDeleteEvents', 'canModifyEventFormat'] },
+  {
+    labelKey: 'draws',
+    keys: [
+      'canCreateDraws',
+      'canDeleteDraws',
+      'canAssignPositions',
+      'canModifyStructures',
+      'canUseDraftPositioning',
+      'canUseManualPositioning',
+    ],
+  },
+  { labelKey: 'scheduling', keys: ['canModifySchedule', 'canUseBulkScheduling', 'canModifyScheduleScenarios'] },
+  {
+    labelKey: 'venues',
+    keys: ['canCreateVenues', 'canDeleteVenues', 'canModifyCourtAvailability', 'canManagePracticeCourts'],
+  },
+  { labelKey: 'scoring', keys: ['canEnterScores', 'canModifyCompletedScores'] },
+  { labelKey: 'publishing', keys: ['canPublish', 'canUnpublish'] },
+  {
+    labelKey: 'settings',
+    keys: ['canModifyTournamentDetails', 'canModifyPolicies', 'canLinkTournaments', 'canAccessProviderAdmin'],
+  },
+  { labelKey: 'communication', keys: ['canUseChat'] },
+];
+
+function isKeyAllowed(key: Key): boolean {
+  return getDemoOverlay()?.permissions[key] !== false;
+}
+
+function badgeElement(key: Key): HTMLElement {
+  const coverage = coverageFor(key);
+  const span = document.createElement('span');
+  span.className = `tmx-demo-badge tmx-demo-badge-${coverage}`;
+  span.textContent = coverage === 'both' ? 'UI+MUT' : coverage === 'ui' ? 'UI' : coverage === 'mutation' ? 'MUT' : '—';
+  span.title =
+    coverage === 'none'
+      ? t('demoMode.badge.none')
+      : coverage === 'ui'
+        ? t('demoMode.badge.ui')
+        : coverage === 'mutation'
+          ? t('demoMode.badge.mutation')
+          : t('demoMode.badge.both');
+  return span;
+}
+
+export function demoModeDrawer(): void {
+  const content = document.createElement('div');
+  content.className = 'tmx-demo-panel';
+
+  const warning = document.createElement('div');
+  warning.className = 'tmx-demo-warning';
+  warning.textContent = t('demoMode.clientOnly');
+  content.appendChild(warning);
+
+  // ── Posture ──
+  const postureHeading = document.createElement('div');
+  postureHeading.className = 'tmx-demo-heading';
+  postureHeading.textContent = t('demoMode.posture');
+  content.appendChild(postureHeading);
+
+  const rerender = () => {
+    context.drawer.close();
+    demoModeDrawer();
+    renderDemoAffordance();
+  };
+
+  for (const preset of DEMO_PRESET_IDS) {
+    const row = document.createElement('label');
+    row.className = 'tmx-demo-preset';
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'tmx-demo-preset';
+    radio.checked = (getDemoOverlay()?.preset ?? 'providerDefaults') === preset;
+    radio.addEventListener('change', () => {
+      const overrides = overridesForPreset(preset as DemoPresetId);
+      if (!overrides) clearDemoOverlay();
+      else setDemoOverlay({ v: 1, preset, permissions: overrides });
+      rerender();
+    });
+    const text = document.createElement('span');
+    text.textContent = t(`demoMode.presets.${preset}`);
+    row.append(radio, text);
+    content.appendChild(row);
+  }
+
+  // ── Capabilities ──
+  const capsHeading = document.createElement('div');
+  capsHeading.className = 'tmx-demo-heading';
+  capsHeading.textContent = t('demoMode.capabilities');
+  content.appendChild(capsHeading);
+
+  const known = new Set<string>(BOOLEAN_PERMISSION_KEYS);
+  for (const group of GROUPS) {
+    const groupLabel = document.createElement('div');
+    groupLabel.className = 'tmx-demo-group';
+    groupLabel.textContent = t(`demoMode.groups.${group.labelKey}`);
+    content.appendChild(groupLabel);
+
+    for (const key of group.keys) {
+      if (!known.has(key)) continue; // key retired upstream — skip rather than render a dead row
+      const row = document.createElement('label');
+      row.className = 'tmx-demo-row';
+
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.checked = isKeyAllowed(key);
+      box.addEventListener('change', () => {
+        setDemoPermission(key, box.checked);
+        renderDemoAffordance();
+      });
+
+      const label = document.createElement('span');
+      label.className = 'tmx-demo-label';
+      label.textContent = key;
+
+      row.append(box, label, badgeElement(key));
+      content.appendChild(row);
+    }
+  }
+
+  const legend = document.createElement('div');
+  legend.className = 'tmx-demo-legend';
+  legend.textContent = t('demoMode.legend');
+  content.appendChild(legend);
+
+  const footer = document.createElement('div');
+  const exit = document.createElement('button');
+  exit.className = 'button is-warning';
+  exit.textContent = t('demoMode.exit');
+  exit.addEventListener('click', () => {
+    clearDemoOverlay();
+    context.drawer.close();
+    renderDemoAffordance();
+  });
+  footer.appendChild(exit);
+
+  context.drawer.open({ title: t('demoMode.title'), content, footer, side: RIGHT, width: '420px' });
+}

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -10,6 +10,8 @@ export interface FeatureFlags {
   formatWizard: boolean;
   schedulePlan: boolean;
   usePublishState: boolean;
+  /** Demo-mode lockdown simulator (avatar menu). Off by default. */
+  demoMode: boolean;
 }
 
 const defaults: FeatureFlags = {
@@ -17,6 +19,7 @@ const defaults: FeatureFlags = {
   formatWizard: false,
   schedulePlan: false,
   usePublishState: false,
+  demoMode: false,
 };
 
 let current: FeatureFlags = { ...defaults };

--- a/src/config/providerConfig.ts
+++ b/src/config/providerConfig.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ProviderBranding, ProviderConfigData, ProviderPermissions } from '@courthive/provider-config';
+import { demoVersion, getDemoOverlay } from 'services/demoMode/demoState';
+import { intersectPermissions } from 'services/demoMode/intersect';
 import { context } from 'services/context';
 
 export type { ProviderBranding, ProviderConfigData, ProviderPermissions };
@@ -58,19 +60,44 @@ const DEFAULT_PERMISSIONS: Required<ProviderPermissions> = {
 };
 
 let current: ProviderConfigData = {};
+let configVersion = 0;
+
+// Memoized composition of `current` with the demo overlay. `get()` returned a
+// stable reference before the overlay existed and there are ~a dozen per-render
+// readers, so rebuilding on every call would churn. Keyed on (config, demo).
+let composed: ProviderConfigData = current;
+let composedKey = '';
+
+function resolved(): Readonly<ProviderConfigData> {
+  const overlay = getDemoOverlay();
+  const key = `${configVersion}:${demoVersion()}`;
+  if (key === composedKey) return composed;
+  composedKey = key;
+  composed = overlay
+    ? { ...current, permissions: intersectPermissions(current.permissions, overlay.permissions) }
+    : current;
+  return composed;
+}
 
 export const providerConfig = {
-  get: (): Readonly<ProviderConfigData> => current,
+  get: (): Readonly<ProviderConfigData> => resolved(),
   set: (config: ProviderConfigData) => {
     current = { ...current, ...config };
+    configVersion += 1;
     applyBranding(current.branding);
   },
+  // NOTE: reset() deliberately does NOT clear the demo overlay. The overlay is a
+  // separate layer with its own lifecycle (cleared on login/logout), and reset()
+  // runs on every provider switch — clearing here would silently drop the demo
+  // posture mid-demonstration, the same shape as the documented "switch to
+  // BOBOCA still shows INTENNSE" branding bug.
   reset: () => {
     current = {};
+    configVersion += 1;
     applyBranding(undefined);
   },
   isAllowed: (key: keyof ProviderPermissions): boolean => {
-    const val = current.permissions?.[key] ?? DEFAULT_PERMISSIONS[key];
+    const val = resolved().permissions?.[key] ?? DEFAULT_PERMISSIONS[key];
     if (typeof val === 'boolean') return val;
     return true;
   },
@@ -83,10 +110,11 @@ export const providerConfig = {
       | 'allowedCategories'
       | 'allowedTierSystems',
   ): any[] => {
-    if (key === 'allowedMatchUpFormats') return current.policies?.allowedMatchUpFormats ?? [];
-    if (key === 'allowedCategories') return current.policies?.allowedCategories ?? [];
-    if (key === 'allowedTierSystems') return current.policies?.allowedTierSystems ?? [];
-    return (current.permissions?.[key as keyof ProviderPermissions] as any[]) ?? [];
+    const active = resolved();
+    if (key === 'allowedMatchUpFormats') return active.policies?.allowedMatchUpFormats ?? [];
+    if (key === 'allowedCategories') return active.policies?.allowedCategories ?? [];
+    if (key === 'allowedTierSystems') return active.policies?.allowedTierSystems ?? [];
+    return (active.permissions?.[key as keyof ProviderPermissions] as any[]) ?? [];
   },
 } as const;
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2543,5 +2543,42 @@
       "unpublish": "This provider does not allow unpublishing.",
       "useChat": "Chat is disabled for this provider."
     }
+  },
+  "demoMode": {
+    "title": "Demo mode",
+    "menuItem": "Demo mode…",
+    "clientOnly": "Client-side simulation only. The server still enforces the real provider configuration.",
+    "posture": "POSTURE",
+    "capabilities": "CAPABILITIES",
+    "exit": "Exit demo mode",
+    "badgeLabel": "DEMO",
+    "bannerText": "Demo mode — {{preset}} · {{count}} capabilities disabled · client-side only",
+    "legend": "UI+MUT = control hidden and mutation refused · UI = control hidden only · MUT = mutation refused only · — = no gate implemented, toggling changes nothing",
+    "presets": {
+      "providerDefaults": "Provider defaults (no simulation)",
+      "recorder": "Scoring only (Recorder)",
+      "scheduler": "Schedule + score",
+      "registrar": "Registration desk",
+      "director": "Tournament director",
+      "readOnly": "Read only",
+      "custom": "Custom"
+    },
+    "groups": {
+      "participants": "Participants",
+      "events": "Events",
+      "draws": "Draws",
+      "scheduling": "Scheduling",
+      "venues": "Venues",
+      "scoring": "Scoring",
+      "publishing": "Publishing",
+      "settings": "Settings",
+      "communication": "Communication"
+    },
+    "badge": {
+      "both": "Enforced by a hidden control and by the mutation gate.",
+      "ui": "Hides the control, but the mutation itself is ungated.",
+      "mutation": "The mutation is refused, but the control is still offered.",
+      "none": "No gate implemented — toggling this changes nothing."
+    }
   }
 }

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -29,6 +29,7 @@ import { tipster } from 'components/popovers/tipster';
 import { tmx2db } from 'services/storage/tmx2db';
 import { revokeRefreshToken } from './authApi';
 import { isFunction } from 'functions/typeOf';
+import { clearDemoOverlay, isDemoEligible } from 'services/demoMode/demoEligibility';
 import { context } from 'services/context';
 import { t } from 'i18n';
 
@@ -84,6 +85,8 @@ export function getLoginState(): LoginState | undefined {
 }
 
 export function logOut(): void {
+  // A demo posture must never outlive an identity change.
+  clearDemoOverlay();
   // Best-effort server-side revocation of the refresh token so a leaked copy
   // can't be replayed after logout. Fire-and-forget; never blocks local logout.
   const refreshToken = getRefreshToken();
@@ -122,6 +125,8 @@ export function logIn({
   data: { token: string; refreshToken?: string };
   callback?: () => void;
 }): void {
+  // A demo posture must never outlive an identity change.
+  clearDemoOverlay();
   const valid = validateToken(data.token);
   const tournamentInState = tournamentEngine.q.tournament()?.tournamentId;
   if (valid) {
@@ -281,6 +286,11 @@ export function initLoginToggle(id: string): void {
           text: t('loginMenu.admin'),
           hide: !isActiveProviderAdmin(),
           onClick: () => context.router?.navigate('/admin'),
+        },
+        {
+          text: t('demoMode.menuItem'),
+          hide: !isDemoEligible(),
+          onClick: () => void import('components/drawers/demoModeDrawer').then((m) => m.demoModeDrawer()),
         },
         {
           text: t('loginMenu.logOut'),

--- a/src/services/demoMode/demoAffordance.ts
+++ b/src/services/demoMode/demoAffordance.ts
@@ -1,0 +1,56 @@
+/**
+ * Demo mode must be visually unmistakable — a posture that silently persists
+ * looks like a bug report waiting to happen.
+ *
+ * Two signals, because either alone can be missed on a projector: a navbar badge
+ * and a non-dismissible banner. Both use `--tmx-fill-warning`, which is defined
+ * with the same value in light and dark, so no per-theme override is needed.
+ */
+import { isDemoActive, getDemoOverlay } from './demoState';
+import { t } from 'i18n';
+
+const BADGE_ID = 'demoBadge';
+const BANNER_ID = 'demoBanner';
+
+function deniedCount(): number {
+  return Object.keys(getDemoOverlay()?.permissions ?? {}).length;
+}
+
+export function renderDemoAffordance(): void {
+  if (typeof document === 'undefined') return;
+
+  const active = isDemoActive();
+  document.documentElement.dataset.tmxDemo = active ? 'true' : '';
+
+  // ── navbar badge ──
+  let badge = document.getElementById(BADGE_ID);
+  if (!active) {
+    badge?.remove();
+  } else {
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.id = BADGE_ID;
+      badge.className = 'tmx-demo-navbar-badge';
+      document.getElementById('provider')?.parentElement?.appendChild(badge);
+    }
+    badge.textContent = t('demoMode.badgeLabel');
+  }
+
+  // ── banner ──
+  let banner = document.getElementById(BANNER_ID);
+  if (!active) {
+    banner?.remove();
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = BANNER_ID;
+    banner.className = 'tmx-demo-banner';
+    document.body.prepend(banner);
+  }
+  const preset = getDemoOverlay()?.preset ?? 'custom';
+  banner.textContent = t('demoMode.bannerText', {
+    preset: t(`demoMode.presets.${preset}`, { defaultValue: preset }),
+    count: deniedCount(),
+  });
+}

--- a/src/services/demoMode/demoEligibility.test.ts
+++ b/src/services/demoMode/demoEligibility.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { featureFlags } from 'config/featureFlags';
+
+vi.mock('services/authentication/tokenManagement', () => ({ getToken: () => mockToken }));
+
+let mockToken: string | undefined;
+
+function tokenWithRoles(roles: string[]): string {
+  return `x.${btoa(JSON.stringify({ roles }))}.y`;
+}
+
+describe('isDemoEligible', () => {
+  beforeEach(() => {
+    mockToken = undefined;
+    featureFlags.set({ demoMode: true });
+  });
+  afterEach(() => featureFlags.reset());
+
+  it('is off unless the beta flag is on', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    featureFlags.set({ demoMode: false });
+    expect(isDemoEligible()).toBe(false);
+  });
+
+  it('is available to an anonymous session', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    mockToken = undefined;
+    expect(isDemoEligible()).toBe(true);
+  });
+
+  it('is available to a super-admin', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    mockToken = tokenWithRoles(['superadmin', 'client']);
+    expect(isDemoEligible()).toBe(true);
+  });
+
+  // Deliberate: one stray click by a provider member on a live provider becomes
+  // a support ticket saying TMX is broken.
+  it('is NOT available to an ordinary logged-in user', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    mockToken = tokenWithRoles(['client']);
+    expect(isDemoEligible()).toBe(false);
+  });
+
+  it('fails closed on an unparseable token', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    mockToken = 'not-a-jwt';
+    expect(isDemoEligible()).toBe(false);
+  });
+});

--- a/src/services/demoMode/demoEligibility.ts
+++ b/src/services/demoMode/demoEligibility.ts
@@ -1,0 +1,36 @@
+/**
+ * Who may enter demo mode, and when the posture must be discarded.
+ *
+ * Split from `demoState` so `loginState` can import the eligibility check
+ * without `demoState` needing to import `loginState` back.
+ *
+ * Deliberately NOT offered to an ordinary provider member on a live provider:
+ * one stray click and they file a support ticket saying TMX is broken. Requires
+ * the beta flag AND either an anonymous session or a super-admin.
+ */
+import { clearDemoOverlay as clearOverlay } from './demoState';
+import { getToken } from 'services/authentication/tokenManagement';
+import { featureFlags } from 'config/featureFlags';
+
+export { clearDemoOverlay } from './demoState';
+
+export function isDemoEligible(): boolean {
+  if (!featureFlags.get().demoMode) return false;
+  try {
+    // Decode the raw token rather than reading the resolved login state: this
+    // module is imported BY loginState, and reading it back would be a cycle.
+    // It also keeps a future identity mask from hiding the menu item that turns
+    // the mask off.
+    const raw = getToken();
+    if (!raw) return true; // anonymous / local-only session
+    const payload = JSON.parse(atob(raw.split('.')[1] ?? ''));
+    return !!payload?.roles?.includes('superadmin');
+  } catch {
+    return false;
+  }
+}
+
+/** Called on login and logout — a posture must never outlive an identity change. */
+export function clearDemoOnIdentityChange(): void {
+  clearOverlay();
+}

--- a/src/services/demoMode/demoMode.test.ts
+++ b/src/services/demoMode/demoMode.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { clearDemoOverlay, getDemoOverlay, isDemoActive, setDemoOverlay, setDemoPermission } from './demoState';
+import { intersectList, intersectPermissions } from './intersect';
+import { overridesForPreset } from './demoPresets';
+import { providerConfig } from 'config/providerConfig';
+import { can } from 'services/capability/can';
+
+describe('demo overlay — intersect only', () => {
+  it('can remove a capability', () => {
+    expect(intersectPermissions({ canCreateEvents: true }, { canCreateEvents: false }).canCreateEvents).toBe(false);
+  });
+
+  it('cannot grant one the provider has denied', () => {
+    // The overlay type makes `true` unrepresentable; this asserts the runtime
+    // agrees even if someone casts around the type.
+    const result = intersectPermissions({ canCreateEvents: false }, { canCreateEvents: true } as any);
+    expect(result.canCreateEvents).toBe(false);
+  });
+
+  it('leaves untouched keys alone', () => {
+    const result = intersectPermissions({ canPublish: true, canCreateDraws: true }, { canPublish: false });
+    expect(result.canCreateDraws).toBe(true);
+  });
+});
+
+describe('intersectList — empty base means unrestricted (A3)', () => {
+  it('treats an empty base as "no restriction yet" rather than "nothing allowed"', () => {
+    // The fail-open trap: naive intersection would return [] here, which
+    // getAllowedList consumers read as UNRESTRICTED — more permissive, not less.
+    expect(intersectList([], ['SINGLE_ELIMINATION'])).toEqual(['SINGLE_ELIMINATION']);
+    expect(intersectList(undefined, ['SINGLE_ELIMINATION'])).toEqual(['SINGLE_ELIMINATION']);
+  });
+
+  it('intersects when the base is a real restriction', () => {
+    expect(intersectList(['A', 'B', 'C'], ['B', 'C', 'D'])).toEqual(['B', 'C']);
+  });
+
+  it('is a no-op without an overlay', () => {
+    expect(intersectList(['A'], undefined)).toEqual(['A']);
+  });
+});
+
+describe('demo overlay reaches the production resolution path', () => {
+  beforeEach(() => {
+    providerConfig.reset();
+    clearDemoOverlay();
+  });
+  afterEach(() => clearDemoOverlay());
+
+  it('is invisible when inactive', () => {
+    expect(isDemoActive()).toBe(false);
+    expect(can('createEvent').allowed).toBe(true);
+  });
+
+  // The point of injecting at providerConfig's accessors: every existing and
+  // future call site picks the overlay up with no per-site change, and there is
+  // no parallel demo path to diverge (standard A1).
+  it('is observed by providerConfig.isAllowed', () => {
+    setDemoPermission('canCreateEvents', false);
+    expect(providerConfig.isAllowed('canCreateEvents')).toBe(false);
+  });
+
+  it('is observed by the can() resolver, with a reason', () => {
+    setDemoPermission('canCreateEvents', false);
+    const result = can('createEvent');
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.because).toBe('provider');
+  });
+
+  it('is observed by providerConfig.get()', () => {
+    setDemoPermission('canPublish', false);
+    expect(providerConfig.get().permissions?.canPublish).toBe(false);
+  });
+
+  it('survives providerConfig.reset() — a provider switch must not drop the posture', () => {
+    setDemoPermission('canCreateEvents', false);
+    providerConfig.reset();
+    expect(providerConfig.isAllowed('canCreateEvents')).toBe(false);
+  });
+
+  it('still intersects after a later provider config is applied', () => {
+    setDemoPermission('canCreateEvents', false);
+    providerConfig.set({ permissions: { canCreateEvents: true } });
+    expect(providerConfig.isAllowed('canCreateEvents')).toBe(false);
+  });
+
+  it('is fully reversible', () => {
+    setDemoPermission('canCreateEvents', false);
+    expect(can('createEvent').allowed).toBe(false);
+    clearDemoOverlay();
+    expect(can('createEvent').allowed).toBe(true);
+  });
+
+  it('memoization invalidates on both config and demo changes', () => {
+    expect(providerConfig.isAllowed('canPublish')).toBe(true);
+    setDemoPermission('canPublish', false);
+    expect(providerConfig.isAllowed('canPublish')).toBe(false);
+    setDemoPermission('canPublish', true);
+    expect(providerConfig.isAllowed('canPublish')).toBe(true);
+  });
+});
+
+describe('presets set the checkboxes rather than bypassing them', () => {
+  beforeEach(() => clearDemoOverlay());
+  afterEach(() => clearDemoOverlay());
+
+  it('providerDefaults removes the overlay rather than switching everything on', () => {
+    expect(overridesForPreset('providerDefaults')).toBeUndefined();
+  });
+
+  it('recorder allows scoring and denies everything structural', () => {
+    const overrides = overridesForPreset('recorder')!;
+    expect(overrides.canEnterScores).toBeUndefined(); // left on
+    expect(overrides.canCreateEvents).toBe(false);
+    expect(overrides.canCreateDraws).toBe(false);
+    expect(overrides.canAssignPositions).toBe(false);
+    expect(overrides.canCreateVenues).toBe(false);
+    expect(overrides.canModifySchedule).toBe(false);
+  });
+
+  it('a recorder posture is observable through the resolver', () => {
+    setDemoOverlay({ v: 1, preset: 'recorder', permissions: overridesForPreset('recorder')! });
+    expect(can('enterScores').allowed).toBe(true);
+    expect(can('createEvent').allowed).toBe(false);
+    expect(can('createDraw').allowed).toBe(false);
+    expect(can('modifySchedule').allowed).toBe(false);
+  });
+
+  it('scheduler adds scheduling to the recorder posture', () => {
+    setDemoOverlay({ v: 1, preset: 'scheduler', permissions: overridesForPreset('scheduler')! });
+    expect(can('modifySchedule').allowed).toBe(true);
+    expect(can('enterScores').allowed).toBe(true);
+    expect(can('createEvent').allowed).toBe(false);
+  });
+
+  it('readOnly denies everything', () => {
+    setDemoOverlay({ v: 1, preset: 'readOnly', permissions: overridesForPreset('readOnly')! });
+    for (const action of ['createEvent', 'enterScores', 'modifySchedule', 'createVenue'] as const) {
+      expect(can(action).allowed, action).toBe(false);
+    }
+  });
+
+  it('ticking a box after choosing a preset marks the posture custom', () => {
+    setDemoOverlay({ v: 1, preset: 'recorder', permissions: overridesForPreset('recorder')! });
+    setDemoPermission('canCreateEvents', true);
+    expect(getDemoOverlay()?.preset).toBe('custom');
+    expect(can('createEvent').allowed).toBe(true);
+    expect(can('createDraw').allowed).toBe(false);
+  });
+});

--- a/src/services/demoMode/demoPresets.ts
+++ b/src/services/demoMode/demoPresets.ts
@@ -1,0 +1,71 @@
+/**
+ * Named lockdown postures for demonstration.
+ *
+ * A preset **sets the checkboxes** — it is not a second code path. Selecting one
+ * computes an overlay from `ALLOWED_BY_PRESET` and stores it exactly as if the
+ * operator had ticked each box by hand, so there is nothing a preset can express
+ * that the raw grid cannot, and nothing to diverge.
+ *
+ * Names come from the role research in
+ * `Mentat/planning/TMX_LOCKDOWN_AND_ROLE_MODEL.md` §2 — `RECORDER` is the
+ * "authority over the record, none over play" position that tennis staffs
+ * everywhere and names nowhere.
+ */
+import { BOOLEAN_PERMISSION_KEYS } from '@courthive/provider-config';
+
+import type { ProviderPermissions } from '@courthive/provider-config';
+import type { DemoPermissionOverride } from './demoState';
+
+export type DemoPresetId = 'providerDefaults' | 'recorder' | 'scheduler' | 'registrar' | 'director' | 'readOnly';
+
+type Key = keyof ProviderPermissions;
+
+/** What each preset LEAVES ON. Everything else is switched off. */
+const ALLOWED_BY_PRESET: Record<Exclude<DemoPresetId, 'providerDefaults'>, Key[]> = {
+  // The empty cell: may write the record, may do nothing else.
+  recorder: ['canEnterScores', 'canUseChat'],
+  scheduler: [
+    'canModifySchedule',
+    'canUseBulkScheduling',
+    'canModifyCourtAvailability',
+    'canEnterScores',
+    'canUseChat',
+  ],
+  registrar: [
+    'canCreateCompetitors',
+    'canModifyEntries',
+    'canEditParticipantDetails',
+    'canImportParticipants',
+    'canUseChat',
+  ],
+  director: BOOLEAN_PERMISSION_KEYS.filter(
+    (key) => !(['canAccessProviderAdmin', 'canModifyCompletedScores', 'canModifyPolicies'] as string[]).includes(key),
+  ) as Key[],
+  readOnly: [],
+};
+
+export const DEMO_PRESET_IDS: readonly DemoPresetId[] = [
+  'providerDefaults',
+  'recorder',
+  'scheduler',
+  'registrar',
+  'director',
+  'readOnly',
+];
+
+/**
+ * The overrides a preset implies.
+ *
+ * `providerDefaults` returns `undefined` — it REMOVES the overlay rather than
+ * switching everything on. Those differ: an all-on overlay is still a layer,
+ * and would mask a capability the provider itself has disabled.
+ */
+export function overridesForPreset(preset: DemoPresetId): DemoPermissionOverride | undefined {
+  if (preset === 'providerDefaults') return undefined;
+  const allowed = new Set<string>(ALLOWED_BY_PRESET[preset]);
+  const overrides: DemoPermissionOverride = {};
+  for (const key of BOOLEAN_PERMISSION_KEYS) {
+    if (!allowed.has(key)) overrides[key as Key] = false;
+  }
+  return overrides;
+}

--- a/src/services/demoMode/demoState.ts
+++ b/src/services/demoMode/demoState.ts
@@ -1,0 +1,90 @@
+/**
+ * Demo-mode lockdown overlay — the store only. No DOM, no config imports, so
+ * `providerConfig` can depend on this without a cycle.
+ *
+ * ## Intersect-only, by construction
+ *
+ * The overlay can REMOVE capability and can never GRANT it. `permissions` is
+ * typed `Partial<Record<BooleanPermissionKey, false>>` so the rule is
+ * unrepresentable to violate: a demo that granted something the live session
+ * lacks would be showing a customer behaviour that does not exist for them,
+ * which is the exact failure this feature is meant to prevent.
+ *
+ * ## sessionStorage, not localStorage
+ *
+ * A mid-demo reload is routine — dev-server restart, projector reconnect — so
+ * the posture must survive F5. It must NOT survive the tab, or a demo posture
+ * could be inherited by tomorrow's real session on a shared machine.
+ */
+import type { ProviderPermissions } from '@courthive/provider-config';
+
+export type DemoPermissionOverride = Partial<Record<keyof ProviderPermissions, false>>;
+
+export type DemoOverlay = {
+  v: 1;
+  /** Name of the preset the operator selected, or 'custom' once they tick a box. */
+  preset?: string;
+  permissions: DemoPermissionOverride;
+};
+
+const STORAGE_KEY = 'tmx_demo_overlay';
+
+let overlay: DemoOverlay | undefined;
+/** Bumped on every mutation so memoized consumers can invalidate cheaply. */
+let version = 0;
+
+function persist(): void {
+  try {
+    if (overlay) globalThis.sessionStorage?.setItem(STORAGE_KEY, JSON.stringify(overlay));
+    else globalThis.sessionStorage?.removeItem(STORAGE_KEY);
+  } catch {
+    /* sessionStorage unavailable (private mode / SSR) — the overlay still works in memory */
+  }
+}
+
+/** Restore a posture across a reload. Safe to call more than once. */
+export function hydrateDemoOverlay(): void {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed?.v === 1 && parsed.permissions && typeof parsed.permissions === 'object') {
+      overlay = { v: 1, preset: parsed.preset, permissions: parsed.permissions };
+      version += 1;
+    }
+  } catch {
+    /* corrupt payload — ignore rather than trapping the operator in a broken posture */
+  }
+}
+
+export function getDemoOverlay(): DemoOverlay | undefined {
+  return overlay;
+}
+
+export function isDemoActive(): boolean {
+  return !!overlay;
+}
+
+/** Monotonic counter for memoization keys. */
+export function demoVersion(): number {
+  return version;
+}
+
+export function setDemoOverlay(next: DemoOverlay | undefined): void {
+  overlay = next;
+  version += 1;
+  persist();
+}
+
+/** Turn a single capability off (or back on) without disturbing the rest. */
+export function setDemoPermission(key: keyof ProviderPermissions, allowed: boolean): void {
+  const permissions: DemoPermissionOverride = { ...(overlay?.permissions ?? {}) };
+  if (allowed) delete permissions[key];
+  else permissions[key] = false;
+  setDemoOverlay({ v: 1, preset: 'custom', permissions });
+}
+
+/** Leave demo mode entirely. */
+export function clearDemoOverlay(): void {
+  setDemoOverlay(undefined);
+}

--- a/src/services/demoMode/intersect.ts
+++ b/src/services/demoMode/intersect.ts
@@ -1,0 +1,35 @@
+/**
+ * Composition of the live provider config with the demo overlay.
+ *
+ * Strictly narrowing: `false` in either input wins. There is no path by which
+ * the overlay can turn something on.
+ */
+import type { ProviderPermissions } from '@courthive/provider-config';
+
+import type { DemoPermissionOverride } from './demoState';
+
+export function intersectPermissions(
+  base: ProviderPermissions | undefined,
+  overlay: DemoPermissionOverride,
+): ProviderPermissions {
+  const result: ProviderPermissions = { ...(base ?? {}) };
+  for (const key of Object.keys(overlay) as (keyof ProviderPermissions)[]) {
+    (result as Record<string, unknown>)[key as string] = false;
+  }
+  return result;
+}
+
+/**
+ * Intersect an allowed-universe list.
+ *
+ * `getAllowedList` returns `[]` to mean **unrestricted**, so a naive
+ * intersection with an empty base yields `[]` — i.e. MORE permissive, inverting
+ * the intent. That is the fail-open shape architectural standard A3 bans, so the
+ * empty base is special-cased: an empty base means "no restriction yet", and the
+ * overlay becomes the restriction.
+ */
+export function intersectList(base: string[] | undefined, overlay: string[] | undefined): string[] {
+  if (!overlay) return base ?? [];
+  if (!base?.length) return overlay;
+  return base.filter((value) => overlay.includes(value));
+}

--- a/src/styles/tmx.css
+++ b/src/styles/tmx.css
@@ -1449,3 +1449,107 @@ img {
   font-style: italic;
   padding-top: 0.2em;
 }
+
+/* ── Demo mode ──────────────────────────────────────────────────────────────
+   Every colour resolves through --tmx-* tokens, all of which carry a dark
+   definition in theme.css, so the panel and its affordances render correctly in
+   both themes without a per-theme override here. --tmx-fill-warning is
+   deliberately the same value in light and dark (AA against white either way),
+   which is why the badge needs no theme branch. */
+
+.tmx-demo-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.25rem;
+  color: var(--tmx-text-primary);
+}
+
+.tmx-demo-warning {
+  background: var(--tmx-panel-yellow-bg);
+  border: 1px solid var(--tmx-panel-yellow-border);
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.tmx-demo-heading {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.tmx-demo-group {
+  font-size: 0.75rem;
+  font-weight: 600;
+  opacity: 0.8;
+  margin: 0.5rem 0 0.15rem;
+}
+
+.tmx-demo-preset,
+.tmx-demo-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.15rem 0.25rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.tmx-demo-row:hover,
+.tmx-demo-preset:hover {
+  background: var(--tmx-bg-secondary);
+}
+
+.tmx-demo-label {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.tmx-demo-badge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  opacity: 0.75;
+}
+
+/* A key that gates nothing must not look like a working control. */
+.tmx-demo-badge-none {
+  color: var(--tmx-fill-warning);
+  opacity: 1;
+}
+
+.tmx-demo-legend {
+  margin-top: 0.75rem;
+  font-size: 0.7rem;
+  opacity: 0.7;
+  line-height: 1.35;
+}
+
+.tmx-demo-navbar-badge {
+  background: var(--tmx-fill-warning);
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  margin-left: 0.4rem;
+}
+
+/* Deliberately not dismissible — a demo posture that can be hidden defeats it. */
+.tmx-demo-banner {
+  background: var(--tmx-fill-warning);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 0.3rem 0.5rem;
+}


### PR DESCRIPTION
**P3** of `Mentat/planning/TMX_LOCKDOWN_AND_ROLE_MODEL.md` §6 — the demo-mode lockdown simulator.

Adopt a restricted posture for a demonstration — **"Scoring only"**, "Schedule + score", "Registration desk", "Read only" — and drive TMX under those limitations. Plus a raw grid to switch any single capability off.

## Where the overlay is injected, and why it is the only correct point

Inside `providerConfig`'s three read accessors — the one place TMX resolves a capability. Every existing and future call site picks it up **with no per-site change**, and there is no demo-only branch anywhere in the gating code.

That matters more than convenience: a parallel demo path would eventually show a customer a restriction TMX does not implement. That is the mock/production divergence class recorded as standard **A1**, whose own example surfaced *"only in the live publisher demo run"* — precisely this feature's failure mode.

## Intersect-only, by construction

The override type is `Partial<Record<BooleanPermissionKey, false>>`, so granting a capability the live session lacks is **unrepresentable**. A demo that turned something ON would show behaviour that does not exist for that provider.

Presets **set the checkboxes** rather than bypassing them — nothing a preset expresses that the grid cannot, and nothing to diverge. `providerDefaults` *removes* the overlay rather than switching everything on; an all-on overlay is still a layer and would mask a capability the provider itself disabled.

## Honesty badges

Each row carries a coverage badge from #1334: `UI+MUT`, `UI`, `MUT`, or `—`. A key that gates nothing renders as `—` in warning colour with *"No gate implemented — toggling this changes nothing."*

Without that, the panel would render a working-looking checkbox for a decorative key and mislead whoever is being demonstrated to. Two keys currently qualify: `canAccessProviderAdmin` and `canModifyCompletedScores`.

## Deliberate details

- **`providerConfig.reset()` does NOT clear the overlay.** `reset()` runs on every provider switch, so clearing there would drop the posture mid-demonstration — the same shape as the documented "switch to BOBOCA still shows INTENNSE" branding bug.
- **`sessionStorage`, not `localStorage`.** A mid-demo reload is routine (dev-server restart, projector reconnect) so the posture survives F5; it dies with the tab so it cannot be inherited by tomorrow's real session on a shared machine.
- **Cleared on login and logout** — a posture must not outlive an identity change.
- **Eligibility** requires the beta flag AND an anonymous session or a super-admin. An ordinary member on a live provider would file a support ticket saying TMX is broken. It decodes the raw token rather than reading login state, so a future identity mask cannot hide the menu item that turns the mask off.
- **`intersectList` special-cases an empty base**, which `getAllowedList` consumers read as *unrestricted* — naive intersection there would be MORE permissive, the fail-open shape standard **A3** bans.
- Menu item goes on the live avatar menu (`initLoginToggle`), not the `mainMenu.ts` deleted in #1334 as unreachable.
- Badge and banner resolve through `--tmx-*` tokens that all carry dark definitions; the banner is deliberately **not** dismissible.

## Scope, stated plainly

This simulates the **client** contract. The server still enforces the real provider configuration, and the panel says so in a persistent warning. Demo mode proves what TMX renders and refuses locally — not what the server would accept.

## Verification

types clean · lint clean · prettier clean · `i18n-audit` and `attr-audit` exit 0 · **1426 tests in 133 files pass**

41 tests across the capability + demo modules, including that a `recorder` posture allows `enterScores` while denying `createEvent`, `createDraw` and `modifySchedule` **through the production resolver**, that the overlay survives `reset()`, that it still intersects after a later provider config is applied, and that it is fully reversible.