### PR TITLE
refactor(capability): use the shared scoped-grant predicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "yargs": "18.1.0"
   },
   "dependencies": {
-    "@courthive/provider-config": "0.17.0",
+    "@courthive/provider-config": "0.18.0",
     "@courthive/scoring-visualizations": "^0.2.9",
     "@eslint/js": "^10.0.1",
     "animate.css": "4.1.1",

--- a/src/services/capability/can.ts
+++ b/src/services/capability/can.ts
@@ -37,7 +37,7 @@ import { isPermittedOnResource } from 'services/capability/scopeState';
 import { providerConfig } from 'config/providerConfig';
 import { t } from 'i18n';
 
-import type { ScopedResource } from 'services/capability/scopeState';
+import type { ScopeTarget } from 'services/capability/scopeState';
 import type { ProviderPermissions } from '@courthive/provider-config';
 
 /** Which layer refused. Ordered most-specific-first, as the resolver evaluates. */
@@ -150,7 +150,7 @@ export function denialReason(action: CapabilityAction): string | undefined {
  * A subject holding no grants is unrestricted here, which makes this safe to
  * call everywhere — it is a no-op until someone is actually scoped.
  */
-export function canForResource(action: CapabilityAction, resource: ScopedResource): Capability {
+export function canForResource(action: CapabilityAction, resource: ScopeTarget): Capability {
   const unscoped = can(action);
   if (!unscoped.allowed) return unscoped;
 
@@ -164,6 +164,6 @@ export function canForResource(action: CapabilityAction, resource: ScopedResourc
 }
 
 /** Convenience for `hide:` / `disabled:` call sites that act on a resource. */
-export function cannotForResource(action: CapabilityAction, resource: ScopedResource): boolean {
+export function cannotForResource(action: CapabilityAction, resource: ScopeTarget): boolean {
   return !canForResource(action, resource).allowed;
 }

--- a/src/services/capability/scopeState.test.ts
+++ b/src/services/capability/scopeState.test.ts
@@ -1,12 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import {
-  clearCallerGrants,
-  isPermittedOnResource,
-  isResourceInScope,
-  isScopeUnrestricted,
-  setCallerGrants,
-} from './scopeState';
+import { clearCallerGrants, isPermittedOnResource, isScopeUnrestricted, setCallerGrants } from './scopeState';
+import { isTargetInScope } from '@courthive/provider-config';
 import { canForResource, cannotForResource, can } from './can';
 import { providerConfig } from 'config/providerConfig';
 
@@ -24,29 +19,29 @@ describe('scope state', () => {
     expect(isPermittedOnResource('canEnterScores', { courtId: 'centre' })).toBe(true);
   });
 
-  describe('isResourceInScope mirrors the server predicate', () => {
+  describe('isTargetInScope — now the shared predicate, no longer mirrored', () => {
     it('treats an empty scope as tournament-wide', () => {
-      expect(isResourceInScope({}, { courtId: 'centre' })).toBe(true);
-      expect(isResourceInScope(undefined, {})).toBe(true);
+      expect(isTargetInScope({}, { courtId: 'centre' })).toBe(true);
+      expect(isTargetInScope(undefined, {})).toBe(true);
     });
 
     it('matches a declared dimension', () => {
-      expect(isResourceInScope({ courtIds: ['c1'] }, { courtId: 'c1' })).toBe(true);
-      expect(isResourceInScope({ courtIds: ['c1'] }, { courtId: 'c2' })).toBe(false);
+      expect(isTargetInScope({ courtIds: ['c1'] }, { courtId: 'c1' })).toBe(true);
+      expect(isTargetInScope({ courtIds: ['c1'] }, { courtId: 'c2' })).toBe(false);
     });
 
     it('denies a resource that cannot answer the dimension', () => {
-      expect(isResourceInScope({ courtIds: ['c1'] }, {})).toBe(false);
+      expect(isTargetInScope({ courtIds: ['c1'] }, {})).toBe(false);
     });
 
     it('requires every declared dimension', () => {
       const scope = { courtIds: ['c1'], scheduledDates: ['2026-08-24'] };
-      expect(isResourceInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-24' })).toBe(true);
-      expect(isResourceInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-25' })).toBe(false);
+      expect(isTargetInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-24' })).toBe(true);
+      expect(isTargetInScope(scope, { courtId: 'c1', scheduledDate: '2026-08-25' })).toBe(false);
     });
 
     it('refuses a scope with an unrecognized key rather than ignoring it', () => {
-      expect(isResourceInScope({ somethingNew: ['x'] } as any, { courtId: 'c1' })).toBe(false);
+      expect(isTargetInScope({ somethingNew: ['x'] } as any, { courtId: 'c1' })).toBe(false);
     });
   });
 

--- a/src/services/capability/scopeState.ts
+++ b/src/services/capability/scopeState.ts
@@ -29,50 +29,17 @@
  * authoritative; the worst a divergence causes is a control offered and then
  * refused, never one wrongly permitted.
  */
-import type { ProviderPermissions } from '@courthive/provider-config';
+import { grantCoversCapability, isTargetInScope } from '@courthive/provider-config';
 
-/** Scope dimensions — must match SCOPE_KEYS in the server's grantScope.ts. */
-export const SCOPE_KEYS = [
-  'eventIds',
-  'drawIds',
-  'structureIds',
-  'venueIds',
-  'courtIds',
-  'scheduledDates',
-  'matchUpIds',
-] as const;
+import type { GrantScope, ProviderPermissions, ScopeTarget } from '@courthive/provider-config';
 
-export type ScopeKey = (typeof SCOPE_KEYS)[number];
-export type GrantScope = Partial<Record<ScopeKey, string[]>>;
+export type { GrantScope, ScopeKey, ScopeTarget } from '@courthive/provider-config';
 
 export type CallerGrant = {
   /** A ProviderPermissions key, or '*' for a full grant narrowed only by scope. */
   capability: string;
   scope: GrantScope;
 };
-
-/** The resource a UI control would act on. */
-export type ScopedResource = {
-  matchUpId?: string;
-  courtId?: string;
-  scheduledDate?: string;
-  eventId?: string;
-  drawId?: string;
-  structureId?: string;
-  venueId?: string;
-};
-
-const RESOURCE_TO_SCOPE: Record<keyof ScopedResource, ScopeKey> = {
-  matchUpId: 'matchUpIds',
-  courtId: 'courtIds',
-  scheduledDate: 'scheduledDates',
-  eventId: 'eventIds',
-  drawId: 'drawIds',
-  structureId: 'structureIds',
-  venueId: 'venueIds',
-};
-
-const SCOPE_KEY_SET: ReadonlySet<string> = new Set(SCOPE_KEYS);
 
 let grants: CallerGrant[] = [];
 let version = 0;
@@ -99,34 +66,6 @@ export function clearCallerGrants(): void {
   setCallerGrants([]);
 }
 
-/** Does a grant's capability cover this permission key? */
-export function grantCoversCapability(capability: string, key: keyof ProviderPermissions): boolean {
-  return capability === '*' || capability === key;
-}
-
-/**
- * Does `resource` fall inside `scope`?
- *
- * Every declared dimension must match. A dimension the resource cannot answer is
- * a **deny** — an unscheduled matchUp is not on Court 7 — and a scope carrying
- * an unrecognized key is refused rather than ignored. Both mirror the server.
- */
-export function isResourceInScope(scope: GrantScope | undefined, resource: ScopedResource): boolean {
-  if (!scope || !Object.keys(scope).length) return true; // tournament-wide
-  if (!Object.keys(scope).every((key) => SCOPE_KEY_SET.has(key))) return false;
-
-  for (const [key, allowed] of Object.entries(scope) as [ScopeKey, string[]][]) {
-    if (!Array.isArray(allowed) || !allowed.length) continue;
-    const field = (Object.keys(RESOURCE_TO_SCOPE) as (keyof ScopedResource)[]).find(
-      (name) => RESOURCE_TO_SCOPE[name] === key,
-    );
-    const value = field ? resource[field] : undefined;
-    if (!value) return false;
-    if (!allowed.includes(value)) return false;
-  }
-  return true;
-}
-
 /**
  * May the caller exercise `key` on `resource`?
  *
@@ -134,9 +73,7 @@ export function isResourceInScope(scope: GrantScope | undefined, resource: Scope
  * both the capability and the resource — holding a Court-7 scoring grant is a
  * statement about where you may score, so anywhere else is refused.
  */
-export function isPermittedOnResource(key: keyof ProviderPermissions, resource: ScopedResource): boolean {
+export function isPermittedOnResource(key: keyof ProviderPermissions, resource: ScopeTarget): boolean {
   if (isScopeUnrestricted()) return true;
-  return grants.some(
-    (grant) => grantCoversCapability(grant.capability, key) && isResourceInScope(grant.scope, resource),
-  );
+  return grants.some((grant) => grantCoversCapability(grant.capability, key) && isTargetInScope(grant.scope, resource));
 }


### PR DESCRIPTION
Completes the extraction agreed with CA. Deletes TMX's copy of the scope predicate in favour of `@courthive/provider-config@0.18.0` (provider-config #78, CFS #924).

The server enforces scope and this client shapes its UI to match. **Two implementations of one predicate would drift**, and a drift means TMX offers a control the server then refuses.

`scopeState` keeps what is genuinely client-side — the grant store, the unrestricted check, the version counter — and delegates every predicate. The shared `ScopeTarget` replaces the local `ScopedResource`, which named the same thing.

The tests now import `isTargetInScope` **from the package** rather than locally, so they exercise the shared implementation rather than a copy that could quietly agree with a stale local one.

## Verification

Every gate in its CI invocation: `pnpm lint` · `attr-audit --ci` · `i18n-audit --ci` · `format:check` · `check-types` — all exit 0 · **1467 tests in 136 files**

Confirmed no local predicate remains: zero matches for a local `SCOPE_KEYS` or `isTargetInScope` definition in `scopeState.ts`.

Next, per CA: the grant-management API in AMS, entered from the tournament Actions panel.