### PR TITLE
chore(deps): update @courthive/provider-config to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "yargs": "18.1.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "0.16.0",
+    "@courthive/provider-config": "0.17.0",
     "@courthive/scoring-visualizations": "^0.2.9",
     "@eslint/js": "^10.0.1",
     "animate.css": "4.1.1",


### PR DESCRIPTION
Completes the fan-out of [provider-config 0.17.0](https://github.com/CourtHive/provider-config/pull/76), which maps the three per-matchUp check-in mutations into `MUTATION_PERMISSIONS`.

TMX started emitting `toggleParticipantCheckInState` in [#1340](https://github.com/CourtHive/TMX/pull/1340), and those methods were **unmapped** — and `isMutationAllowed` returns `true` for an unmapped method. This closes that granularity gap.

**Nothing changes behaviour.** They are gated under `canEditParticipantDetails`, the same key as `modifyParticipantsSignInStatus`, and that key is not in `PERMISSIONS_DEFAULT_FALSE` — so a provider with no `permissions` object configured (which the production audit found to be all of them) is unaffected. provider-config #76 asserts exactly that against `computeEffectiveConfig({})`.

TMX is the last of five consumers; the other four (competition-factory-server, courthive-ams incl. its nested `client/`, courthive-hiveid, courthive-public) went via `Mentat/scripts/bump-provider-config-consumers.sh`. TMX gets a PR because its `main` requires the `lint` check and rejects a direct cascade push.

**The lockfile is deliberately unchanged**: provider-config is a `link:` override here, so the lockfile records the link rather than a version, and CI strips the overrides and re-resolves from this pin with `--no-frozen-lockfile`.

Verified locally: `lint 0 · check-types 0 · format:check clean · 1440 tests pass`.