### PR TITLE
feat(matchups): per-matchUp check-in at the desk

### DIFF
--- a/e2e/journeys/104-participants-call-sheet.spec.ts
+++ b/e2e/journeys/104-participants-call-sheet.spec.ts
@@ -5,7 +5,7 @@ import { TournamentPage } from '../pages/TournamentPage';
 import { S } from '../helpers/selectors';
 
 /**
- * Journey 100 — the call sheet, and the multi-contact drawer behind it.
+ * Journey 104 — the call sheet, and the multi-contact drawer behind it.
  *
  * This journey carries more weight than most, because TMX has **no jsdom**: the unit suite runs in
  * the vitest `node` environment, so the pure logic (`collectContacts`, `buildCallSheet`,
@@ -75,7 +75,7 @@ async function gotoStaff(page: Page, tournamentId: string): Promise<void> {
   await page.waitForSelector(ROWS, { timeout: 15_000 });
 }
 
-test.describe('Journey 100 — participants call sheet', () => {
+test.describe('Journey 104 — participants call sheet', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);

--- a/e2e/journeys/105-matchup-check-in.spec.ts
+++ b/e2e/journeys/105-matchup-check-in.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { createMutationCollector } from '../helpers/mutation-collector';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 105 — per-matchUp check-in at the desk.
+ *
+ * CA's framing, which is what this covers: `signInStatus` is FIRST ARRIVAL at the tournament;
+ * separately a specific matchUp needs its own check-in, because several matchUps are scheduled at
+ * 12:00 and **both individual participants of a doubles pair must present themselves at the desk**
+ * before the matchUp is called to court.
+ *
+ * **The draw is DOUBLES on purpose.** A singles fixture exercises none of the mechanism — it has no
+ * nested `individualParticipants`, so an implementation that ignored them would pass a singles suite
+ * and then show an empty panel for exactly the matchUps a desk operator cares about. That is not a
+ * hypothetical: deleting the nested-individual branch leaves the singles unit test green while both
+ * doubles ones go red.
+ *
+ * TMX vitest is node-env by design, so `checkInState.test.ts` covers the pure derivation and nothing
+ * that renders. This is the only layer that can assert the panel exists, that a click **dispatches
+ * `toggleParticipantCheckInState`**, and that the call-to-court gate warns rather than blocks (D4d).
+ */
+
+const MATCHUPS = S.TOURNAMENT_MATCHUPS;
+// The panel is a hand-built <ul> of <li> rows in its own tippy — `:not(.menu-list)` keeps it distinct
+// from the three-dot action menu, which renderMenu emits as <ul class="menu-list">. Same trick as
+// journey 94's official picker.
+const PANEL_ROW = '.tippy-content ul:not(.menu-list) > li';
+
+async function seedDoubles(page: Page): Promise<{ tournamentId: string; sideOneName: string }> {
+  return page.evaluate(async () => {
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ drawSize: 4, eventType: 'DOUBLES', eventName: 'Mens Doubles' }],
+      tournamentAttributes: { tournamentId: 'e2e-checkin' },
+      nonRandom: 1,
+      setState: true,
+    });
+    await dev.load(tournamentRecord);
+
+    const engine = dev.factory.tournamentEngine;
+    const { matchUps } = engine.allTournamentMatchUps();
+    const matchUp = matchUps.find((m: any) => m.sides?.every((s: any) => s?.participant?.individualParticipants));
+    return {
+      tournamentId: tournamentRecord.tournamentId,
+      // An INDIVIDUAL's name, not the PAIR's: the matchUps table renders the side from its members,
+      // so the pair's own `participantName` ("Ripley/Chip") never appears as row text.
+      sideOneName: matchUp?.sides?.[0]?.participant?.individualParticipants?.[0]?.participantName ?? '',
+    };
+  });
+}
+
+async function openCheckInPanel(page: Page, sideOneName: string) {
+  const targetRow = page.locator(`${MATCHUPS} .tabulator-row`).filter({ hasText: sideOneName }).first();
+  await expect(targetRow).toBeVisible({ timeout: 10_000 });
+
+  const threeDots = targetRow.locator('.fa-ellipsis-vertical');
+  const menu = page.locator('.tippy-content .menu-list');
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (await menu.isVisible().catch(() => false)) break;
+    await threeDots.click({ force: true });
+    await page.waitForTimeout(250);
+  }
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+  return menu;
+}
+
+test.describe('Journey 105 — per-matchUp check-in', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('the menu offers Check in with a partial count, never a tick', async ({ page }) => {
+    const { tournamentId, sideOneName } = await seedDoubles(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToMatchUps();
+
+    const menu = await openCheckInPanel(page, sideOneName);
+
+    // "Check in", never "Sign in" (D4a) — signing in is arrival at the tournament and is
+    // tournament-wide. And `0/4`, because a doubles matchUp has FOUR individuals who each present
+    // themselves separately; a boolean would collapse the state the desk is managing.
+    await expect(menu.locator('a', { hasText: 'Check in' })).toContainText('0/4');
+    await expect(menu.locator('a', { hasText: 'Sign in' })).toHaveCount(0);
+  });
+
+  test('the panel lists all four individuals and a click dispatches the toggle', async ({ page }) => {
+    const { tournamentId, sideOneName } = await seedDoubles(page);
+    const collector = createMutationCollector(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToMatchUps();
+
+    const menu = await openCheckInPanel(page, sideOneName);
+    await menu.locator('a', { hasText: 'Check in' }).click();
+
+    // Four rows — the individuals, not the two PAIRs (D4c). The factory would accept a PAIR-level
+    // check-in and nothing reconciles it with the individual ones, so the UI must never offer it.
+    const rows = page.locator(PANEL_ROW);
+    await expect(rows).toHaveCount(4, { timeout: 5_000 });
+
+    await rows.first().click();
+
+    // The dispatch is the assertion that matters — a panel that paints a tick and stores nothing is
+    // exactly the failure a DOM-only check would miss.
+    await collector.waitForMethod('toggleParticipantCheckInState', 10_000);
+    collector.detach();
+
+    // And it persisted: the engine now reports one individual checked in on that matchUp.
+    const checkedIn = await page.evaluate(() => {
+      const { matchUps } = dev.factory.tournamentEngine.allTournamentMatchUps();
+      return matchUps.flatMap((m: any) => m.checkedInParticipantIds ?? []).length;
+    });
+    expect(checkedIn).toEqual(1);
+
+    // Partial state is now visible rather than implied.
+    await expect(page.locator('.tmx-checkin-heading')).toContainText('1/4');
+    await expect(page.locator('.tmx-checkin-row.is-checked-in')).toHaveCount(1);
+  });
+
+  test('checking in is reversible from the same row', async ({ page }) => {
+    const { tournamentId, sideOneName } = await seedDoubles(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToMatchUps();
+
+    const menu = await openCheckInPanel(page, sideOneName);
+    await menu.locator('a', { hasText: 'Check in' }).click();
+
+    const rows = page.locator(PANEL_ROW);
+    await expect(rows).toHaveCount(4, { timeout: 5_000 });
+
+    await rows.first().click();
+    await expect(page.locator('.tmx-checkin-row.is-checked-in')).toHaveCount(1);
+
+    // A desk operator checks somebody in by mistake constantly; the same control has to undo it.
+    await rows.first().click();
+    await expect(page.locator('.tmx-checkin-row.is-checked-in')).toHaveCount(0);
+
+    const checkedIn = await page.evaluate(() => {
+      const { matchUps } = dev.factory.tournamentEngine.allTournamentMatchUps();
+      return matchUps.flatMap((m: any) => m.checkedInParticipantIds ?? []).length;
+    });
+    expect(checkedIn).toEqual(0);
+  });
+});

--- a/src/components/popovers/matchUpActions.ts
+++ b/src/components/popovers/matchUpActions.ts
@@ -10,7 +10,9 @@ import {
   canToggleScheduleLock,
   isScheduleLocked,
 } from 'pages/tournament/tabs/scheduleViews/scheduleLocks';
+import { getMatchUpCheckInState, checkInSummary } from 'services/checkIn/checkInState';
 import { setMatchUpSchedule } from 'components/tables/matchUpsTable/setMatchUpSchedule';
+import { toggleCheckIn } from 'services/checkIn/toggleCheckIn';
 import type { CandidateConflicts } from 'services/officiating/officialConflicts';
 import { openCrowdTrackersModal } from 'components/modals/crowdTrackersModal';
 import { getScheduleDateRange } from 'pages/tournament/tabs/scheduleUtils';
@@ -38,6 +40,17 @@ import { BOTTOM } from 'constants/tmxConstants';
 const OFFICIAL = ParticipantRoleEnum.OFFICIAL;
 
 let officialTip: Instance | undefined;
+let checkInTip: Instance | undefined;
+
+/** Shared tippy theme for the popover panels this module opens. */
+const TIP_THEME = 'light-border';
+
+function destroyCheckInTip() {
+  if (checkInTip) {
+    checkInTip.destroy();
+    checkInTip = undefined;
+  }
+}
 
 function destroyOfficialTip() {
   if (officialTip) {
@@ -219,7 +232,7 @@ export function matchUpActions({
       destroyOfficialTip();
       officialTip = tippy(anchorEl, {
         content: noOfficialsEl,
-        theme: 'light-border',
+        theme: TIP_THEME,
         trigger: 'manual',
         interactive: true,
         placement: BOTTOM as any,
@@ -336,7 +349,7 @@ export function matchUpActions({
     destroyOfficialTip();
     officialTip = tippy(anchorEl, {
       content: wrapper,
-      theme: 'light-border',
+      theme: TIP_THEME,
       trigger: 'manual',
       interactive: true,
       maxWidth: 'none',
@@ -344,6 +357,105 @@ export function matchUpActions({
       appendTo: document.body,
     });
     officialTip.show();
+  };
+
+  /**
+   * The desk panel: one row per INDIVIDUAL, click to toggle.
+   *
+   * Rows are individuals even for doubles — four names, not two pairs — because the state a desk is
+   * managing is "one of the partners is standing here" (D4c). The panel re-derives from the engine
+   * after each toggle rather than mutating the row locally, so two operators working the same match
+   * converge instead of drifting.
+   */
+  const openCheckInPanel = () => {
+    // A sibling of `render`, not nested inside its row loop: the mutation callback would otherwise be
+    // a fifth level of nested function and trip `sonarjs/no-nested-functions` (threshold 4).
+    const handleToggle = (participantId: string) =>
+      toggleCheckIn({
+        participantId,
+        matchUpId: matchUp.matchUpId,
+        drawId: matchUp.drawId,
+        callback: (result: any) => onToggled(result),
+      });
+
+    const onToggled = (result: any) => {
+      if (!result?.success) {
+        logMutationError('checkIn', result, { message: t('checkIn.toggleFailed') });
+        return;
+      }
+      // Re-render the panel from the engine, and refresh the row behind it so the summary the menu
+      // shows agrees with what the panel is showing.
+      render();
+      updateRow({});
+    };
+
+    const render = () => {
+      // Re-read from the engine so the panel reflects what was actually stored, including a toggle
+      // made from another surface. `findMatchUp` returns it hydrated, which is what carries
+      // `checkedInParticipantIds` (attached by `addMatchUpContext`).
+      const stored = tournamentEngine.findMatchUp({ drawId: matchUp.drawId, matchUpId: matchUp.matchUpId })?.matchUp;
+      const state = getMatchUpCheckInState(stored ?? matchUp);
+
+      const wrapper = document.createElement('div');
+      wrapper.style.cssText = 'position:relative; padding:8px; padding-top:22px; min-width:200px;';
+
+      const closeBtn = document.createElement('span');
+      closeBtn.textContent = '\u00d7';
+      closeBtn.style.cssText =
+        'position:absolute; top:2px; right:6px; cursor:pointer; font-size:16px; line-height:1; color:var(--chc-text-secondary, #888); z-index:1;';
+      closeBtn.onclick = (e) => {
+        e.stopPropagation();
+        destroyCheckInTip();
+      };
+      wrapper.appendChild(closeBtn);
+
+      const heading = document.createElement('div');
+      heading.className = 'tmx-checkin-heading';
+      heading.textContent = `${t('checkIn.title')} ${checkInSummary(state)}`;
+      wrapper.appendChild(heading);
+
+      const list = document.createElement('ul');
+      list.style.cssText = 'list-style:none; margin:0; padding:0;';
+
+      for (const participant of state.participants) {
+        const li = document.createElement('li');
+        li.className = participant.checkedIn ? 'tmx-checkin-row is-checked-in' : 'tmx-checkin-row';
+        li.title = participant.checkedIn ? t('checkIn.clickToCheckOut') : t('checkIn.clickToCheckIn');
+
+        const mark = document.createElement('span');
+        mark.className = 'tmx-checkin-mark';
+        mark.setAttribute('aria-hidden', 'true');
+        mark.textContent = participant.checkedIn ? '\u2713' : '\u25cb';
+        li.appendChild(mark);
+
+        const name = document.createElement('span');
+        name.textContent = participant.participantName;
+        li.appendChild(name);
+
+        li.onclick = (e) => {
+          e.stopPropagation();
+          handleToggle(participant.participantId);
+        };
+        list.appendChild(li);
+      }
+
+      wrapper.appendChild(list);
+
+      const anchorEl = (target || pointerEvent.target) as HTMLElement;
+      destroyCheckInTip();
+      checkInTip = tippy(anchorEl, {
+        content: wrapper,
+        theme: TIP_THEME,
+        trigger: 'manual',
+        interactive: true,
+        maxWidth: 'none',
+        placement: BOTTOM as any,
+        appendTo: document.body,
+      });
+      checkInTip.show();
+    };
+
+    render();
   };
 
   const matchUpStatus = matchUp?.matchUpStatus;
@@ -398,6 +510,13 @@ export function matchUpActions({
       onClick: () => setTimeField('endTime'),
       text: 'End time',
       hide: hideTimeOptions,
+    },
+    {
+      // Per-matchUp check-in — the desk action. Deliberately worded "Check in", never "Sign in":
+      // signing in is arrival at the tournament and is tournament-wide (D4a).
+      onClick: openCheckInPanel,
+      text: `${t('checkIn.action')} (${checkInSummary(getMatchUpCheckInState(matchUp))})`,
+      hide: noParticipants || isTerminal,
     },
     {
       onClick: selectOfficial,

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -88,6 +88,9 @@ export const RESET_DRAW_DEFINITION = 'resetDrawDefinition';
 export const RESET_MATCHUP_LINEUPS = 'resetMatchUpLinesUps';
 export const RESET_SCORECARD = 'resetScorecard';
 export const SET_MATCHUP_CALLED_AT = 'setMatchUpCalledAt';
+// Per-matchUp check-in — a participant presenting at the desk for THIS match. Distinct from
+// MODIFY_SIGN_IN_STATUS, which records first arrival at the tournament and is tournament-wide.
+export const TOGGLE_PARTICIPANT_CHECK_IN_STATE = 'toggleParticipantCheckInState';
 export const SET_MATCHUP_FORMAT = 'setMatchUpFormat';
 export const SET_MATCHUP_SCHEDULE_LOCK = 'setMatchUpScheduleLock';
 export const SET_MATCHUP_STATUS = 'setMatchUpStatus';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2580,5 +2580,16 @@
       "mutation": "The mutation is refused, but the control is still offered.",
       "none": "No gate implemented — toggling this changes nothing."
     }
+  },
+  "checkIn": {
+    "action": "Check in",
+    "title": "Checked in",
+    "clickToCheckIn": "Click to check in",
+    "clickToCheckOut": "Click to check out",
+    "toggleFailed": "Could not change the check-in state",
+    "callBeforeCheckIn_one": "{{count}} participant has not checked in. Call to court anyway?",
+    "callBeforeCheckIn_other": "{{count}} participants have not checked in. Call to court anyway?",
+    "columnHeader": "Checked in",
+    "columnTooltip": "Participants who have presented at the desk for this match"
   }
 }

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -8,6 +8,7 @@
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
+import { awaitingCheckIn, getMatchUpCheckInState } from 'services/checkIn/checkInState';
 import { collectStartAllRestWarning, type StartAllRestWarning } from './startAllRestGuard';
 import { buildScheduleLockMethod, isScheduleLocked } from './scheduleLocks';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
@@ -330,6 +331,20 @@ function showMatchUpCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
   const callToCourt = () => {
     const drawId = matchUp?.drawId || cellData.drawId;
     if (!drawId) return;
+
+    // WARN and proceed, never block (D4d). The desk knows things the record does not — a player who
+    // rang ahead, an official who waved them through — and a hard block would teach operators to check
+    // everyone in pre-emptively, which destroys the signal the check-in is there to carry.
+    const checkInState = getMatchUpCheckInState(matchUp);
+    const awaiting = awaitingCheckIn(checkInState);
+    if (checkInState.hasParticipants && awaiting.length) {
+      const names = awaiting
+        .map((participant) => participant.participantName)
+        .filter(Boolean)
+        .join(', ');
+      if (!globalThis.confirm(`${t('checkIn.callBeforeCheckIn', { count: awaiting.length })}\n\n${names}`)) return;
+    }
+
     executeMethods(
       [{ method: SET_MATCHUP_CALLED_AT, params: { matchUpId, drawId, calledAt: new Date().toISOString() } }],
       onRefresh,

--- a/src/services/checkIn/checkInState.test.ts
+++ b/src/services/checkIn/checkInState.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Per-matchUp check-in state.
+ *
+ * **Every meaningful case here is a DOUBLES case.** A singles fixture exercises none of the mechanism:
+ * it has no nested individuals, so a derivation that ignored `individualParticipants` entirely would
+ * pass a singles-only suite and then show an empty menu for exactly the matchUps a desk operator cares
+ * about. The partial state — one of two partners present — is the reason the feature exists.
+ */
+import { awaitingCheckIn, getMatchUpCheckInState, checkInSummary } from './checkInState';
+import { describe, expect, it } from 'vitest';
+
+const IKE = 'Ike Nkemelu';
+
+const singlesMatchUp = (checkedInParticipantIds: string[] = []) => ({
+  checkedInParticipantIds,
+  sides: [
+    {
+      sideNumber: 1,
+      participant: { participantId: 'p1', participantName: 'Ana Rivas', participantType: 'INDIVIDUAL' },
+    },
+    {
+      sideNumber: 2,
+      participant: { participantId: 'p2', participantName: 'Raj Patel', participantType: 'INDIVIDUAL' },
+    },
+  ],
+});
+
+const doublesMatchUp = (checkedInParticipantIds: string[] = []) => ({
+  checkedInParticipantIds,
+  sides: [
+    {
+      sideNumber: 1,
+      participant: {
+        participantId: 'pair1',
+        participantName: 'Rivas/Cole',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p1', participantName: 'Ana Rivas' },
+          { participantId: 'p2', participantName: 'Sam Cole' },
+        ],
+      },
+    },
+    {
+      sideNumber: 2,
+      participant: {
+        participantId: 'pair2',
+        participantName: 'Patel/Nkemelu',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p3', participantName: 'Raj Patel' },
+          { participantId: 'p4', participantName: IKE },
+        ],
+      },
+    },
+  ],
+});
+
+describe('who may check in', () => {
+  it('lists both players of a singles matchUp', () => {
+    const state = getMatchUpCheckInState(singlesMatchUp());
+    expect(state.participants.map((p) => p.participantId)).toEqual(['p1', 'p2']);
+    expect(state.total).toEqual(2);
+  });
+
+  it('lists all FOUR individuals of a doubles matchUp', () => {
+    // The mechanism. CA: "doubles, and both individual participants must present themselves at the
+    // physical tournament desk before the matchUp is called to court."
+    const state = getMatchUpCheckInState(doublesMatchUp());
+    expect(state.participants.map((p) => p.participantId)).toEqual(['p1', 'p2', 'p3', 'p4']);
+    expect(state.total).toEqual(4);
+  });
+
+  it('NEVER offers the PAIR itself (D4c)', () => {
+    // The factory would accept it — `allRelevantParticipantIds` includes `sideParticipantIds` — and
+    // nothing reconciles a PAIR-level check-in with its two individual ones. Excluding it here makes
+    // the wrong write unreachable from the UI rather than merely discouraged.
+    const ids = getMatchUpCheckInState(doublesMatchUp()).participants.map((p) => p.participantId);
+    expect(ids).not.toContain('pair1');
+    expect(ids).not.toContain('pair2');
+  });
+
+  it('carries the side number so the desk can tell the pairs apart', () => {
+    const state = getMatchUpCheckInState(doublesMatchUp());
+    expect(state.participants.map((p) => p.sideNumber)).toEqual([1, 1, 2, 2]);
+  });
+
+  it('carries names, because a desk operator reads names and not ids', () => {
+    expect(getMatchUpCheckInState(doublesMatchUp()).participants[3].participantName).toEqual(IKE);
+  });
+});
+
+describe('partial state — the reason this is not a boolean', () => {
+  it('reports one of two doubles partners present', () => {
+    const state = getMatchUpCheckInState(doublesMatchUp(['p1']));
+    expect(state.checkedInCount).toEqual(1);
+    expect(state.partial).toBe(true);
+    expect(state.allCheckedIn).toBe(false);
+    expect(checkInSummary(state)).toEqual('1/4');
+  });
+
+  it('reports everybody present', () => {
+    const state = getMatchUpCheckInState(doublesMatchUp(['p1', 'p2', 'p3', 'p4']));
+    expect(state.allCheckedIn).toBe(true);
+    expect(state.partial).toBe(false);
+    expect(checkInSummary(state)).toEqual('4/4');
+  });
+
+  it('reports nobody present — distinct from partial', () => {
+    const state = getMatchUpCheckInState(doublesMatchUp());
+    expect(state.partial).toBe(false);
+    expect(state.allCheckedIn).toBe(false);
+    expect(checkInSummary(state)).toEqual('0/4');
+  });
+
+  it('ignores a checked-in id that is not on this matchUp', () => {
+    // A stale id must not inflate the count into a false "everyone is here".
+    const state = getMatchUpCheckInState(doublesMatchUp(['p1', 'someone-else']));
+    expect(state.checkedInCount).toEqual(1);
+    expect(state.allCheckedIn).toBe(false);
+  });
+
+  it('does NOT report allCheckedIn for a matchUp with nobody in it', () => {
+    // 0 === 0 would otherwise read as "everyone present" and let the call-to-court gate pass silently.
+    const state = getMatchUpCheckInState({ sides: [], checkedInParticipantIds: [] });
+    expect(state.allCheckedIn).toBe(false);
+    expect(state.hasParticipants).toBe(false);
+  });
+});
+
+describe('awaitingCheckIn', () => {
+  it('names exactly the people a call-to-court warning must name', () => {
+    const state = getMatchUpCheckInState(doublesMatchUp(['p1', 'p3']));
+    expect(awaitingCheckIn(state).map((p) => p.participantName)).toEqual(['Sam Cole', IKE]);
+  });
+
+  it('is empty once everyone has presented', () => {
+    expect(awaitingCheckIn(getMatchUpCheckInState(singlesMatchUp(['p1', 'p2'])))).toEqual([]);
+  });
+});
+
+describe('input guards', () => {
+  it('tolerates an absent matchUp, absent sides and absent checked-in list', () => {
+    for (const input of [undefined, {}, { sides: null }, { sides: [{}] }] as any[]) {
+      const state = getMatchUpCheckInState(input);
+      expect(state.total).toEqual(0);
+      expect(state.hasParticipants).toBe(false);
+    }
+  });
+
+  it('skips an empty side of a partially-drawn matchUp', () => {
+    const matchUp = { checkedInParticipantIds: [], sides: [{ sideNumber: 1 }, singlesMatchUp().sides[1]] };
+    expect(getMatchUpCheckInState(matchUp).participants.map((p) => p.participantId)).toEqual(['p2']);
+  });
+});

--- a/src/services/checkIn/checkInState.ts
+++ b/src/services/checkIn/checkInState.ts
@@ -1,0 +1,125 @@
+/**
+ * Who has presented themselves at the desk for THIS matchUp.
+ *
+ * **Not the same thing as signing in.** `signInStatus` is first arrival at the tournament, is
+ * tournament-wide, and lives on the participant. Check-in is per-matchUp, lives on the matchUp as a
+ * `CHECK_IN` timeItem carrying the participantId, and is what a desk operator manages when several
+ * matchUps are scheduled at 12:00 (D4a — the two never share a control).
+ *
+ * Pure and DOM-free: TMX's unit suite runs in the vitest `node` environment with no jsdom, so the
+ * decisions live here and the rendering stays a thin shell.
+ *
+ * **The read needs no query.** `addMatchUpContext` already attaches `checkedInParticipantIds` and
+ * `allParticipantsCheckedIn` to every hydrated matchUp, so this only has to pair those ids with the
+ * individuals they belong to.
+ */
+
+export interface CheckInParticipant {
+  participantName: string;
+  participantId: string;
+  sideNumber?: number;
+  checkedIn: boolean;
+}
+
+export interface MatchUpCheckInState {
+  participants: CheckInParticipant[];
+  /** Some, but not all, are at the desk — the state the whole feature exists to make visible. */
+  hasParticipants: boolean;
+  checkedInCount: number;
+  allCheckedIn: boolean;
+  partial: boolean;
+  total: number;
+}
+
+const INDIVIDUAL = 'INDIVIDUAL';
+
+/**
+ * The individuals who may check in to a matchUp.
+ *
+ * Mirrors the factory's `getMatchUpParticipantIds` **for display only** — that function is not
+ * exported from the package root, so TMX cannot call it. That asymmetry is safe in one direction and
+ * only one: `checkInParticipant` validates every write against its own `allRelevantParticipantIds`, so
+ * if this derivation missed somebody the menu would be short a row, never able to write a bad id.
+ *
+ * **The PAIR itself is deliberately excluded, and this is load-bearing (D4c).** The factory's
+ * `allRelevantParticipantIds` also contains `sideParticipantIds`, so it would accept a check-in
+ * against the PAIR — and nothing reconciles a PAIR-level check-in with its two individual ones. A desk
+ * that checked in the pair and a desk that checked in both players would store different state for the
+ * same physical fact. Returning only individuals makes the wrong write unreachable from the UI rather
+ * than merely discouraged.
+ */
+function individualsOf(matchUp: any): { participantId: string; participantName: string; sideNumber?: number }[] {
+  const individuals: { participantId: string; participantName: string; sideNumber?: number }[] = [];
+
+  for (const side of matchUp?.sides ?? []) {
+    const participant = side?.participant;
+    if (!participant) continue;
+    const { sideNumber } = side;
+
+    // A PAIR or TEAM contributes its members, never itself.
+    const nested = participant.individualParticipants;
+    if (Array.isArray(nested) && nested.length) {
+      for (const member of nested) {
+        if (member?.participantId) {
+          individuals.push({
+            participantId: member.participantId,
+            participantName: member.participantName ?? '',
+            sideNumber,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (participant.participantType === INDIVIDUAL && participant.participantId) {
+      individuals.push({
+        participantId: participant.participantId,
+        participantName: participant.participantName ?? '',
+        sideNumber,
+      });
+    }
+  }
+
+  return individuals;
+}
+
+export function getMatchUpCheckInState(matchUp?: any): MatchUpCheckInState {
+  const checkedInIds = new Set<string>(
+    Array.isArray(matchUp?.checkedInParticipantIds) ? matchUp.checkedInParticipantIds : [],
+  );
+
+  const participants: CheckInParticipant[] = individualsOf(matchUp).map((individual) => ({
+    ...individual,
+    checkedIn: checkedInIds.has(individual.participantId),
+  }));
+
+  const total = participants.length;
+  const checkedInCount = participants.filter((participant) => participant.checkedIn).length;
+
+  return {
+    participants,
+    total,
+    checkedInCount,
+    hasParticipants: total > 0,
+    // `allCheckedIn` is false for a matchUp with nobody in it — "everyone present" is meaningless
+    // when there is no one, and reporting true would let the call-to-court gate pass silently.
+    allCheckedIn: total > 0 && checkedInCount === total,
+    partial: checkedInCount > 0 && checkedInCount < total,
+  };
+}
+
+/**
+ * `1/2`, never a tick.
+ *
+ * A boolean collapses the two states a desk is actually distinguishing — "nobody has arrived" and "one
+ * of the doubles partners is standing here" — which is the whole reason per-matchUp check-in is worth
+ * surfacing at all.
+ */
+export function checkInSummary(state: MatchUpCheckInState): string {
+  return `${state.checkedInCount}/${state.total}`;
+}
+
+/** The individuals who are NOT at the desk — what a call-to-court warning has to name. */
+export function awaitingCheckIn(state: MatchUpCheckInState): CheckInParticipant[] {
+  return state.participants.filter((participant) => !participant.checkedIn);
+}

--- a/src/services/checkIn/toggleCheckIn.ts
+++ b/src/services/checkIn/toggleCheckIn.ts
@@ -1,0 +1,35 @@
+/**
+ * Flip one individual's check-in state for one matchUp.
+ *
+ * `toggleParticipantCheckInState` reads the matchUp's current `checkedInParticipantIds` and dispatches
+ * to `checkInParticipant` / `checkOutParticipant` itself, so the client never has to decide which
+ * direction it is going — which matters at a desk, where two operators can be looking at the same row.
+ *
+ * `drawId`, never a resolved `drawDefinition`: the execution pipeline resolves it (ecosystem rule).
+ *
+ * ⚠️ `participantId` must be an **INDIVIDUAL**, never a PAIR (D4c). The factory would accept a PAIR —
+ * its `allRelevantParticipantIds` includes `sideParticipantIds` — and nothing reconciles a PAIR-level
+ * check-in with its two individual ones. `getMatchUpCheckInState` only ever offers individuals, which
+ * is what keeps that unreachable rather than merely discouraged.
+ *
+ * ⚠️ `toggleParticipantCheckInState` also declares `matchUpIds?: string[]` in its args type and never
+ * reads it. Do not pass it expecting to check somebody into several matchUps at once.
+ */
+import { mutationRequest } from 'services/mutation/mutationRequest';
+
+import { TOGGLE_PARTICIPANT_CHECK_IN_STATE } from 'constants/mutationConstants';
+
+export function toggleCheckIn({
+  participantId,
+  matchUpId,
+  callback,
+  drawId,
+}: {
+  callback?: (result: any) => void;
+  participantId: string;
+  matchUpId: string;
+  drawId: string;
+}): void {
+  const methods = [{ method: TOGGLE_PARTICIPANT_CHECK_IN_STATE, params: { matchUpId, drawId, participantId } }];
+  mutationRequest({ methods, callback });
+}

--- a/src/styles/tmx.css
+++ b/src/styles/tmx.css
@@ -1553,3 +1553,54 @@ img {
   text-align: center;
   padding: 0.3rem 0.5rem;
 }
+
+/* ── Per-matchUp check-in ────────────────────────────────────────────── */
+/*
+ * The desk panel. Distinct from the participants page's sign-in tick, deliberately: signing in is
+ * ARRIVAL at the tournament and is tournament-wide, checking in is per-match (D4a). They never share a
+ * control, so they should not share a visual language either.
+ *
+ * Partial state is carried by the `n/m` summary rather than by colour alone — "one of two partners is
+ * standing here" has to survive a monochrome print and a colour-blind operator.
+ */
+:root {
+  --tmx-checkin-mark-fg: #7a8290;
+  --tmx-checkin-done-fg: #1c7a4a;
+  --tmx-checkin-done-bg: rgba(28, 122, 74, 0.10);
+}
+[data-theme='dark'] {
+  --tmx-checkin-mark-fg: #9aa4b2;
+  --tmx-checkin-done-fg: #6fd39b;
+  --tmx-checkin-done-bg: rgba(111, 211, 155, 0.14);
+}
+
+.tmx-checkin-heading {
+  font-weight: 600;
+  font-size: 0.85em;
+  color: var(--tmx-text-secondary);
+  padding: 0 0.5em 0.35em;
+}
+.tmx-checkin-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.3em 0.5em;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--tmx-text-primary);
+}
+.tmx-checkin-row:hover {
+  background: var(--chc-hover-bg, rgba(127, 127, 127, 0.12));
+}
+.tmx-checkin-row.is-checked-in {
+  background: var(--tmx-checkin-done-bg);
+  color: var(--tmx-checkin-done-fg);
+}
+.tmx-checkin-mark {
+  width: 1em;
+  text-align: center;
+  color: var(--tmx-checkin-mark-fg);
+}
+.tmx-checkin-row.is-checked-in .tmx-checkin-mark {
+  color: var(--tmx-checkin-done-fg);
+}


### PR DESCRIPTION
**P4(b)** of `Mentat/planning/TMX_PRESENCE_AND_CHECK_IN.md`.

CA's framing: `signInStatus` is FIRST ARRIVAL at the tournament. Separately, a specific matchUp needs its own check-in — several matchUps are scheduled at 12:00, it's doubles, and **both individual participants must present themselves at the physical desk** before the matchUp is called to court.

TMX had never surfaced this. The only occurrence of `checkedIn` in the entire client was `src/dev/cfsToTournamentRecord.mjs`, a console helper.

## What this adds

- **"Check in (n/m)"** in the matchUp actions menu, opening a panel with one row per individual. Click toggles; the same row checks back out.
- **Partial state is the point.** A doubles matchUp reads `1/4`, never a tick — "nobody has arrived" and "one of the partners is standing here" are the two states a desk operator is actually distinguishing.
- **Call to court warns and proceeds**, naming who has not checked in.

## Decisions carried in (CA, 2026-08-23)

- **D4a — vocabulary.** *Signed in* stays arrival, tournament-wide, unchanged everywhere. *Checked in* is this matchUp. Never both on one control. The journey asserts the menu says "Check in" and does **not** say "Sign in".
- **D4c — the subject is the INDIVIDUAL.** The factory would accept a **PAIR**: its `allRelevantParticipantIds` is `unique(individualParticipantIds ∪ sideParticipantIds)`, and nothing reconciles a PAIR-level check-in with its two individual ones. Two desks would store different state for the same physical fact. Returning only individuals makes the wrong write *unreachable from the UI* rather than merely discouraged.
- **D4d — warn, don't block.** A hard block teaches operators to check everyone in pre-emptively, which destroys the signal.

D4b (per-day presence) is **not** in this PR — per D4e it is scoped jointly with the officials board.

## Design notes

- **No new query.** `addMatchUpContext` already attaches `checkedInParticipantIds` and `allParticipantsCheckedIn` to every hydrated matchUp, so this is display, not fetch.
- **`toggleParticipantCheckInState`** decides the direction itself from stored state, which matters at a desk where two operators can be looking at the same row.
- TMX has no jsdom, so the derivation lives in a pure module with its own tests and the panel is a thin shell.

## Verification

`lint 0 · check-types 0 · format:check clean · i18n-audit 0 · attr-audit 0 · 1407 unit tests pass` (+14). Journey 105 green.

**8 falsification probes, all two-run pairs.** The one worth reading: deleting the nested-individual branch leaves the **singles** unit test green while both doubles tests go red — concrete proof that a singles-only fixture would have proved nothing, which is why journey 105 seeds DOUBLES.

## Follow-up, not in this PR

`checkInParticipant` / `checkOutParticipant` / `toggleParticipantCheckInState` are **absent from `MUTATION_PERMISSIONS`**, and `isMutationAllowed` is `if (!permKey) return true` — unmapped means allowed. Not a live hole (nothing emitted them until now) but it should be closed with a `provider-config` publish + bump.