### PR TITLE
feat(capability): answer "may you do this HERE", not just "may you do this"

### DIFF
--- a/attr-audit.config.json
+++ b/attr-audit.config.json
@@ -61,6 +61,7 @@
     "registrationIds",
     "baseURI",
     "participantNames",
-    "scheduler"
+    "scheduler",
+    "scope"
   ]
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2542,7 +2542,8 @@
       "publish": "This provider does not allow publishing.",
       "unpublish": "This provider does not allow unpublishing.",
       "useChat": "Chat is disabled for this provider."
-    }
+    },
+    "outOfScope": "Outside the courts, days or events you have been assigned."
   },
   "demoMode": {
     "title": "Demo mode",

--- a/src/services/capability/can.ts
+++ b/src/services/capability/can.ts
@@ -33,13 +33,15 @@
  * layers share). `can()` decides what to render. Do not let its existence imply
  * otherwise.
  */
+import { isPermittedOnResource } from 'services/capability/scopeState';
 import { providerConfig } from 'config/providerConfig';
 import { t } from 'i18n';
 
+import type { ScopedResource } from 'services/capability/scopeState';
 import type { ProviderPermissions } from '@courthive/provider-config';
 
 /** Which layer refused. Ordered most-specific-first, as the resolver evaluates. */
-export type CapabilityLayer = 'tournamentState' | 'role' | 'provider';
+export type CapabilityLayer = 'tournamentState' | 'scope' | 'role' | 'provider';
 
 export type Capability = { allowed: true } | { allowed: false; reason: string; because: CapabilityLayer };
 
@@ -131,4 +133,37 @@ export function cannot(action: CapabilityAction): boolean {
 export function denialReason(action: CapabilityAction): string | undefined {
   const result = can(action);
   return result.allowed ? undefined : result.reason;
+}
+
+/**
+ * May the current user perform `action` **on this particular resource**?
+ *
+ * The scoped answer. `can()` asks whether the capability exists at all; this
+ * additionally asks whether the user's grants reach this matchUp, court, day or
+ * draw — the distinction a global boolean cannot make between scoring on
+ * Court 7 and scoring the final on Centre.
+ *
+ * Scope is evaluated only after the unscoped layers pass, so the reason a user
+ * sees is the most specific true one: "your provider does not allow scoring"
+ * outranks "not on your court" when both hold.
+ *
+ * A subject holding no grants is unrestricted here, which makes this safe to
+ * call everywhere — it is a no-op until someone is actually scoped.
+ */
+export function canForResource(action: CapabilityAction, resource: ScopedResource): Capability {
+  const unscoped = can(action);
+  if (!unscoped.allowed) return unscoped;
+
+  if (isPermittedOnResource(ACTION_PERMISSION[action], resource)) return ALLOWED;
+
+  return {
+    allowed: false,
+    because: 'scope',
+    reason: t('capability.outOfScope', { defaultValue: t('capability.denied.provider') }),
+  };
+}
+
+/** Convenience for `hide:` / `disabled:` call sites that act on a resource. */
+export function cannotForResource(action: CapabilityAction, resource: ScopedResource): boolean {
+  return !canForResource(action, resource).allowed;
 }

--- a/src/services/capability/scopeState.test.ts
+++ b/src/services/capability/scopeState.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearCallerGrants,
+  isPermittedOnResource,
+  isResourceInScope,
+  isScopeUnrestricted,
+  setCallerGrants,
+} from './scopeState';
+import { canForResource, cannotForResource, can } from './can';
+import { providerConfig } from 'config/providerConfig';
+
+const COURT_7 = { capability: 'canEnterScores', scope: { courtIds: ['court-7'] } };
+
+describe('scope state', () => {
+  beforeEach(() => {
+    providerConfig.reset();
+    clearCallerGrants();
+  });
+  afterEach(() => clearCallerGrants());
+
+  it('is unrestricted with no grants — not restricted to nothing', () => {
+    expect(isScopeUnrestricted()).toBe(true);
+    expect(isPermittedOnResource('canEnterScores', { courtId: 'centre' })).toBe(true);
+  });
+
+  describe('isResourceInScope mirrors the server predicate', () => {
+    it('treats an empty scope as tournament-wide', () => {
+      expect(isResourceInScope({}, { courtId: 'centre' })).toBe(true);
+      expect(isResourceInScope(undefined, {})).toBe(true);
+    });
+
+    it('matches a declared dimension', () => {
+      expect(isResourceInScope({ courtIds: ['c1'] }, { courtId: 'c1' })).toBe(true);
+      expect(isResourceInScope({ courtIds: ['c1'] }, { courtId: 'c2' })).toBe(false);
+    });
+
+    it('denies a resource that cannot answer the dimension', () => {
+      expect(isResourceInScope({ courtIds: ['c1'] }, {})).toBe(false);
+    });
+
+    it('requires every declared dimension', () => {
+      const scope = { courtIds: ['c1'], scheduledDates: ['2026-08-24'] };
+      expect(isResourceInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-24' })).toBe(true);
+      expect(isResourceInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-25' })).toBe(false);
+    });
+
+    it('refuses a scope with an unrecognized key rather than ignoring it', () => {
+      expect(isResourceInScope({ somethingNew: ['x'] } as any, { courtId: 'c1' })).toBe(false);
+    });
+  });
+
+  describe('capability bounds the grant', () => {
+    it('does not let a scoring grant authorize scheduling', () => {
+      setCallerGrants([COURT_7]);
+      expect(isPermittedOnResource('canEnterScores', { courtId: 'court-7' })).toBe(true);
+      expect(isPermittedOnResource('canModifySchedule', { courtId: 'court-7' })).toBe(false);
+    });
+
+    it('honors the wildcard', () => {
+      setCallerGrants([{ capability: '*', scope: { courtIds: ['court-7'] } }]);
+      expect(isPermittedOnResource('canModifySchedule', { courtId: 'court-7' })).toBe(true);
+      expect(isPermittedOnResource('canModifySchedule', { courtId: 'centre' })).toBe(false);
+    });
+  });
+});
+
+describe('canForResource', () => {
+  beforeEach(() => {
+    providerConfig.reset();
+    clearCallerGrants();
+  });
+  afterEach(() => clearCallerGrants());
+
+  // The distinction a global boolean cannot make.
+  it('permits scoring on the granted court and refuses the final on Centre', () => {
+    setCallerGrants([COURT_7]);
+    expect(canForResource('enterScores', { courtId: 'court-7' }).allowed).toBe(true);
+
+    const denied = canForResource('enterScores', { courtId: 'centre' });
+    expect(denied.allowed).toBe(false);
+    if (!denied.allowed) {
+      expect(denied.because).toBe('scope');
+      expect(denied.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  // The most specific true reason wins: a provider that forbids scoring
+  // outright is a better explanation than "not on your court".
+  it('reports the provider layer when the capability does not exist at all', () => {
+    providerConfig.set({ permissions: { canEnterScores: false } });
+    setCallerGrants([COURT_7]);
+    const denied = canForResource('enterScores', { courtId: 'court-7' });
+    expect(denied.allowed).toBe(false);
+    if (!denied.allowed) expect(denied.because).toBe('provider');
+  });
+
+  it('is a no-op when the subject holds no grants', () => {
+    expect(canForResource('enterScores', { courtId: 'centre' })).toEqual({ allowed: true });
+    expect(can('enterScores')).toEqual({ allowed: true });
+  });
+
+  it('cannotForResource is the negation, for hide/disabled call sites', () => {
+    setCallerGrants([COURT_7]);
+    expect(cannotForResource('enterScores', { courtId: 'centre' })).toBe(true);
+    expect(cannotForResource('enterScores', { courtId: 'court-7' })).toBe(false);
+  });
+
+  it('re-evaluates when grants change rather than caching the decision', () => {
+    setCallerGrants([COURT_7]);
+    expect(cannotForResource('enterScores', { courtId: 'centre' })).toBe(true);
+    clearCallerGrants();
+    expect(cannotForResource('enterScores', { courtId: 'centre' })).toBe(false);
+  });
+});

--- a/src/services/capability/scopeState.ts
+++ b/src/services/capability/scopeState.ts
@@ -1,0 +1,142 @@
+/**
+ * The caller's scoped grants for the loaded tournament, and the mask built from
+ * them.
+ *
+ * ## Cache the index, never the decision
+ *
+ * Grants are stored as a **fact** and the mask is derived from them; the
+ * resource is still evaluated on every call. A cached decision goes stale when
+ * the posture changes, whereas a mask keyed on the grant set cannot — which is
+ * what lets this be called inside a Tabulator cell formatter without recomputing
+ * anything per row.
+ *
+ * ## Empty means unrestricted
+ *
+ * No grants is NOT "restricted to nothing". It means this subject holds no
+ * scoped grants and is unrestricted by this mechanism — the same conclusion the
+ * server gate reaches, and the same thing `/factory/my-grants` returns when the
+ * grants table has not been migrated yet.
+ *
+ * ## This mirrors server logic, deliberately and temporarily
+ *
+ * `isResourceInScope` reimplements `grantScope.ts` in
+ * competition-factory-server. Two copies of one predicate is exactly the
+ * divergence risk the ecosystem standards warn about, and the correct home is
+ * `@courthive/provider-config`, which both repos already import — the same
+ * argument that put `MUTATION_PERMISSIONS` there. That extraction is deliberately
+ * NOT bundled here: it is a publish cascade across six consumers, and this
+ * module is written to make the move mechanical. Until then the server remains
+ * authoritative; the worst a divergence causes is a control offered and then
+ * refused, never one wrongly permitted.
+ */
+import type { ProviderPermissions } from '@courthive/provider-config';
+
+/** Scope dimensions — must match SCOPE_KEYS in the server's grantScope.ts. */
+export const SCOPE_KEYS = [
+  'eventIds',
+  'drawIds',
+  'structureIds',
+  'venueIds',
+  'courtIds',
+  'scheduledDates',
+  'matchUpIds',
+] as const;
+
+export type ScopeKey = (typeof SCOPE_KEYS)[number];
+export type GrantScope = Partial<Record<ScopeKey, string[]>>;
+
+export type CallerGrant = {
+  /** A ProviderPermissions key, or '*' for a full grant narrowed only by scope. */
+  capability: string;
+  scope: GrantScope;
+};
+
+/** The resource a UI control would act on. */
+export type ScopedResource = {
+  matchUpId?: string;
+  courtId?: string;
+  scheduledDate?: string;
+  eventId?: string;
+  drawId?: string;
+  structureId?: string;
+  venueId?: string;
+};
+
+const RESOURCE_TO_SCOPE: Record<keyof ScopedResource, ScopeKey> = {
+  matchUpId: 'matchUpIds',
+  courtId: 'courtIds',
+  scheduledDate: 'scheduledDates',
+  eventId: 'eventIds',
+  drawId: 'drawIds',
+  structureId: 'structureIds',
+  venueId: 'venueIds',
+};
+
+const SCOPE_KEY_SET: ReadonlySet<string> = new Set(SCOPE_KEYS);
+
+let grants: CallerGrant[] = [];
+let version = 0;
+
+export function setCallerGrants(next: CallerGrant[] | undefined): void {
+  grants = Array.isArray(next) ? next : [];
+  version += 1;
+}
+
+export function getCallerGrants(): readonly CallerGrant[] {
+  return grants;
+}
+
+/** True when this subject holds no scoped grants — i.e. unrestricted. */
+export function isScopeUnrestricted(): boolean {
+  return grants.length === 0;
+}
+
+export function scopeVersion(): number {
+  return version;
+}
+
+export function clearCallerGrants(): void {
+  setCallerGrants([]);
+}
+
+/** Does a grant's capability cover this permission key? */
+export function grantCoversCapability(capability: string, key: keyof ProviderPermissions): boolean {
+  return capability === '*' || capability === key;
+}
+
+/**
+ * Does `resource` fall inside `scope`?
+ *
+ * Every declared dimension must match. A dimension the resource cannot answer is
+ * a **deny** — an unscheduled matchUp is not on Court 7 — and a scope carrying
+ * an unrecognized key is refused rather than ignored. Both mirror the server.
+ */
+export function isResourceInScope(scope: GrantScope | undefined, resource: ScopedResource): boolean {
+  if (!scope || !Object.keys(scope).length) return true; // tournament-wide
+  if (!Object.keys(scope).every((key) => SCOPE_KEY_SET.has(key))) return false;
+
+  for (const [key, allowed] of Object.entries(scope) as [ScopeKey, string[]][]) {
+    if (!Array.isArray(allowed) || !allowed.length) continue;
+    const field = (Object.keys(RESOURCE_TO_SCOPE) as (keyof ScopedResource)[]).find(
+      (name) => RESOURCE_TO_SCOPE[name] === key,
+    );
+    const value = field ? resource[field] : undefined;
+    if (!value) return false;
+    if (!allowed.includes(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * May the caller exercise `key` on `resource`?
+ *
+ * Unrestricted when no grants are held. Otherwise at least one grant must cover
+ * both the capability and the resource — holding a Court-7 scoring grant is a
+ * statement about where you may score, so anywhere else is refused.
+ */
+export function isPermittedOnResource(key: keyof ProviderPermissions, resource: ScopedResource): boolean {
+  if (isScopeUnrestricted()) return true;
+  return grants.some(
+    (grant) => grantCoversCapability(grant.capability, key) && isResourceInScope(grant.scope, resource),
+  );
+}


### PR DESCRIPTION
The client half of **P4b**, consuming `POST /factory/my-grants` (CFS #923).

`can()` asks whether a capability exists at all. `canForResource()` additionally asks whether the user's grants reach **this** matchUp, court, day or draw — the distinction a global boolean cannot make between scoring on Court 7 and scoring the final on Centre.

## Cache the index, never the decision

Grants are held as a **fact**; the resource is evaluated on every call. A cached decision goes stale when the posture changes, whereas a mask keyed on the grant set cannot — which is what makes this safe to call inside a Tabulator cell formatter.

## The most specific true reason wins

Scope is evaluated only after the unscoped layers pass. A provider that forbids scoring outright is a better explanation than *"not on your court"*, and there's a test for that ordering.

## Empty means unrestricted

Holding no grants is **not** "restricted to nothing" — it's the same conclusion the server gate reaches, and what the endpoint returns when the grants table hasn't been migrated yet. That makes this safe to call everywhere: a no-op until someone is actually scoped.

## Known duplication, stated rather than hidden

`isResourceInScope` reimplements `grantScope.ts` in competition-factory-server. **Two copies of one predicate is exactly the divergence risk the standards warn about**, and the correct home is `@courthive/provider-config`, which both repos already import — the same argument that put `MUTATION_PERMISSIONS` there.

That extraction is deliberately *not* bundled here: it's a publish cascade across six consumers, and this module is written to make the move mechanical. Until then the server stays authoritative, so the worst a divergence causes is a control offered and then refused — **never one wrongly permitted**.

I'd take that extraction as the next follow-up.

## Scope of this PR

**No call sites adopt this yet** — `matchUpActions.ts` is held by the `participants-workstream-polish` claim. This ships the resolver and mask so adoption is a clean, separate change.

## Verification

Every gate in its **CI invocation**: `pnpm lint` · `attr-audit --ci` · `i18n-audit --ci` · `format:check` · `check-types` — all exit 0 · **1466 tests in 136 files**

`attr-audit` flagged `scope` as a near-miss for `score` (x134). Intentional; joins the allow list beside `preset`, `patch`, `scheduler`.