### PR TITLE
fix(officiating): tell "not checked" apart from "no conflicts"

### DIFF
--- a/src/components/popovers/matchUpActions.ts
+++ b/src/components/popovers/matchUpActions.ts
@@ -44,6 +44,7 @@ let checkInTip: Instance | undefined;
 
 /** Shared tippy theme for the popover panels this module opens. */
 const TIP_THEME = 'light-border';
+const ARIA_HIDDEN = 'aria-hidden';
 
 function destroyCheckInTip() {
   if (checkInTip) {
@@ -285,15 +286,27 @@ export function matchUpActions({
       }
       const conflict = conflictByOfficial.get(official.participantId) ?? { level: 'none', reasons: [] };
       const isBlocked = conflict.level === 'blocked';
+      // `unknown` = the check could not run. Rendered distinctly and still SELECTABLE: failing open is
+      // the deliberate behaviour, and the factory gate re-runs the check on the mutation anyway. What
+      // must not happen is it looking like `none`, which is "assessed and clean".
+      const notChecked = conflict.level === 'unknown';
 
       li.textContent = official.participantName ?? null;
-      if (conflict.level !== 'none') {
+      if (notChecked) {
+        li.title = `${t('officiating.notChecked')}\n${conflict.reasons.join('\n')}`;
+        const mark = document.createElement('span');
+        mark.textContent = '?';
+        mark.setAttribute(ARIA_HIDDEN, 'true');
+        mark.style.cssText = 'margin-left:6px; font-weight:700; color: var(--chc-text-secondary, #888);';
+        li.appendChild(mark);
+        li.setAttribute('data-conflict', 'unknown');
+      } else if (conflict.level !== 'none') {
         // Reasons come from the factory already human-readable, e.g. "Official shares a COACH grouping
         // (Team Alpha) with this participant" — the UI lists them rather than composing a sentence.
         li.title = conflict.reasons.join('\n');
         const dot = document.createElement('span');
         dot.textContent = '\u25cf';
-        dot.setAttribute('aria-hidden', 'true');
+        dot.setAttribute(ARIA_HIDDEN, 'true');
         dot.style.cssText = `margin-left:6px; color:${isBlocked ? 'var(--tmx-danger, #d64545)' : 'var(--tmx-warning, #d99e00)'};`;
         li.appendChild(dot);
         li.setAttribute('data-conflict', conflict.level);
@@ -424,7 +437,7 @@ export function matchUpActions({
 
         const mark = document.createElement('span');
         mark.className = 'tmx-checkin-mark';
-        mark.setAttribute('aria-hidden', 'true');
+        mark.setAttribute(ARIA_HIDDEN, 'true');
         mark.textContent = participant.checkedIn ? '\u2713' : '\u25cb';
         li.appendChild(mark);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2498,7 +2498,8 @@
   "officiating": {
     "conflictWarning": "This official has a potential conflict of interest with a participant in this match. Assign anyway?",
     "selectOfficial": "Select official",
-    "noOfficialsFound": "No officials found"
+    "noOfficialsFound": "No officials found",
+    "notChecked": "Conflicts could not be checked for this official"
   },
   "participantRoles": {
     "ADMINISTRATION": "Administration",

--- a/src/services/officiating/officialConflicts.test.ts
+++ b/src/services/officiating/officialConflicts.test.ts
@@ -99,8 +99,24 @@ describe('evaluateCandidate', () => {
   });
 
   it('fails OPEN when the engine errors — a UI that cannot evaluate must not invent a refusal', () => {
-    // The factory gate on the mutation is the enforcement point; this is only an affordance.
+    // The factory gate on the mutation is the enforcement point; this is only an affordance. The
+    // property this test is named for is UNCHANGED: an errored evaluation still does not block.
+    //
+    // What changed is that it no longer reports `none`. `none` means "assessed and clean", and
+    // returning it for an evaluation that never ran made those two indistinguishable in the picker —
+    // the failure the fail-soft rule exists to prevent. The level is now `unknown`, which the picker
+    // renders as not-assessed while still allowing the selection.
     getMatchUpOfficialConflictsMock.mockReturnValue({ error: { code: 'ERR_MISSING_CONFLICT_SOURCE' } });
+    const result = evaluateCandidate(args);
+    expect(result.level).toEqual('unknown');
+    // The fail-open property, asserted directly rather than implied by the label.
+    expect(result.level).not.toEqual('blocked');
+  });
+
+  it('reports a clean evaluation as `none`, distinct from an unrunnable one', () => {
+    // The control for the case above. Without this, `unknown` could have been made the return for
+    // everything and the suite would not notice.
+    getMatchUpOfficialConflictsMock.mockReturnValue({ conflicts: [] });
     expect(evaluateCandidate(args)).toEqual({ level: 'none', reasons: [] });
   });
 });

--- a/src/services/officiating/officialConflicts.ts
+++ b/src/services/officiating/officialConflicts.ts
@@ -17,8 +17,15 @@ const { POLICY_OFFICIATING_CONFLICT_OF_INTEREST } = fixtures.policies;
 
 const { POLICY_TYPE_OFFICIATING_CONFLICT } = policyConstants;
 
-/** Severity of the worst conflict found for a candidate. `none` means evaluated and clean. */
-export type ConflictLevel = 'none' | 'warn' | 'blocked';
+/**
+ * Outcome of evaluating a candidate.
+ *
+ * `none` means **evaluated and clean**; `unknown` means **the check could not run**. Those are
+ * different facts and the picker has to say which — a check that could not run must not look like a
+ * check that found nothing. Before this, an errored evaluation returned `none`, so a candidate the
+ * engine had never assessed rendered identically to one it had cleared.
+ */
+export type ConflictLevel = 'none' | 'warn' | 'blocked' | 'unknown';
 
 export type CandidateConflicts = {
   level: ConflictLevel;
@@ -56,9 +63,14 @@ export function summarizeConflicts(result: any): CandidateConflicts {
 /**
  * Evaluate one candidate official against one matchUp.
  *
- * Fails OPEN by design: if the evaluation errors, the candidate is reported `none` rather than blocked.
- * A UI that cannot evaluate must not invent a refusal — and it is not the enforcement point anyway, the
- * factory gate on the mutation is. That gate re-runs the same check server-side with the same policy.
+ * Fails OPEN by design: an errored evaluation does not block the candidate. A UI that cannot evaluate
+ * must not invent a refusal — and it is not the enforcement point anyway; the factory gate on the
+ * mutation is, and it re-runs the same check server-side with the same policy.
+ *
+ * But failing open is not the same as reporting clean. The error case now returns `unknown`, so the
+ * picker can show that the candidate was *not assessed* while still allowing the selection. Returning
+ * `none` here — as this did — made "we checked and found nothing" and "we could not check" the same
+ * pixel, which is the failure mode the fail-soft rule exists to prevent.
  */
 export function evaluateCandidate({
   officialParticipantId,
@@ -78,6 +90,6 @@ export function evaluateCandidate({
     drawId,
   });
 
-  if (result?.error) return { level: 'none', reasons: [] };
+  if (result?.error) return { level: 'unknown', reasons: [String(result.error?.message ?? result.error)] };
   return summarizeConflicts(result);
 }


### PR DESCRIPTION
The last of the three remaining defects in the participants workstream.

`evaluateCandidate` returned `{ level: 'none', reasons: [] }` when the engine errored — and `'none'` is exactly what a **clean** evaluation returns. So a candidate the engine had never assessed rendered identically to one it had cleared.

That is the failure the fail-soft rule exists to prevent, stated in `TMX_OFFICIALS_COORDINATION.md` as: *a check that could not run must not look like a check that found nothing.*

## What does NOT change

**Failing open.** An errored evaluation still does not block the candidate, and it is still selectable. A UI that cannot evaluate must not invent a refusal, and it is not the enforcement point anyway — the factory gate on `addMatchUpOfficial` re-runs the same check server-side with the same policy.

## What changes

A fourth level, **`unknown`**, returned only on the error branch, carrying the engine's message as its reason. The picker renders it with its own marker (`?`, neutral) and a "conflicts could not be checked" tooltip, distinct from both the clean row and the warn/blocked dot.

This gives the picker the three states the officials plan calls for: **checked-clean · checked-conflicted · not-checkable**.

## On the existing test

One existing assertion changed, and deliberately — it pinned `level: 'none'` for the error case. The property that test is *named* for ("fails OPEN … must not invent a refusal") is **unchanged and now asserted directly** (`not.toEqual('blocked')`) rather than implied by the label. A control was added alongside it: a clean evaluation must still report `none`, so `unknown` cannot be made the answer for everything without the suite noticing.

## Verification

`lint 0 · check-types 0 · format:check clean · i18n-audit 0 · attr-audit 0 · 1441 tests pass`.

**Falsified in both directions:** reverting the error branch to `'none'` turns the fail-open test red; returning `'unknown'` for every outcome turns the clean-evaluation control (and the blocking test) red.