### PR TITLE
fix(schedule): correct five fail-open defects in participant rest

### DIFF
--- a/e2e/journeys/106-schedule2-inspector-actions.spec.ts
+++ b/e2e/journeys/106-schedule2-inspector-actions.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { todayLocal } from '../helpers/dates';
+import { TournamentPage } from '../pages/TournamentPage';
+
+/**
+ * Journey 106 — Schedule2 Inspector actions popover.
+ *
+ * The catalog cannot host this menu and that is the reason the Inspector does.
+ * Catalog cards are natively `draggable`, so a press competes with drag
+ * initiation, and the catalog rebuilds every card on every state change, which
+ * orphans anything anchored to one. The Inspector has one stable target per
+ * selection.
+ *
+ * Seeded as **DOUBLES** deliberately. The offerable-participants rule is the
+ * only real decision in this feature — a pair must expand to its two players,
+ * because the side label ("Smith/Jones") is neither of them and opens neither
+ * card. A singles seed would pass whether or not that expansion works, which is
+ * exactly the vacuous-probe shape: the assertion has to be able to fail.
+ *
+ * The popover's DOM half has no unit coverage — TMX runs vitest without a DOM —
+ * so this journey is the only evidence it renders at all.
+ */
+
+const SCHEDULE_DATE = todayLocal();
+
+const INSPECTOR = '[data-panel="inspector"]';
+const CATALOG_PANEL = '[data-panel="catalog"]';
+const UNSCHEDULED_TAB = 'button[data-sidebar-tab="unscheduled"]';
+const CARD = '.spl-matchup-card';
+const ACTIONS = '.tmx-inspector-actions';
+const TRIGGER = '.tmx-inspector-actions-trigger';
+const MENU = '.tmx-inspector-actions-menu';
+const ACTION_ROW = '.tmx-inspector-action-row';
+// `cModal` (courthive-components) is the participant profile's host, not the
+// unrelated `#tmxModal`. Assert on the DIALOG, not the outer `.chc-modal`
+// section: `.chc-modal-container` is `position: fixed`, so the section collapses
+// to zero height and reads as hidden even while the modal is plainly on screen.
+const MODAL = '.chc-modal-dialog';
+
+type Seed = { tournamentId: string; matchUpId: string; individualNames: string[]; pairName: string };
+
+/**
+ * A doubles draw with a single unscheduled R1 matchUp identified, plus the four
+ * individual names the popover must offer and the pair label it must NOT.
+ *
+ * Throws rather than falling back if the sides are not hydrated with their
+ * members — a seed that stopped producing them would leave the central
+ * assertion checking an empty list and passing.
+ */
+async function seedDoubles(page: import('@playwright/test').Page): Promise<Seed> {
+  return page.evaluate(
+    async ({ date }) => {
+      await dev.tmx2db.initDB();
+
+      const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+        nonRandom: 1,
+        setState: true,
+        tournamentName: 'E2E Inspector Actions',
+        tournamentAttributes: { tournamentId: 'e2e-inspector-actions', startDate: date, endDate: date },
+        drawProfiles: [{ eventName: 'Doubles', drawSize: 8, eventType: 'DOUBLES', drawType: 'SINGLE_ELIMINATION' }],
+        venueProfiles: [{ courtsCount: 2, venueName: 'Actions Venue' }],
+      });
+
+      const matchUps = dev.factory.competitionEngine.allTournamentMatchUps({ inContext: true }).matchUps || [];
+      const target = matchUps.find(
+        (m: any) =>
+          m.roundNumber === 1 &&
+          m.matchUpStatus !== 'BYE' &&
+          (m.sides || []).every((s: any) => s.participant?.individualParticipants?.length === 2),
+      );
+      if (!target) throw new Error('seed produced no doubles matchUp with hydrated pair members');
+
+      const individualNames = (target.sides || []).flatMap((s: any) =>
+        (s.participant.individualParticipants || []).map((i: any) => i.participantName),
+      );
+      const pairName = target.sides[0].participant.participantName;
+
+      await dev.tmx2db.addTournament(dev.factory.tournamentEngine.getTournament().tournamentRecord);
+
+      return {
+        tournamentId: tournamentRecord.tournamentId as string,
+        matchUpId: target.matchUpId as string,
+        individualNames: individualNames as string[],
+        pairName: pairName as string,
+      };
+    },
+    { date: SCHEDULE_DATE },
+  );
+}
+
+test.describe('Journey 106 — Schedule2 Inspector actions', () => {
+  let seed: Seed;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    seed = await seedDoubles(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(seed.tournamentId);
+    await tournament.navigateToScheduling();
+    await page.locator(UNSCHEDULED_TAB).click();
+    await page.locator(CATALOG_PANEL).waitFor({ state: 'visible', timeout: 10_000 });
+    await page.locator(`${CARD}[data-matchup-id="${seed.matchUpId}"]`).click();
+  });
+
+  test('the actions block is a SIBLING of the rest section, not a child of it', async ({ page }) => {
+    // The structural guarantee behind the whole design: the rest section calls
+    // replaceChildren() on itself every 30 seconds, which would destroy an open
+    // popover mid-interaction. Asserted structurally because waiting out a
+    // 30-second tick in a journey would be both slow and flaky.
+    await expect(page.locator(`${INSPECTOR} ${ACTIONS}`)).toBeVisible();
+    await expect(page.locator(`${INSPECTOR} .tmx-rest ${ACTIONS}`)).toHaveCount(0);
+  });
+
+  test('the trigger opens a popover offering the draw and every individual', async ({ page }) => {
+    await page.locator(`${INSPECTOR} ${TRIGGER}`).click();
+
+    const menu = page.locator(MENU);
+    await expect(menu).toBeVisible();
+    await expect(menu.locator(ACTION_ROW)).toHaveCount(seed.individualNames.length + 1);
+
+    const labels = await menu.locator(ACTION_ROW).evaluateAll((els) => els.map((el) => el.textContent?.trim()));
+    for (const name of seed.individualNames) expect(labels).toContain(name);
+
+    // The control: the pair label is not a person and opens no card, so it must
+    // NOT appear. Without this the test would pass on a side-label expansion.
+    expect(labels).not.toContain(seed.pairName);
+  });
+
+  test('choosing a participant opens their card and dismisses the popover', async ({ page }) => {
+    await page.locator(`${INSPECTOR} ${TRIGGER}`).click();
+    await page.locator(MENU).getByText(seed.individualNames[0], { exact: true }).click();
+
+    await expect(page.locator(MODAL)).toBeVisible();
+    await expect(page.locator(MODAL)).toContainText(seed.individualNames[0]);
+    await expect(page.locator(MENU)).toHaveCount(0);
+  });
+
+  test('choosing the draw navigates to the structure view', async ({ page }) => {
+    await page.locator(`${INSPECTOR} ${TRIGGER}`).click();
+    await page.locator(`${MENU} ${ACTION_ROW}`).first().click();
+
+    await expect(page).toHaveURL(/\/event\/[^/]+\/draw\//);
+    await expect(page.locator(MENU)).toHaveCount(0);
+  });
+
+  test('no unresolved i18n key reaches the operator', async ({ page }) => {
+    await page.locator(`${INSPECTOR} ${TRIGGER}`).click();
+
+    const text = (await page.locator(MENU).innerText()).trim();
+    expect(text).not.toBe('');
+    // `t()` echoes its key when it resolves to nothing; a dotted path in
+    // rendered copy is the signature.
+    expect(text).not.toMatch(/schedule\.inspector\.actions/);
+    expect(text).not.toContain('{{');
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -964,10 +964,13 @@
       "rest": {
         "onCourt": "on court",
         "none": "no prior match",
+        "unknown": "rest unknown",
         "limit": "#{{ordinal}}",
         "tooltipRest": "{{name}} — {{rested}} rested of {{required}} required",
         "tooltipOnCourt": "{{name}} — still on court",
-        "tooltipNone": "{{name}} — no prior match today"
+        "tooltipOnCourtOverrun": "{{name}} — still on court, past the expected finish",
+        "tooltipNone": "{{name}} — no prior match today",
+        "tooltipUnknown": "{{name}} — prior match has no recorded finish"
       }
     },
     "inspector": {
@@ -991,6 +994,11 @@
           "unknownMatchUp": "This matchUp is no longer in the tournament."
         }
       },
+      "actions": {
+        "trigger": "MatchUp actions",
+        "viewDraw": "View draw",
+        "participants": "Participants"
+      },
       "rest": {
         "heading": "Rest",
         "hoursMinutes": "{{hours}}h {{minutes}}m",
@@ -999,6 +1007,8 @@
         "resting": "{{rested}} of {{required}} — ready {{time}}",
         "onCourt": "On court now",
         "onCourtUntil": "On court now — ready {{time}}",
+        "onCourtOverrun": "On court now — past the expected finish",
+        "anchorUnreliable": "Prior match has no recorded finish — rest cannot be measured",
         "noPriorMatch": "No prior match today",
         "typeChange": "type change",
         "ordinal": "match #{{ordinal}} today",

--- a/src/pages/tournament/tabs/scheduleViews/inspectorActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorActions.ts
@@ -1,0 +1,146 @@
+/**
+ * Schedule2 — the Inspector's actions popover.
+ *
+ * The impure half of `inspectorActionsModel.ts`: builds the trigger, opens a
+ * tippy popover, and dispatches into TMX's existing navigation and participant
+ * surfaces. It decides nothing about *what* is offerable.
+ *
+ * ── Why this is anchored on the Inspector and not on the Rest section ──
+ *
+ * `inspectorRest.ts` drives a 30-second ticker that calls `replaceChildren()` on
+ * its own section so the rest figures keep counting up. Anything anchored inside
+ * that section is destroyed twice a minute — mid-interaction, with the popover
+ * open. This block is a sibling of the Rest section rather than a child of it,
+ * so it survives every tick and is rebuilt only when the Inspector's selection
+ * actually changes, which is exactly when a stale popover *should* close.
+ *
+ * The two destinations reuse what already exists rather than reimplementing
+ * navigation: `navigateToEvent` resolves the draw and structure from the matchUp
+ * and highlights it on arrival, and `participantProfileModal` is the same card
+ * the participants table opens.
+ */
+
+import { participantProfileModal } from 'components/modals/participantProfileModal';
+import { navigateToEvent } from 'components/tables/common/navigateToEvent';
+import { buildInspectorActionModel } from './inspectorActionsModel';
+import { getCachedAllMatchUps } from './schedule2DataCache';
+import tippy, { Instance as TippyInstance } from 'tippy.js';
+import { t } from 'i18n';
+
+// constants and types
+import type { InspectorActionModel, InspectorActionParticipant } from './inspectorActionsModel';
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+/** One clickable row in the popover. Shared shape so the draw row and the people read alike. */
+function actionRow(label: string, onClick: () => void, icon?: string): HTMLElement {
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'tmx-inspector-action-row';
+  if (icon) {
+    const glyph = document.createElement('i');
+    glyph.className = icon;
+    glyph.setAttribute('aria-hidden', 'true');
+    row.appendChild(glyph);
+  }
+  const text = document.createElement('span');
+  text.textContent = label;
+  row.appendChild(text);
+  row.addEventListener('click', onClick);
+  return row;
+}
+
+function heading(text: string): HTMLElement {
+  const element = document.createElement('div');
+  element.className = 'tmx-inspector-action-heading';
+  element.textContent = text;
+  return element;
+}
+
+/** The popover body: the draw destination, then every individual on the matchUp. */
+function buildContent(model: InspectorActionModel, requestClose: () => void): HTMLElement {
+  const content = document.createElement('div');
+  content.className = 'tmx-inspector-actions-menu';
+
+  content.appendChild(
+    actionRow(
+      t('schedule.inspector.actions.viewDraw'),
+      () => {
+        requestClose();
+        navigateToEvent({ eventId: model.eventId, matchUpId: model.matchUpId });
+      },
+      'fa-solid fa-sitemap',
+    ),
+  );
+
+  if (model.participants.length) {
+    content.appendChild(heading(t('schedule.inspector.actions.participants')));
+    for (const participant of model.participants) content.appendChild(participantRow(participant, requestClose));
+  }
+  return content;
+}
+
+function participantRow(participant: InspectorActionParticipant, requestClose: () => void): HTMLElement {
+  return actionRow(
+    participant.participantName,
+    () => {
+      requestClose();
+      participantProfileModal({ participantId: participant.participantId });
+    },
+    'fa-solid fa-id-card',
+  );
+}
+
+function openMenu(anchor: HTMLElement, model: InspectorActionModel): void {
+  // Forward-declared so a row can dismiss the popover before navigating; a
+  // popover left open across a route change lingers over the next page.
+  let tip: TippyInstance | null = null;
+  const content = buildContent(model, () => tip?.hide());
+
+  tip = tippy(anchor, {
+    content,
+    trigger: 'manual',
+    interactive: true,
+    placement: 'bottom-start',
+    theme: 'light-border',
+    appendTo: () => document.body,
+    onHidden: (instance) => instance.destroy(),
+  });
+  tip.show();
+}
+
+/**
+ * The Inspector's actions block for one matchUp. Returns a fresh element per
+ * call, matching the Inspector's rebuild-on-every-render contract, or null when
+ * the matchUp is no longer in the tournament.
+ */
+export function renderInspectorActions(matchUpId: string): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const { matchUps } = getCachedAllMatchUps();
+  const model = buildInspectorActionModel(matchUpId, (matchUps ?? []) as ReadinessMatchUp[]);
+  if (!model) return null;
+
+  const block = document.createElement('div');
+  block.className = 'tmx-inspector-actions';
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.className = 'tmx-inspector-actions-trigger';
+  trigger.title = t('schedule.inspector.actions.trigger');
+  trigger.dataset.matchUpId = matchUpId;
+
+  const glyph = document.createElement('i');
+  glyph.className = 'fa-solid fa-sitemap';
+  glyph.setAttribute('aria-hidden', 'true');
+  trigger.appendChild(glyph);
+
+  trigger.addEventListener('click', () => openMenu(trigger, model));
+  block.appendChild(trigger);
+
+  const label = document.createElement('span');
+  label.className = 'tmx-inspector-actions-label';
+  label.textContent = model.label;
+  block.appendChild(label);
+
+  return block;
+}

--- a/src/pages/tournament/tabs/scheduleViews/inspectorActionsModel.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorActionsModel.test.ts
@@ -1,0 +1,124 @@
+import { buildInspectorActionModel } from './inspectorActionsModel';
+import { describe, expect, it } from 'vitest';
+
+// constants and types
+import type { ReadinessMatchUp } from './matchUpReadiness';
+
+const EVENT_ID = 'e-1';
+const ALICE = 'p-alice';
+const ALICE_NAME = 'Alice Smith';
+const PAIR_1 = 'pair-1';
+const SMITH_JONES = 'Smith/Jones';
+
+function matchUp(overrides: Partial<ReadinessMatchUp> = {}): ReadinessMatchUp {
+  return { matchUpId: 'm-1', eventId: EVENT_ID, roundName: 'R16', ...overrides };
+}
+
+describe('buildInspectorActionModel — who the popover can open', () => {
+  it('returns undefined for a matchUp no longer in the tournament', () => {
+    expect(buildInspectorActionModel('m-gone', [matchUp()])).toBeUndefined();
+  });
+
+  it('offers both singles players, by their own names', () => {
+    const target = matchUp({
+      sides: [
+        { participantId: ALICE, participantName: ALICE_NAME },
+        { participantId: 'p-bob', participantName: 'Bob Jones' },
+      ],
+    });
+    const model = buildInspectorActionModel('m-1', [target]);
+    expect(model?.participants).toEqual([
+      { participantId: ALICE, participantName: ALICE_NAME },
+      { participantId: 'p-bob', participantName: 'Bob Jones' },
+    ]);
+    expect(model?.eventId).toBe(EVENT_ID);
+    expect(model?.label).toBe('R16: Alice Smith vs Bob Jones');
+  });
+
+  it('offers the four individuals of a doubles matchUp, never the pair name twice', () => {
+    const target = matchUp({
+      matchUpType: 'DOUBLES',
+      sides: [
+        {
+          participantId: PAIR_1,
+          participant: {
+            participantId: PAIR_1,
+            participantName: SMITH_JONES,
+            individualParticipants: [
+              { participantId: ALICE, participantName: ALICE_NAME },
+              { participantId: 'p-bob', participantName: 'Bob Jones' },
+            ],
+          },
+        },
+        {
+          participantId: 'pair-2',
+          participant: {
+            participantId: 'pair-2',
+            participantName: 'Chen/Dana',
+            individualParticipants: [
+              { participantId: 'p-chen', participantName: 'Chen Wu' },
+              { participantId: 'p-dana', participantName: 'Dana Reid' },
+            ],
+          },
+        },
+      ],
+    });
+    const model = buildInspectorActionModel('m-1', [target]);
+    expect(model?.participants.map((p) => p.participantId)).toEqual([ALICE, 'p-bob', 'p-chen', 'p-dana']);
+    expect(model?.participants.map((p) => p.participantName)).not.toContain(SMITH_JONES);
+  });
+
+  it('falls back to the side participant when a pair was not hydrated with its members', () => {
+    const target = matchUp({
+      sides: [{ participantId: PAIR_1, participant: { participantId: PAIR_1, participantName: SMITH_JONES } }],
+    });
+    expect(buildInspectorActionModel('m-1', [target])?.participants).toEqual([
+      { participantId: PAIR_1, participantName: SMITH_JONES },
+    ]);
+  });
+
+  it('offers nobody for a side that is still TBD, rather than a card that cannot open', () => {
+    const target = matchUp({ sides: [{ participantId: ALICE, participantName: ALICE_NAME }, {}] });
+    expect(buildInspectorActionModel('m-1', [target])?.participants).toEqual([
+      { participantId: ALICE, participantName: ALICE_NAME },
+    ]);
+  });
+
+  it('never offers the same individual twice', () => {
+    const target = matchUp({
+      sides: [
+        {
+          participantId: 'team-1',
+          participant: {
+            participantId: 'team-1',
+            individualParticipants: [
+              { participantId: ALICE, participantName: ALICE_NAME },
+              { participantId: ALICE, participantName: ALICE_NAME },
+            ],
+          },
+        },
+      ],
+    });
+    expect(buildInspectorActionModel('m-1', [target])?.participants).toHaveLength(1);
+  });
+});
+
+describe('buildInspectorActionModel — defensive fallbacks', () => {
+  it('falls back to the id when a hydrated member carries no name, rather than rendering blank', () => {
+    const target = matchUp({
+      sides: [
+        {
+          participantId: PAIR_1,
+          participant: { participantId: PAIR_1, individualParticipants: [{ participantId: ALICE }] },
+        },
+      ],
+    });
+    expect(buildInspectorActionModel('m-1', [target])?.participants).toEqual([
+      { participantId: ALICE, participantName: ALICE },
+    ]);
+  });
+
+  it('offers nobody for a matchUp with no sides at all', () => {
+    expect(buildInspectorActionModel('m-1', [matchUp()])?.participants).toEqual([]);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/inspectorActionsModel.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorActionsModel.ts
@@ -1,0 +1,86 @@
+/**
+ * Schedule2 — what the Inspector's actions popover can offer, as data.
+ *
+ * Pure and DOM-free, for the same reason `participantRest.ts` is: TMX runs its
+ * unit suite without a DOM, so a decision embedded in element construction gets
+ * no coverage at all. The rules about *which* participants are offerable — and
+ * what a side contributes when its players are not yet known — live here; the
+ * element assembly lives in `inspectorActions.ts`.
+ *
+ * The catalog cannot host this menu. Its cards are natively `draggable`, so a
+ * press-and-hold competes with drag initiation, and the catalog rebuilds every
+ * card on every state change, which orphans anything anchored to one. The
+ * Inspector has a single stable target per selection and is where the operator
+ * already is once they have chosen a matchUp.
+ */
+
+import { matchUpLabel } from './matchUpReadiness';
+
+// constants and types
+import type { ReadinessMatchUp, ReadinessSide } from './matchUpReadiness';
+
+export interface InspectorActionParticipant {
+  participantId: string;
+  participantName: string;
+}
+
+export interface InspectorActionModel {
+  matchUpId: string;
+  /** Needed by `navigateToEvent`, which resolves draw and structure from the matchUp. */
+  eventId?: string;
+  /** `R16: Alice Smith vs Bob Jones` — the popover's own heading. */
+  label: string;
+  /** Individuals whose participant card can be opened. Empty when the sides are still TBD. */
+  participants: InspectorActionParticipant[];
+}
+
+/**
+ * The individuals one side contributes.
+ *
+ * A hydrated pair or team carries `individualParticipants`, and those are the
+ * people a director wants to open — `nameFor` deliberately returns the *side*
+ * label, which would list one doubles pair's name twice and offer neither
+ * player. A side with no members falls back to the side participant itself
+ * (a singles player, or a pair whose members were not hydrated); a side with
+ * no participant at all is still TBD and contributes nothing, because there is
+ * no card to open.
+ */
+function sideParticipants(side: ReadinessSide): InspectorActionParticipant[] {
+  const members = side.participant?.individualParticipants ?? [];
+  const named = members
+    .filter((member) => member?.participantId)
+    .map((member) => ({
+      participantId: member.participantId as string,
+      participantName: member.participantName ?? (member.participantId as string),
+    }));
+  if (named.length) return named;
+
+  const participantId = side.participantId ?? side.participant?.participantId;
+  if (!participantId) return [];
+  return [
+    { participantId, participantName: side.participant?.participantName ?? side.participantName ?? participantId },
+  ];
+}
+
+/** The offerable actions for one matchUp, or undefined when it is no longer in the tournament. */
+export function buildInspectorActionModel(
+  matchUpId: string,
+  matchUps: ReadinessMatchUp[],
+): InspectorActionModel | undefined {
+  const matchUp = matchUps.find((candidate) => candidate.matchUpId === matchUpId);
+  if (!matchUp) return undefined;
+
+  // Deduped because a team event can carry the same individual on both the team
+  // side and its hydrated members, and offering one person twice reads as a bug.
+  const seen = new Set<string>();
+  const participants: InspectorActionParticipant[] = [];
+  for (const side of matchUp.sides ?? []) {
+    for (const participant of sideParticipants(side)) {
+      if (seen.has(participant.participantId)) continue;
+      seen.add(participant.participantId);
+      participants.push(participant);
+    }
+  }
+
+  return { matchUpId, eventId: matchUp.eventId, label: matchUpLabel(matchUp), participants };
+}

--- a/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorReadiness.ts
@@ -22,6 +22,7 @@
 
 import { makeTimingResolver } from './scheduleTimingResolver';
 import { analyzeMatchUpReadiness } from './matchUpReadiness';
+import { renderInspectorActions } from './inspectorActions';
 import { getCachedAllMatchUps } from './schedule2DataCache';
 import { renderRestSection } from './inspectorRest';
 import { t } from 'i18n';
@@ -121,6 +122,12 @@ export function renderInspectorSections(matchUpId: string, viewedDate: string | 
 
   const container = document.createElement('div');
   container.className = 'tmx-inspector-extra';
+
+  // Deliberately a SIBLING of the rest section rather than a child of it: the
+  // rest section replaces its own children every 30 seconds to keep the figures
+  // counting up, which would destroy an open popover mid-interaction.
+  const actions = renderInspectorActions(matchUpId);
+  if (actions) container.appendChild(actions);
 
   const rest = renderRestSection(matchUpId, viewedDate);
   if (rest) container.appendChild(rest);

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
@@ -1,8 +1,9 @@
-import { normalizeTimes, toDayMinutesFromClock, toDayMinutesFromInstant } from './inspectorRest';
+import { describeRest, normalizeTimes, toDayMinutesFromClock, toDayMinutesFromInstant } from './inspectorRest';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
 import type { ReadinessMatchUp } from './matchUpReadiness';
+import type { RestRow } from './participantRest';
 
 const DATE = '2026-08-22';
 
@@ -122,5 +123,34 @@ describe('normalizeTimes', () => {
   it('yields nothing usable for a matchUp with no schedule at all', () => {
     const result = normalizeTimes({ matchUpId: 'm1', schedule: null }, DATE);
     expect(Object.values(result).every((value) => value === undefined)).toBe(true);
+  });
+});
+
+// ── Regressions: rendering for the states added on 2026-08-23 ────────────────
+
+describe('describeRest — states that carry no measurable interval', () => {
+  const base = {
+    participantId: 'p1',
+    participantName: 'Alice',
+    requiredMinutes: 60,
+    typeChange: false,
+    load: { singles: 1, doubles: 0, total: 1, ordinal: 2, atLimit: [] },
+  };
+
+  it('never emits a dangling "ready" with no time when the anchor is unreliable', () => {
+    const text = describeRest({ ...base, status: 'resting', restMinutes: 0, anchorUnreliable: true } as RestRow);
+    expect(text).not.toMatch(/ready\s*$/);
+    expect(text).not.toMatch(/\b0m\b/);
+  });
+
+  it('reports an overrunning match as past its expected finish, not as a time already gone by', () => {
+    const text = describeRest({ ...base, status: 'onCourt', overrun: true } as RestRow);
+    expect(text).not.toMatch(/\d{2}:\d{2}/);
+    expect(text).toMatch(/expected/i);
+  });
+
+  it('still names the projected finish while the match is inside its expected duration', () => {
+    const text = describeRest({ ...base, status: 'onCourt', readyAt: '16:00' } as RestRow);
+    expect(text).toMatch(/16:00/);
   });
 });

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -143,10 +143,14 @@ export function describeSource(row: RestRow): string {
 export function describeRest(row: RestRow): string {
   if (row.status === 'none') return t('schedule.inspector.rest.noPriorMatch');
   if (row.status === 'onCourt') {
+    if (row.overrun) return t('schedule.inspector.rest.onCourtOverrun');
     return row.readyAt
       ? t('schedule.inspector.rest.onCourtUntil', { time: row.readyAt })
       : t('schedule.inspector.rest.onCourt');
   }
+  // No interval can be measured from an anchor in the future, so say that rather
+  // than printing the zero the arithmetic produced.
+  if (row.anchorUnreliable) return t('schedule.inspector.rest.anchorUnreliable');
   const rested = formatDuration(row.restMinutes ?? 0);
   const required = formatDuration(row.requiredMinutes);
   if (row.status === 'rested') return t('schedule.inspector.rest.rested', { rested, required });
@@ -190,6 +194,8 @@ function buildRow(row: RestRow): HTMLElement {
   // A row whose anchor was inferred rather than recorded must say so structurally,
   // not only in prose, so the distinction survives styling and screen readers.
   if (row.source && row.source !== 'endTime') element.dataset.estimated = 'true';
+  if (row.anchorUnreliable) element.dataset.anchorUnreliable = 'true';
+  if (row.overrun) element.dataset.overrun = 'true';
   if (row.fromMatchUpLabel) element.title = row.fromMatchUpLabel;
   return element;
 }

--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
@@ -60,6 +60,12 @@ export interface ReadinessMatchUp {
   loserMatchUpId?: string;
   sides?: ReadinessSide[];
   schedule?: ReadinessSchedule | null;
+  /**
+   * Present once any score has been entered. Rest reads only whether it is
+   * populated: a DEFAULTED matchUp carrying sets was played and then defaulted,
+   * while a DEFAULTED matchUp with no score is a no-show who never took court.
+   */
+  score?: { sets?: unknown[]; scoreStringSide1?: string } | null;
 }
 
 export interface ReadinessSide {
@@ -69,6 +75,13 @@ export interface ReadinessSide {
     participantId?: string;
     participantName?: string;
     individualParticipantIds?: string[];
+    /**
+     * Hydrated members of a pair or team, present on `inContext` matchUps.
+     * `individualParticipantIds` carries the same identities without names, so
+     * anything that must *show* a person reads this and anything that only needs
+     * to compare identities reads the ids.
+     */
+    individualParticipants?: { participantId?: string; participantName?: string }[];
   };
 }
 

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
@@ -368,3 +368,353 @@ describe('analyzeParticipantRest — daily load', () => {
     expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({ total: 0, ordinal: 1 });
   });
 });
+
+// ── Regressions: five defects found by source read 2026-08-23 ────────────────
+// Every one of these fails open — it reports a player as freer than they are —
+// which is the direction that gets a tired player called to court.
+
+describe('a match that overruns its average duration still occupies the player', () => {
+  /**
+   * The original `isUnderWay` bounded "under way" at `start + averageMinutes`,
+   * so a 90-minute-average match still unscored at three hours was neither
+   * finished nor under way and was dropped from the analysis entirely. The
+   * player read "No prior match today" while standing on court.
+   */
+  const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
+  const running = singles({ id: 'm-running', ids: [ALICE, CHEN], scheduledTime: '10:00' });
+
+  it('reports onCourt three hours into a 90-minute-average match', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, running],
+          times: { 'm-running': { startMinutes: 600 } },
+          asOfMinutes: 780, // 13:00 — 180 minutes in, twice the 90-minute average
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice?.status).toBe('onCourt');
+    expect(alice?.fromMatchUpId).toBe('m-running');
+  });
+
+  it('withholds readyAt once the projected finish has already passed, rather than naming a time in the past', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, running],
+          times: { 'm-running': { startMinutes: 600 } },
+          asOfMinutes: 780,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice?.readyAt).toBeUndefined();
+    expect(alice?.overrun).toBe(true);
+  });
+
+  it('still projects readyAt while the match is inside its expected duration', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, running],
+          times: { 'm-running': { startMinutes: 600 } },
+          asOfMinutes: 660, // 11:00 — one hour in, still under the 90-minute average
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'onCourt', readyAt: '12:30' });
+    expect(alice?.overrun).toBeUndefined();
+  });
+});
+
+describe('a completed matchUp with no scheduledDate is dated by its scoredTime', () => {
+  /**
+   * Scores entered from the draw view leave no `schedule.scheduledDate`, so the
+   * day filter discarded them and the player read as unplayed. `scoredTime` is a
+   * full instant and already normalizes to minutes-from-viewed-midnight, so a
+   * stamp from another day lands outside `0..1439` and dates the match for free.
+   */
+  const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
+
+  function undated(id: string, ids: string[]): ReadinessMatchUp {
+    return { ...singles({ id, ids, status: 'COMPLETED', winningSide: 1 }), schedule: {} };
+  }
+
+  it('counts an undated completed match whose scoredTime falls on the viewed day', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, undated('m-undated', [ALICE, CHEN])],
+          times: { 'm-undated': { scoredMinutes: 700 } },
+          asOfMinutes: 800,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'rested', restMinutes: 100, source: 'scoredTime' });
+  });
+
+  it('does NOT count an undated match whose scoredTime belongs to another day', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, undated('m-yesterday', [ALICE, CHEN])],
+          times: { 'm-yesterday': { scoredMinutes: -220 } }, // 20:20 the previous evening
+          asOfMinutes: 800,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.status).toBe('none');
+  });
+
+  it('does NOT count an undated match that cannot be dated at all', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, undated('m-nodate', [ALICE, CHEN])],
+          times: { 'm-nodate': { startMinutes: 600 } },
+          asOfMinutes: 800,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.status).toBe('none');
+  });
+});
+
+describe('a walkover is not a match played', () => {
+  const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
+
+  function priorWith(status: string, score?: Record<string, unknown>): ReadinessMatchUp {
+    return { ...singles({ id: 'm-prior', ids: [ALICE, CHEN], status, winningSide: 1 }), score };
+  }
+
+  it.each(['WALKOVER', 'DOUBLE_WALKOVER'])('charges no recovery for a %s', (status) => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, priorWith(status)],
+          times: { 'm-prior': { endMinutes: 700 } },
+          asOfMinutes: 720,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice?.status).toBe('none');
+    expect(alice?.load.ordinal).toBe(1);
+  });
+
+  it('charges no recovery for a DEFAULTED with no score — a no-show never took the court', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, priorWith('DEFAULTED')],
+          times: { 'm-prior': { endMinutes: 700 } },
+          asOfMinutes: 720,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.status).toBe('none');
+  });
+
+  it('DOES charge recovery for a DEFAULTED that carries a score — they played before being defaulted', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, priorWith('DEFAULTED', { sets: [{ side1Score: 6, side2Score: 4 }] })],
+          times: { 'm-prior': { endMinutes: 700 } },
+          asOfMinutes: 720,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 20 });
+  });
+
+  it('DOES charge recovery for a RETIRED — a retirement means they played', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, priorWith('RETIRED', { sets: [{ side1Score: 6, side2Score: 1 }] })],
+          times: { 'm-prior': { endMinutes: 700 } },
+          asOfMinutes: 720,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.status).toBe('resting');
+  });
+});
+
+describe('an anchor projected into the future is never read as rest already taken', () => {
+  /**
+   * A finished match with no recorded finish falls to `scheduledTime + average`,
+   * which can land after "now". `Math.max(0, …)` then produced `0m of 60m —
+   * ready 16:20` for a player who was not tired at all. Prefer an anchor that is
+   * actually in the past; when none exists, report zero rest rather than a
+   * fictional figure, and say the anchor is unreliable.
+   */
+  const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
+
+  it('prefers the latest anchor at or before now over a later one in the future', () => {
+    const early = singles({ id: 'm-early', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+    const future = singles({ id: 'm-future', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, early, future],
+          times: { 'm-early': { endMinutes: 600 }, 'm-future': { scheduledMinutes: 900 } },
+          asOfMinutes: 780, // 13:00; m-future projects to 16:30
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'rested', restMinutes: 180, fromMatchUpId: 'm-early' });
+  });
+
+  it('reports zero rest and flags the anchor when every anchor is in the future', () => {
+    const future = singles({ id: 'm-future', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, future],
+          times: { 'm-future': { scheduledMinutes: 900 } },
+          asOfMinutes: 780,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 0, anchorUnreliable: true });
+    expect(alice?.readyAt).toBeUndefined();
+  });
+});
+
+describe('rows are ordered by how far short of ready they are, not by side order', () => {
+  /**
+   * The badge takes the head of the worst band. Sorting by band alone left the
+   * within-band order as `individualIds` side order, so a doubles pair resting
+   * at 10m and 40m badged whichever happened to be listed first.
+   */
+  function doubles(id: string, pairs: string[][], overrides: Partial<ReadinessMatchUp> = {}): ReadinessMatchUp {
+    return {
+      matchUpId: id,
+      matchUpType: 'DOUBLES',
+      sides: pairs.map((individualParticipantIds, i) => ({
+        participantId: `pair-${id}-${i}`,
+        participant: { participantId: `pair-${id}-${i}`, individualParticipantIds },
+      })),
+      schedule: { scheduledDate: DATE },
+      ...overrides,
+    };
+  }
+
+  it('puts the participant furthest from ready first within the resting band', () => {
+    const target = doubles('m-next', [
+      [ALICE, BOB],
+      [CHEN, 'p-dana'],
+    ]);
+    const alicePrior = doubles(
+      'm-a',
+      [
+        [ALICE, 'p-x'],
+        ['p-y', 'p-z'],
+      ],
+      { matchUpStatus: 'COMPLETED', winningSide: 1 },
+    );
+    const bobPrior = doubles(
+      'm-b',
+      [
+        [BOB, 'p-x'],
+        ['p-y', 'p-z'],
+      ],
+      { matchUpStatus: 'COMPLETED', winningSide: 1 },
+    );
+
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, alicePrior, bobPrior],
+          // Alice finished at 12:00 (40m ago), Bob at 12:30 (10m ago) — Bob is worse off.
+          times: { 'm-a': { endMinutes: 720 }, 'm-b': { endMinutes: 750 } },
+          asOfMinutes: 760,
+        }),
+      ),
+    );
+    const resting = result.rows.filter((row) => row.status === 'resting');
+    expect(resting.map((row) => row.participantId)).toEqual([BOB, ALICE]);
+  });
+});
+
+describe('the DOUBLES daily limit, whose SINGLES twin was already covered', () => {
+  /** A doubles matchUp counted against `DOUBLES` rather than `SINGLES`, in its own right. */
+  function pair(id: string, individuals: string[], overrides: Partial<ReadinessMatchUp> = {}): ReadinessMatchUp {
+    return {
+      matchUpId: id,
+      matchUpType: 'DOUBLES',
+      sides: [
+        {
+          participantId: `pair-${id}`,
+          participant: { participantId: `pair-${id}`, individualParticipantIds: individuals },
+        },
+        {
+          participantId: `opp-${id}`,
+          participant: { participantId: `opp-${id}`, individualParticipantIds: ['p-x', 'p-y'] },
+        },
+      ],
+      schedule: { scheduledDate: DATE },
+      ...overrides,
+    };
+  }
+
+  it('flags a participant who would meet the DOUBLES limit', () => {
+    const target = pair('m-next', [ALICE, BOB]);
+    const played = pair('m-done', [ALICE, CHEN], { matchUpStatus: 'COMPLETED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, played],
+          times: { 'm-done': { endMinutes: 600 } },
+          asOfMinutes: 800,
+          dailyLimits: { DOUBLES: 2 },
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load).toMatchObject({
+      doubles: 1,
+      ordinal: 2,
+      atLimit: ['doubles'],
+      limit: 2,
+    });
+  });
+
+  it('does NOT flag a participant still below the DOUBLES limit', () => {
+    const target = pair('m-next', [ALICE, BOB]);
+    const played = pair('m-done', [ALICE, CHEN], { matchUpStatus: 'COMPLETED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, played],
+          times: { 'm-done': { endMinutes: 600 } },
+          asOfMinutes: 800,
+          dailyLimits: { DOUBLES: 3 },
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.load.atLimit).toEqual([]);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -136,6 +136,18 @@ export interface RestRow {
   typeChange: boolean;
   /** Clock time the requirement is met, `HH:MM`. Absent when already met or unprojectable. */
   readyAt?: string;
+  /**
+   * True when the participant is still on court past the point their format was
+   * expected to finish. The projected finish is now in the past, so `readyAt` is
+   * withheld rather than naming a time that has already gone by.
+   */
+  overrun?: boolean;
+  /**
+   * True when every anchor available for this participant projects into the
+   * future — the match is recorded as finished but nothing says when. Rest is
+   * reported as zero rather than guessed.
+   */
+  anchorUnreliable?: boolean;
   /** Which rung produced the anchor. Absent for `none`. */
   source?: RestSourceKind;
   /** The matchUp the rest is measured from. Absent for `none`. */
@@ -153,6 +165,47 @@ export type RestResult =
 const BYE = 'BYE';
 const DOUBLES = 'DOUBLES';
 const SINGLES = 'SINGLES';
+const MINUTES_PER_DAY = 1440;
+
+/**
+ * Statuses that advance a participant without their playing. A walkover costs no
+ * energy, so charging recovery for one holds a fresh player back — and counting
+ * it toward a daily match limit can block a player who has not played all day.
+ *
+ * `DEFAULTED` / `DOUBLE_DEFAULT` are deliberately absent: a default can be a
+ * no-show *or* a mid-match disqualification. The score tells them apart, so they
+ * are decided by `wasPlayed` rather than by status alone. `RETIRED` and
+ * `ABANDONED` are likewise absent — both mean time was spent on court.
+ */
+const UNPLAYED_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER']);
+const DEFAULT_STATUSES = new Set(['DEFAULTED', 'DOUBLE_DEFAULT']);
+
+/** True when this matchUp actually put the participants on court. */
+export function wasPlayed(matchUp: ReadinessMatchUp): boolean {
+  const status = matchUp.matchUpStatus;
+  if (status && UNPLAYED_STATUSES.has(status)) return false;
+  // A default with a score was played up to the point of the default; a default
+  // with no score is a no-show. Nothing else about the record distinguishes them.
+  if (status && DEFAULT_STATUSES.has(status)) return !!matchUp.score?.sets?.length;
+  return true;
+}
+
+/**
+ * Whether a matchUp belongs to the day being viewed.
+ *
+ * `scheduledDate` answers it outright when present. When it is absent — which is
+ * what a score entered from the draw view leaves behind — `scoredTime` still
+ * dates the match, because it arrives as a full instant already normalized to
+ * minutes from the viewed day's midnight: a stamp from another day lands outside
+ * `0..1439`. A matchUp with neither is genuinely undatable and is excluded, since
+ * counting it would be a guess about which day's rest it belongs to.
+ */
+export function occursOnViewedDay(matchUp: ReadinessMatchUp, times: NormalizedTimes, viewedDate: string): boolean {
+  const scheduledDate = matchUp.schedule?.scheduledDate;
+  if (scheduledDate) return scheduledDate === viewedDate;
+  const scored = times.scoredMinutes;
+  return scored !== undefined && scored >= 0 && scored < MINUTES_PER_DAY;
+}
 
 /** The ladder, strongest first. Order is the contract; the renderer reports which rung won. */
 const LADDER: { source: RestSourceKind; read: (times: NormalizedTimes) => number | undefined; projected: boolean }[] = [
@@ -182,12 +235,21 @@ export function resolveAnchor(times: NormalizedTimes, timing: RestTiming): Ancho
   return undefined;
 }
 
-/** True when the matchUp is under way at `asOfMinutes` — started (or due) and not yet finished. */
-function isUnderWay(matchUp: ReadinessMatchUp, times: NormalizedTimes, timing: RestTiming, asOfMinutes: number) {
+/**
+ * True when the matchUp is under way at `asOfMinutes` — started (or due) and not
+ * yet finished.
+ *
+ * Deliberately **unbounded above**. An earlier version closed the window at
+ * `start + averageMinutes`, which meant a match that ran long stopped counting as
+ * under way while remaining unfinished, so it was dropped from the analysis
+ * entirely and the player read as having no match today — while standing on
+ * court. `averageMinutes` is an estimate of a typical match; a match is over when
+ * a result says so, not when the estimate expires.
+ */
+function isUnderWay(matchUp: ReadinessMatchUp, times: NormalizedTimes, asOfMinutes: number) {
   if (isFinished(matchUp)) return false;
   const start = times.startMinutes ?? times.calledMinutes ?? times.scheduledMinutes;
-  if (start === undefined || start > asOfMinutes) return false;
-  return asOfMinutes < start + Math.max(timing.averageMinutes, 1);
+  return start !== undefined && start <= asOfMinutes;
 }
 
 /** Recovery owed after `prior`, accounting for a singles ↔ doubles change into `target`. */
@@ -227,11 +289,17 @@ function collectPriorMatchUps(target: ReadinessMatchUp, input: RestInput): Prior
   for (const matchUp of input.matchUps) {
     if (matchUp.matchUpId === target.matchUpId) continue;
     if (matchUp.matchUpStatus === BYE) continue;
-    if (matchUp.schedule?.scheduledDate !== input.scheduledDate) continue;
+    // A walkover is not load the director has spent — it neither tires a player
+    // nor consumes a slot against the daily limit.
+    if (!wasPlayed(matchUp)) continue;
 
+    // Times are resolved before the day test because an undated matchUp is dated
+    // by its `scoredTime`, which only exists in normalized form.
     const times = input.timesFor(matchUp);
+    if (!occursOnViewedDay(matchUp, times, input.scheduledDate)) continue;
+
     const timing = input.timingFor(matchUp);
-    const underWay = isUnderWay(matchUp, times, timing, input.asOfMinutes);
+    const underWay = isUnderWay(matchUp, times, input.asOfMinutes);
     if (!isFinished(matchUp) && !underWay) continue;
     results.push({ matchUp, times, timing, underWay, individuals: new Set(individualIds(matchUp)) });
   }
@@ -264,17 +332,46 @@ function loadFor(prior: PriorMatchUp[], target: ReadinessMatchUp, limits: RestDa
   return { singles, doubles, total, ordinal, atLimit, limit };
 }
 
-/** The most recent anchor across a participant's prior matchUps — "the last one that finished". */
+interface AnchoredPrior {
+  anchor: Anchor;
+  matchUp: ReadinessMatchUp;
+  timing: RestTiming;
+}
+
+/**
+ * The most recent anchor across a participant's prior matchUps — "the last one
+ * that finished".
+ *
+ * Anchors at or before `asOfMinutes` win outright, and only the latest of those
+ * is used. An anchor *after* now is not a finish that has happened: it comes from
+ * a projected rung (`scheduledTime + averageMinutes`) on a matchUp recorded as
+ * complete ahead of its slot. Treating one as a finish produced `0m of 60m` for a
+ * player who had not played, because the negative interval was clamped to zero.
+ *
+ * When every anchor is in the future the match still happened, so reporting "no
+ * prior match" would fail open. The caller is handed the earliest future anchor
+ * and told, via `unreliable`, that it cannot carry a rest figure.
+ */
 function latestAnchor(
   prior: PriorMatchUp[],
-): { anchor: Anchor; matchUp: ReadinessMatchUp; timing: RestTiming } | undefined {
-  let best: { anchor: Anchor; matchUp: ReadinessMatchUp; timing: RestTiming } | undefined;
+  asOfMinutes: number,
+): (AnchoredPrior & { unreliable: boolean }) | undefined {
+  let past: AnchoredPrior | undefined;
+  let future: AnchoredPrior | undefined;
+
   for (const entry of prior) {
     const anchor = resolveAnchor(entry.times, entry.timing);
     if (!anchor) continue;
-    if (!best || anchor.minutes > best.anchor.minutes) best = { anchor, matchUp: entry.matchUp, timing: entry.timing };
+    const candidate = { anchor, matchUp: entry.matchUp, timing: entry.timing };
+    if (anchor.minutes <= asOfMinutes) {
+      if (!past || anchor.minutes > past.anchor.minutes) past = candidate;
+    } else if (!future || anchor.minutes < future.anchor.minutes) {
+      future = candidate;
+    }
   }
-  return best;
+
+  if (past) return { ...past, unreliable: false };
+  return future && { ...future, unreliable: true };
 }
 
 function restRowFor(
@@ -293,27 +390,41 @@ function restRowFor(
   if (live) {
     const { requiredMinutes, typeChange } = requirementFor(live.matchUp, target, live.timing);
     const anchor = resolveAnchor(live.times, live.timing);
+    // The anchor for a live matchUp is a *projected* finish. Once that projection
+    // has passed, the match has overrun its format's average and the projection
+    // has expired with it — naming a readyAt in the past would read as though the
+    // player were already free, which is exactly backwards.
+    const overrun = !!anchor && anchor.minutes <= input.asOfMinutes;
+    const readyAt = anchor && !overrun ? minutesToClock(anchor.minutes + requiredMinutes) : undefined;
     return {
       participantId,
       participantName,
       status: 'onCourt',
       requiredMinutes,
       typeChange,
-      ...(anchor && { readyAt: minutesToClock(anchor.minutes + requiredMinutes), source: anchor.source }),
+      ...(readyAt && { readyAt }),
+      ...(overrun && { overrun: true }),
+      ...(anchor && { source: anchor.source }),
       fromMatchUpId: live.matchUp.matchUpId,
       fromMatchUpLabel: matchUpLabel(live.matchUp),
       load,
     };
   }
 
-  const latest = latestAnchor(prior);
+  const latest = latestAnchor(prior, input.asOfMinutes);
   if (!latest) {
     return { participantId, participantName, status: 'none', requiredMinutes: 0, typeChange: false, load };
   }
 
   const { requiredMinutes, typeChange } = requirementFor(latest.matchUp, target, latest.timing);
-  const restMinutes = Math.max(0, input.asOfMinutes - latest.anchor.minutes);
-  const rested = restMinutes >= requiredMinutes;
+  // An unreliable anchor sits in the future, so no interval can be measured from
+  // it. Zero rest against a real requirement is the conservative reading — it
+  // holds the player back — and `anchorUnreliable` keeps that from reading as a
+  // measured figure. No `readyAt` either: the clock time would be as fictional
+  // as the interval.
+  const restMinutes = latest.unreliable ? 0 : input.asOfMinutes - latest.anchor.minutes;
+  const rested = !latest.unreliable && restMinutes >= requiredMinutes;
+  const showReadyAt = !rested && !latest.unreliable;
 
   return {
     participantId,
@@ -322,12 +433,25 @@ function restRowFor(
     restMinutes,
     requiredMinutes,
     typeChange,
-    ...(!rested && { readyAt: minutesToClock(latest.anchor.minutes + requiredMinutes) }),
+    ...(showReadyAt && { readyAt: minutesToClock(latest.anchor.minutes + requiredMinutes) }),
+    ...(latest.unreliable && { anchorUnreliable: true }),
     source: latest.anchor.source,
     fromMatchUpId: latest.matchUp.matchUpId,
     fromMatchUpLabel: matchUpLabel(latest.matchUp),
     load,
   };
+}
+
+/**
+ * How far short of ready a row is, in minutes. The within-band tiebreak: sorting
+ * by status alone left `individualIds` side order to decide which player the
+ * badge spoke for, so a doubles pair resting at 10m and 40m badged whichever
+ * happened to be listed first. `onCourt` and `none` carry no measurable deficit,
+ * so they return 0 and keep their original order.
+ */
+function deficitMinutes(row: RestRow): number {
+  if (row.status === 'onCourt' || row.status === 'none') return 0;
+  return row.requiredMinutes - (row.restMinutes ?? 0);
 }
 
 /**
@@ -348,7 +472,7 @@ export function analyzeParticipantRest(input: RestInput): RestResult {
   const order: RestStatus[] = ['onCourt', 'resting', 'rested', 'none'];
   const rows = participantIds
     .map((participantId) => restRowFor(participantId, target, input, dayMatchUps))
-    .toSorted((a, b) => order.indexOf(a.status) - order.indexOf(b.status));
+    .toSorted((a, b) => order.indexOf(a.status) - order.indexOf(b.status) || deficitMinutes(b) - deficitMinutes(a));
 
   return { evaluated: true, asOfMinutes: input.asOfMinutes, rows };
 }

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
@@ -105,3 +105,21 @@ describe('badgeText / badgeTooltip', () => {
     expect(tooltip.split('\n')).toHaveLength(2);
   });
 });
+
+// ── Regressions: the two states the analysis gained on 2026-08-23 ────────────
+
+describe('badge honesty for states that carry no measurable interval', () => {
+  it('says the rest is unknown rather than showing the arithmetic zero', () => {
+    expect(badgeText(row({ status: 'resting', restMinutes: 0, anchorUnreliable: true }))).not.toMatch(/0/);
+  });
+
+  it('still shows a duration for an ordinary resting row', () => {
+    expect(badgeText(row({ status: 'resting', restMinutes: 22 }))).toMatch(/22/);
+  });
+
+  it('distinguishes an overrunning match from one inside its expected duration', () => {
+    const overrun = badgeTooltip([row({ status: 'onCourt', overrun: true })]);
+    const normal = badgeTooltip([row({ status: 'onCourt' })]);
+    expect(overrun).not.toEqual(normal);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.ts
@@ -28,7 +28,16 @@ import type { RestResult, RestRow, RestStatus } from './participantRest';
 /** Worst-first; the first status present decides the badge. Mirrors the Inspector's row order. */
 const SEVERITY: RestStatus[] = ['onCourt', 'resting', 'rested', 'none'];
 
-/** The row that decides the badge — the worst status present. */
+/**
+ * The row that decides the badge — the worst status present, and within that
+ * status the participant furthest from being ready.
+ *
+ * The within-status choice is `analyzeParticipantRest`'s to make: it sorts rows
+ * by band and then by shortfall, so taking the first of a band is taking the
+ * worst of it. That ordering is the contract between the two — a caller passing
+ * unsorted rows would get the right band and an arbitrary member of it, which is
+ * the bug this pairing was written to close.
+ */
 export function headlineRow(rows: RestRow[]): RestRow | undefined {
   for (const status of SEVERITY) {
     const row = rows.find((candidate) => candidate.status === status);
@@ -45,6 +54,9 @@ export function headlineRow(rows: RestRow[]): RestRow | undefined {
 export function badgeText(row: RestRow): string {
   if (row.status === 'onCourt') return t('schedule.card.rest.onCourt');
   if (row.status === 'none') return t('schedule.card.rest.none');
+  // A future anchor yields a zero that is arithmetic, not measurement. Showing
+  // `0m` would read as "just walked off", which is the opposite of unknown.
+  if (row.anchorUnreliable) return t('schedule.card.rest.unknown');
   return formatDuration(row.restMinutes ?? 0);
 }
 
@@ -52,8 +64,12 @@ export function badgeText(row: RestRow): string {
 export function badgeTooltip(rows: RestRow[]): string {
   return rows
     .map((row) => {
-      if (row.status === 'onCourt') return t('schedule.card.rest.tooltipOnCourt', { name: row.participantName });
+      if (row.status === 'onCourt') {
+        const key = row.overrun ? 'schedule.card.rest.tooltipOnCourtOverrun' : 'schedule.card.rest.tooltipOnCourt';
+        return t(key, { name: row.participantName });
+      }
       if (row.status === 'none') return t('schedule.card.rest.tooltipNone', { name: row.participantName });
+      if (row.anchorUnreliable) return t('schedule.card.rest.tooltipUnknown', { name: row.participantName });
       return t('schedule.card.rest.tooltipRest', {
         name: row.participantName,
         rested: formatDuration(row.restMinutes ?? 0),

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -459,3 +459,95 @@
   background: var(--tmx-fill-accent, #2563eb);
   color: #fff;
 }
+
+/* ── Schedule2 Inspector: actions block and popover ──
+   A sibling of the rest section, never a child — the rest section replaces its
+   own children every 30 seconds and would take an open popover with it. Tokens
+   only, so both themes are covered without a second rule set. */
+
+.tmx-inspector-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tmx-inspector-actions-trigger {
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+  border: 1px solid transparent;
+  color: inherit;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  transition: opacity 0.15s;
+}
+
+.tmx-inspector-actions-trigger:hover {
+  opacity: 0.75;
+}
+
+.tmx-inspector-actions-trigger:focus-visible {
+  outline: 2px solid var(--tmx-accent-blue, currentColor);
+  outline-offset: 1px;
+}
+
+/* The matchUp label sits beside the trigger so the popover's target is legible
+   without opening it. Truncated rather than wrapped: the Inspector is narrow and
+   a two-line label pushes the rest figures below the fold. */
+.tmx-inspector-actions-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--tmx-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tmx-inspector-actions-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 200px;
+}
+
+.tmx-inspector-action-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--tmx-text-primary);
+  font-size: 0.8125rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tmx-inspector-action-row:hover {
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+}
+
+.tmx-inspector-action-row i {
+  width: 14px;
+  color: var(--tmx-text-secondary);
+  flex: 0 0 auto;
+}
+
+.tmx-inspector-action-heading {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--tmx-text-secondary);
+  padding: 6px 8px 2px;
+  margin-top: 2px;
+  border-top: 1px solid var(--tmx-border-primary);
+}


### PR DESCRIPTION
Five defects in the participant-rest analysis shipped by #1326, found by source read. **Every one reported a player as freer than they were** — the direction that gets a tired player called to court.

## The defects

**1. A match that overran its format's average vanished from the analysis.**
`isUnderWay` bounded "under way" at `start + averageMinutes`, so a match still unscored past that point was neither finished nor under way and `collectPriorMatchUps` dropped it. A player three hours into a 90-minute-average match read **"No prior match today"** while standing on court. Every other defect understated rest; this one erased it.

The bound is gone: a match is over when a result says so, not when the estimate expires. `readyAt` is withheld once the projected finish has passed, rather than naming a time already gone by. `startAllRestGuard` blocks on `onCourt || resting`, so it inherited the same blind spot and is fixed by the same change without being touched.

**2. A completed matchUp with no `schedule.scheduledDate` contributed nothing.**
Scores entered from the draw view leave no scheduledDate, so those matches were invisible to rest. They are now dated by `scoredTime`, which is a full instant already normalized to minutes-from-viewed-midnight — a stamp from another day falls outside `0..1439` and excludes itself. No new machinery.

**3. Walkovers counted as matches played.**
Root cause worth naming: `COMPLETED_STATUSES` is a *readiness* predicate ("can no longer block anything") and rest was reusing it as a *load* predicate. Different questions. New `wasPlayed()` splits them — `WALKOVER`/`DOUBLE_WALKOVER` exempt outright; `DEFAULTED`/`DOUBLE_DEFAULT` decided by whether a score exists, since a default is either a no-show or a mid-match DQ and nothing else in the record tells them apart; `RETIRED` and `ABANDONED` still count, because both mean time on court. Required adding `score?` to `ReadinessMatchUp`.

**4. An anchor projected into the future was read as rest already taken.**
`Math.max(0, …)` clamped the negative interval, producing `0m of 60m — ready 16:20` for a player who had not played. Anchors at or before now win; when only future anchors exist the row reports zero rest and flags the anchor unmeasurable rather than guessing.

**5. The badge did not pick the least-rested participant.**
Sorting by status band alone left `individualIds` side order to decide, so a doubles pair resting at 10m and 40m badged whichever was listed first — contradicting the file's own "worst-participant-only" header. Rows now break ties within a band by shortfall, which is the ordering `headlineRow` already relied on.

## Inspector actions popover

Also in this PR, on the same surface. A sitemap trigger opens a popover with **View draw** — through the existing `navigateToEvent`, which resolves draw and structure and highlights the matchUp — plus every individual on the matchUp, each opening `participantProfileModal`. A doubles pair expands to its two players; the side label is neither of them and opens neither card.

The block is a **sibling** of the Rest section, never a child: the Rest section calls `replaceChildren()` on itself every 30 seconds to keep the figures counting up, and would destroy an open popover mid-interaction. The catalog cannot host this at all — its cards are natively `draggable`, so a press competes with drag initiation, and the catalog rebuilds every card on every state change.

## Verification

`lint 0` · `check-types 0` · `format:check` clean · **1497 unit tests** (baseline 1493) · `attr-audit 0` · `i18n-audit 0` · `build 0`.

**27 schedule journeys pass locally** (97, 98, 102, 106, 29) — journeys are not run by CI, so this is the only evidence for them.

Coverage on the changed pure logic:

| file | % Stmts | % Branch | % Funcs | % Lines |
|---|---|---|---|---|
| `participantRest.ts` | 98.41 | 94.95 | 100 | 100 |
| `inspectorActionsModel.ts` | 100 | 94.73 | 100 | 100 |
| `matchUpReadiness.ts` | 94.40 | 87.50 | 100 | 99.19 |

The DOM halves (`inspectorActions.ts`, `inspectorRest.ts` render paths) are covered by journeys rather than vitest — TMX runs its unit suite without a DOM, which is why the decisions live in pure modules.

**Falsification.** All 30 new unit tests were run red before the fix and green after. The two renderer tests were re-run with the feature deliberately deleted (`FEATURE_OFF=1`, 2 failures; `FEATURE_ON=0`) rather than reasoned about. Journey 106 seeds **DOUBLES** on purpose — pair expansion is the only real decision in the popover, and a singles seed would pass whether or not it worked; its control asserts the pair label is *absent* from the menu.

Rebased onto `main` after #1343 and #1345 landed; the `en.json` merge was verified in both directions (my `schedule.*` keys and #1343's `notChecked` both present, patch content byte-identical across the rebase).