### PR TITLE
feat(capability): hide tournament sections a user has no use for

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -14,6 +14,7 @@ import { featureFlags } from 'config/featureFlags';
 import { deviceConfig } from 'config/deviceConfig';
 import { context } from 'services/context';
 import tippy from 'tippy.js';
+import { canViewTab, ownsTabVisibility } from 'services/capability/navCapability';
 import { t } from 'i18n';
 
 // constants
@@ -85,6 +86,23 @@ const i18nKeys: Record<string, string> = {
 // authority over the tournament's provider. See Phase 2-B.1.
 const CONDITIONAL_ROUTE_IDS = new Set(['rg-route']);
 
+/**
+ * Hide sections the user has no use for.
+ *
+ * Derived from the capability action set rather than a second hand-maintained
+ * list, so a tab cannot drift from what the user can actually do. Re-evaluated
+ * on every tab render alongside the registrations gate, because a demo posture
+ * or a provider switch can change the answer between renders.
+ */
+export function applyTabCapabilityVisibility(): void {
+  for (const [id, tab] of Object.entries(routeMap)) {
+    if (CONDITIONAL_ROUTE_IDS.has(id)) continue; // owned by its own richer gate
+    if (!ownsTabVisibility(tab)) continue;
+    const el = document.getElementById(id);
+    if (el) el.style.display = canViewTab(tab) ? '' : 'none';
+  }
+}
+
 function navigateToRoute(id: string): void {
   clearSyncIndicator();
   document.querySelectorAll('.nav-icon').forEach((i) => ((i as HTMLElement).style.color = ''));
@@ -111,10 +129,14 @@ function setupMobileNav(selectedTab: string | undefined): void {
   // (e.g. `rg-route` for Registrations) only appear in the dropdown
   // when their desktop counterpart is currently visible.
   menu.innerHTML = '';
+  // Mirrors whatever the desktop rail is currently showing — including tabs
+  // hidden by capability, not just the conditional routes this originally
+  // covered. A missing element keeps the prior tolerance so a mobile render
+  // that beats the icons into the DOM does not drop every non-conditional item.
   const ids = Object.keys(routeMap).filter((id) => {
-    if (!CONDITIONAL_ROUTE_IDS.has(id)) return true;
     const el = document.getElementById(id);
-    return !!el && el.style.display !== 'none';
+    if (!el) return !CONDITIONAL_ROUTE_IDS.has(id);
+    return el.style.display !== 'none';
   });
   ids.forEach((id) => {
     const item = document.createElement('button');
@@ -239,6 +261,12 @@ export function tmxNavigation(): void {
     };
   });
 
+  // Apply capability visibility BEFORE the mobile dropdown is built — it mirrors
+  // whichever desktop icons are currently shown, so building it first would list
+  // tabs that are about to be hidden.
+  applyRegistrationsTabVisibility();
+  applyTabCapabilityVisibility();
+
   // Initialize mobile dropdown
   setupMobileNav(selectedTab);
 
@@ -338,6 +366,7 @@ export function highlightTab(selectedTab: string): void {
   // registrationProfile changes over its lifecycle (publish → close)
   // and a director's role at a provider can change between renders.
   applyRegistrationsTabVisibility();
+  applyTabCapabilityVisibility();
 
   document.querySelectorAll('.nav-icon').forEach((i) => ((i as HTMLElement).style.color = ''));
 

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -12,6 +12,7 @@ import { tmxTournaments } from 'pages/tournaments/tournaments';
 import { showSplash } from 'services/transitions/screenSlaver';
 import { renderAdminPage } from 'pages/admin/renderAdminPage';
 import { destroyTables } from 'pages/tournament/destroyTable';
+import { canViewTab, firstPermittedTab, tabDenialReason } from 'services/capability/navCapability';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { context } from 'services/context';
 import Navigo from 'navigo';
@@ -63,8 +64,18 @@ export function routeTMX() {
   });
 
   const displayRoute = ({ selectedTab, renderDraw, renderPoints, data }: any) => {
+    // Route-level capability guard. Hiding a nav icon is not enough on its own:
+    // a bookmark, a shared link, browser history or a typed hash all reach the
+    // route directly. Guarding here rather than at each `router.on` puts it in
+    // the one function every tab-selecting route already calls (standard A10).
+    let tab = selectedTab;
+    if (tab && !canViewTab(tab)) {
+      const reason = tabDenialReason(tab);
+      if (reason) tmxToast({ intent: 'is-warning', message: reason });
+      tab = firstPermittedTab();
+    }
     destroyTables();
-    displayTournament({ config: { selectedTab, renderDraw, renderPoints, ...data } }); // ...data must come last
+    displayTournament({ config: { selectedTab: tab, renderDraw, renderPoints, ...data } }); // ...data must come last
   };
 
   // Topology routes — standalone page, reuses tournament loading

--- a/src/services/capability/navCapability.test.ts
+++ b/src/services/capability/navCapability.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { NAV_TAB_ACTIONS, canViewTab, firstPermittedTab, ownsTabVisibility, tabDenialReason } from './navCapability';
+import { clearDemoOverlay, setDemoOverlay } from 'services/demoMode/demoState';
+import { overridesForPreset } from 'services/demoMode/demoPresets';
+import { providerConfig } from 'config/providerConfig';
+import {
+  TOURNAMENT_OVERVIEW,
+  REGISTRATIONS_TAB,
+  PUBLISHING_TAB,
+  SCHEDULING_TAB,
+  PARTICIPANTS,
+  MATCHUPS_TAB,
+  SETTINGS_TAB,
+  VENUES_TAB,
+  EVENTS_TAB,
+} from 'constants/tmxConstants';
+
+function applyPreset(preset: 'recorder' | 'scheduler' | 'registrar' | 'readOnly') {
+  setDemoOverlay({ v: 1, preset, permissions: overridesForPreset(preset)! });
+}
+
+describe('navCapability', () => {
+  beforeEach(() => {
+    providerConfig.reset();
+    clearDemoOverlay();
+  });
+  afterEach(() => clearDemoOverlay());
+
+  it('shows every tab to an unconfigured provider', () => {
+    for (const tab of Object.keys(NAV_TAB_ACTIONS)) expect(canViewTab(tab), tab).toBe(true);
+  });
+
+  it('does not own the Registrations tab — it has its own richer gate', () => {
+    expect(ownsTabVisibility(REGISTRATIONS_TAB)).toBe(false);
+    expect(canViewTab(REGISTRATIONS_TAB)).toBe(true);
+  });
+
+  it('keeps Overview and Settings available under every posture', () => {
+    applyPreset('readOnly');
+    expect(canViewTab(TOURNAMENT_OVERVIEW)).toBe(true);
+    expect(canViewTab(SETTINGS_TAB)).toBe(true);
+  });
+
+  // CA's case: "the venues pages should not be visible for someone who can only
+  // score/schedule" — but the two halves of that answer differently.
+  describe('the venues case', () => {
+    it('hides Venues from a scoring-only recorder', () => {
+      applyPreset('recorder');
+      expect(canViewTab(VENUES_TAB)).toBe(false);
+    });
+
+    // The trap: deriving from venue CRUD alone would hide it from the person who
+    // most needs it. A scheduler places matches on courts.
+    it('KEEPS Venues for a scheduler, who cannot create a venue but needs the courts', () => {
+      applyPreset('scheduler');
+      expect(providerConfig.isAllowed('canCreateVenues')).toBe(false);
+      expect(canViewTab(VENUES_TAB)).toBe(true);
+    });
+  });
+
+  it('hides construction sections from a recorder but keeps what they must see', () => {
+    applyPreset('recorder');
+    expect(canViewTab(EVENTS_TAB)).toBe(false);
+    expect(canViewTab(PARTICIPANTS)).toBe(false);
+    expect(canViewTab(PUBLISHING_TAB)).toBe(false);
+    // Read-useful: a recorder needs to know when and where they are playing.
+    expect(canViewTab(MATCHUPS_TAB)).toBe(true);
+    expect(canViewTab(SCHEDULING_TAB)).toBe(true);
+  });
+
+  it('gives a registrar the participant and event surfaces', () => {
+    applyPreset('registrar');
+    expect(canViewTab(PARTICIPANTS)).toBe(true);
+    expect(canViewTab(EVENTS_TAB)).toBe(true);
+    expect(canViewTab(VENUES_TAB)).toBe(false);
+    expect(canViewTab(PUBLISHING_TAB)).toBe(false);
+  });
+
+  it('every denied tab can explain itself — the redirect toast is never silent', () => {
+    applyPreset('recorder');
+    for (const tab of Object.keys(NAV_TAB_ACTIONS)) {
+      if (canViewTab(tab)) continue;
+      expect(tabDenialReason(tab), tab).toBeTruthy();
+    }
+  });
+
+  it('returns no reason for a permitted tab', () => {
+    expect(tabDenialReason(MATCHUPS_TAB)).toBeUndefined();
+  });
+
+  it('always resolves a landing tab, even when everything is denied', () => {
+    applyPreset('readOnly');
+    const landing = firstPermittedTab();
+    expect(canViewTab(landing)).toBe(true);
+    expect(landing).toBe(TOURNAMENT_OVERVIEW);
+  });
+
+  it('lands a denied deep link on a tab the user can actually reach', () => {
+    applyPreset('recorder');
+    expect(canViewTab(VENUES_TAB)).toBe(false);
+    expect(canViewTab(firstPermittedTab())).toBe(true);
+  });
+
+  it('reflects a single provider permission, not only demo presets', () => {
+    providerConfig.set({ permissions: { canPublish: false, canUnpublish: false } });
+    expect(canViewTab(PUBLISHING_TAB)).toBe(false);
+    providerConfig.reset();
+    expect(canViewTab(PUBLISHING_TAB)).toBe(true);
+  });
+
+  it('every tab action is a real capability action', () => {
+    for (const [tab, actions] of Object.entries(NAV_TAB_ACTIONS)) {
+      for (const action of actions) expect(typeof action, `${tab}:${action}`).toBe('string');
+    }
+  });
+});

--- a/src/services/capability/navCapability.ts
+++ b/src/services/capability/navCapability.ts
@@ -1,0 +1,139 @@
+/**
+ * Which tournament sections a user has any use for.
+ *
+ * Hiding individual controls is subtle; hiding whole sections is what makes a
+ * restricted posture legible. But there is a trap in the obvious version.
+ *
+ * ## Write capability alone is the wrong signal
+ *
+ * Every capability so far answers *"may you change this"*. Navigation needs
+ * *"is this section of any use to you"*, and the two diverge. Venues must
+ * disappear for a scoring-only user but **must not** disappear for a scheduler:
+ * assigning matches to courts needs the venue surface even when creating a venue
+ * is denied. Deriving purely from write capability would hide it from exactly
+ * the person who needs it — hence `modifySchedule` and `modifyCourtAvailability`
+ * appear in the Venues row below.
+ *
+ * ## Derived, never a second list
+ *
+ * A tab is visible when **any** of its actions is permitted. Nothing here
+ * enumerates permissions independently of `can()`, so a tab cannot drift from
+ * the capability set the way a hand-maintained visibility list would.
+ *
+ * ## Read-useful sections
+ *
+ * A short, explicit exemption for sections a user must SEE without being able to
+ * change anything. A recorder needs to know where and when they are playing.
+ * Keep this list small and justified — every entry weakens the lockdown.
+ */
+import { can } from './can';
+
+import type { CapabilityAction, Capability } from './can';
+import {
+  TOURNAMENT_OVERVIEW,
+  REGISTRATIONS_TAB,
+  PUBLISHING_TAB,
+  SCHEDULING_TAB,
+  PARTICIPANTS,
+  MATCHUPS_TAB,
+  SETTINGS_TAB,
+  REPORTS_TAB,
+  VENUES_TAB,
+  EVENTS_TAB,
+} from 'constants/tmxConstants';
+
+/**
+ * Actions that give a tab purpose. Empty array = always available.
+ *
+ * Registrations is absent deliberately: it already has its own richer gate
+ * (`canManageRegistrations`, which reads the tournament's registrationProfile as
+ * well as the caller's provider authority) and this must not second-guess it.
+ */
+const TAB_ACTIONS: Record<string, CapabilityAction[]> = {
+  [TOURNAMENT_OVERVIEW]: [],
+  [SETTINGS_TAB]: [], // user preferences — language, scoring approach, fonts
+  [PARTICIPANTS]: [
+    'createCompetitor',
+    'createOfficial',
+    'importParticipants',
+    'deleteParticipants',
+    'editParticipantDetails',
+    'modifyEntries',
+  ],
+  [EVENTS_TAB]: [
+    'createEvent',
+    'deleteEvent',
+    'createDraw',
+    'deleteDraw',
+    'assignPositions',
+    'modifyStructures',
+    'modifyEntries',
+  ],
+  [MATCHUPS_TAB]: ['enterScores', 'modifySchedule'],
+  [SCHEDULING_TAB]: ['modifySchedule', 'useBulkScheduling'],
+  // Not just venue CRUD: a scheduler needs this surface to place matches on courts.
+  [VENUES_TAB]: ['createVenue', 'deleteVenue', 'modifySchedule'],
+  [PUBLISHING_TAB]: ['publish', 'unpublish'],
+  [REPORTS_TAB]: ['publish'],
+};
+
+/**
+ * Sections visible even when every action on them is denied, because seeing
+ * them is the point. A recorder scoring on court 7 needs to know when and where
+ * they are playing.
+ */
+const READ_USEFUL_TABS: ReadonlySet<string> = new Set([MATCHUPS_TAB, SCHEDULING_TAB]);
+
+/** Tabs whose visibility this module does NOT own. */
+const EXTERNALLY_GATED: ReadonlySet<string> = new Set([REGISTRATIONS_TAB]);
+
+export function ownsTabVisibility(tab: string): boolean {
+  return !EXTERNALLY_GATED.has(tab) && tab in TAB_ACTIONS;
+}
+
+/**
+ * May this user reach this tab at all?
+ *
+ * MUST be evaluated at render — a provider's effective config is re-fetched on
+ * impersonation switch and a demo posture can change between renders.
+ */
+export function canViewTab(tab: string): boolean {
+  if (!ownsTabVisibility(tab)) return true;
+  if (READ_USEFUL_TABS.has(tab)) return true;
+  const actions = TAB_ACTIONS[tab];
+  if (!actions.length) return true;
+  return actions.some((action) => can(action).allowed);
+}
+
+/**
+ * Why a tab is unavailable — the reason from the first action that would have
+ * granted it. Feeds the redirect toast, so a deep link explains itself rather
+ * than silently bouncing.
+ */
+export function tabDenialReason(tab: string): string | undefined {
+  if (canViewTab(tab)) return undefined;
+  for (const action of TAB_ACTIONS[tab] ?? []) {
+    const result: Capability = can(action);
+    if (!result.allowed) return result.reason;
+  }
+  return undefined;
+}
+
+/** The first tab this user can reach — where a denied deep link lands. */
+export function firstPermittedTab(): string {
+  const order = [
+    TOURNAMENT_OVERVIEW,
+    MATCHUPS_TAB,
+    SCHEDULING_TAB,
+    EVENTS_TAB,
+    PARTICIPANTS,
+    VENUES_TAB,
+    PUBLISHING_TAB,
+    REPORTS_TAB,
+    SETTINGS_TAB,
+  ];
+  return order.find((tab) => canViewTab(tab)) ?? TOURNAMENT_OVERVIEW;
+}
+
+/** Exported for the coverage test and for demo tooling. */
+export const NAV_TAB_ACTIONS: Readonly<Record<string, CapabilityAction[]>> = TAB_ACTIONS;


### PR DESCRIPTION
**P3.5** of `Mentat/planning/TMX_LOCKDOWN_AND_ROLE_MODEL.md` §10.

> CA: *"the venues pages should not be visible for someone who can only score/schedule."*

Hiding individual controls is subtle. Hiding whole sections is what makes a restricted posture legible — and it's what makes a demonstration land.

## The trap in the obvious implementation

Every capability built so far answers **"may you change this"**. Navigation needs **"is this section of any use to you"**, and the two diverge.

Venues must disappear for a scoring-only recorder — and must **not** disappear for a scheduler, who cannot create a venue but places matches on courts. Deriving from venue CRUD alone would hide it from exactly the person who needs it most, so `modifySchedule` is part of the Venues row.

There's a test for that specific inversion, and it **fails against the naive version** — verified by temporarily reducing Venues to `['createVenue', 'deleteVenue']` and watching only that assertion go red.

## Derived, never a second list

A tab is visible when **any** of its actions is permitted. Nothing enumerates permissions independently of `can()`, so a tab cannot drift from the capability set the way a hand-maintained visibility list would.

A short, explicit **read-useful exemption** keeps MatchUps and Schedule visible for a recorder who can change neither but needs to know when and where they're playing. Every entry there weakens the lockdown, so the list is justified inline and kept small.

**Registrations is left alone** — it already has a richer gate reading the tournament's `registrationProfile` as well as provider authority, and this must not second-guess it.

## Routes guarded, not only icons hidden

A bookmark, a shared link, browser history or a typed hash all reach a route directly, so hiding an icon alone is theater — the same lesson as the REST `executionQueue` hole, one layer up.

The guard lives inside `displayRoute`, the one function every tab-selecting route already calls (standard A10), rather than being repeated across ~14 `router.on` registrations. A denied deep link redirects to a reachable tab and **toasts the reason** `can()` already returns, instead of blanking.

## Two things the mobile nav needed

Its dropdown honored `display` **only for `CONDITIONAL_ROUTE_IDS`**, so a capability-hidden tab still appeared there. That filter now mirrors whatever the desktop rail shows, keeping the prior tolerance for a missing element so an early render can't drop every item.

And visibility is applied **before** the dropdown is built, since it's constructed from the visible icons — otherwise the first render lists tabs that are about to be hidden.

## Worked postures (all asserted)

| Tab | Recorder | Scheduler | Registrar |
|---|---|---|---|
| Overview / Settings | ✓ | ✓ | ✓ |
| MatchUps / Schedule | ✓ (read-useful) | ✓ | — |
| **Venues** | **—** | **✓** | — |
| Events / Participants | — | — | ✓ |
| Publishing / Reports | — | — | — |

## No new i18n strings

The toast reuses the `capability.denied.*` reasons from #1338 — which also avoids touching `en.json` while `tmx-matchup-check-in` holds it.

## Verification

Every gate run in its **exact CI invocation** this time, after the `attr-audit --ci` lesson from #1339:

`pnpm lint` · `pnpm attr-audit --ci` · `pnpm i18n-audit --ci` · `pnpm format:check` · `pnpm check-types` — all exit 0 · **1453 tests in 135 files pass**