### PR TITLE
feat(reports): open the participant card from any report row

### DIFF
--- a/e2e/journeys/107-reports-participant-card.spec.ts
+++ b/e2e/journeys/107-reports-participant-card.spec.ts
@@ -1,0 +1,143 @@
+import { initDevBridge, resetState, seedFeatureFlagInitScript, waitForAppReady } from '../helpers/dev-bridge';
+import { seedTournament, PROFILE_COMPLETED, type MockProfile } from '../helpers/seed';
+import { TournamentPage } from '../pages/TournamentPage';
+import { test, expect } from '@playwright/test';
+import { S } from '../helpers/selectors';
+
+// `cModal` mounts each modal as `<section id="cmdl-<n>">` (courthive-components
+// `cmodal.ts:230`) — no stable single id, hence the prefix. Assert on the dialog
+// rather than the section: the section is `display:block` around a
+// `position:fixed` container (`draw.css:243`), so its own box is zero-height and
+// Playwright rightly reports it as not visible.
+const MODAL = 'section[id^="cmdl-"] .chc-modal-dialog';
+
+/**
+ * Journey 107 — a participant name in a report opens the participant card.
+ *
+ * Two assertions, and the second is the one that matters. Reports whose rows
+ * carry `eventId` + `drawId` are row-click navigable (journey 68), and the
+ * participant column lives inside those same rows. `renderIndividual` calls
+ * `pointerEvent.stopPropagation()` before invoking `participantClick`, so the
+ * name click must open the card and NOT also navigate to the draw behind it.
+ *
+ * Without that guarantee the feature is worse than absent: every card open
+ * would drop the operator into a draw they did not ask for.
+ */
+
+test.describe('Journey 107 — reports participant card', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedFeatureFlagInitScript(page, 'reports');
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('clicking a participant name opens the card without navigating to the draw', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_COMPLETED);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    // Prefer a report that is BOTH participant-bearing and row-navigable, so the
+    // click genuinely exercises the stopPropagation path rather than a report
+    // where there is no navigation to suppress.
+    const found = await page.evaluate(() => {
+      const avail: any = dev.factory.tournamentEngine.getAvailableReports?.() ?? {};
+      const reports = (avail.availableReports ?? []).filter((r: any) => r.computableNow && r.source !== 'server');
+      let fallback: string | null = null;
+      for (const r of reports) {
+        const res: any = dev.factory.tournamentEngine.generateReport({ reportId: r.reportId });
+        const rows: any[] = res?.rows ?? [];
+        if (!rows.length || !rows[0].participantId) continue;
+        if (rows[0].eventId && rows[0].drawId) return { reportId: r.reportId as string, navigable: true };
+        fallback ??= r.reportId;
+      }
+      return { reportId: fallback, navigable: false };
+    });
+    expect(found.reportId, 'no participant-bearing local report found').toBeTruthy();
+
+    await page.evaluate(
+      ({ id, reportId }) => {
+        window.location.hash = `#/tournament/${id}/reports/${reportId}`;
+      },
+      { id: tournamentId, reportId: found.reportId },
+    );
+
+    const rows = page.locator('#tournamentReports .tabulator-row');
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+
+    // `renderIndividual` tags every rendered name with `.tmx-i`.
+    const participantName = rows.first().locator('.tmx-i').first();
+    await expect(participantName).toBeVisible({ timeout: 10_000 });
+    const clickedName = (await participantName.textContent())?.trim();
+
+    await participantName.click();
+
+    // The card opened, titled with the participant that was clicked.
+    const modal = page.locator(MODAL);
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    if (clickedName) await expect(modal).toContainText(clickedName, { timeout: 5_000 });
+
+    // ...and the row-click navigation did NOT also fire.
+    await expect(page.locator(S.DRAW_FRAME)).toBeHidden();
+  });
+
+  test('a doubles entry renders both partners, each opening its own card', async ({ page }) => {
+    // The PAIR case is why the column renders `sideBySide` and why participants
+    // are hydrated `withIndividualParticipants`. Without either, a doubles PAIR is
+    // ONE unclickable name — `participantProfileModal` is person-oriented
+    // throughout and would render an empty card for the pair itself.
+    //
+    // Seeding Performance is the report that actually produces PAIR rows. Entry
+    // Status does NOT: mocksEngine enters a doubles event as individuals, so its
+    // rows come back INDIVIDUAL even when the tournament holds 8 PAIRs. Measured
+    // across every local report on a seeded doubles tournament — only
+    // `participant.seedingPerformance` returned PAIR rows.
+    const doublesProfile: MockProfile = {
+      tournamentName: 'E2E Doubles Reports',
+      tournamentAttributes: { tournamentId: 'e2e-doubles-reports' },
+      participantsProfile: { scaledParticipantsCount: 32 },
+      drawProfiles: [
+        { eventName: 'Doubles', eventType: 'DOUBLES', drawSize: 8, seedsCount: 4, drawType: 'SINGLE_ELIMINATION' },
+      ],
+      completeAllMatchUps: true,
+    };
+    const tournamentId = await seedTournament(page, doublesProfile);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    // Guard against a vacuous test: if the seed stops producing PAIR rows this
+    // fails loudly rather than silently exercising the INDIVIDUAL path twice.
+    const pairRowFound = await page.evaluate(() => {
+      const res: any = dev.factory.tournamentEngine.generateReport({ reportId: 'participant.seedingPerformance' });
+      const rows: any[] = res?.rows ?? [];
+      const participants = dev.factory.tournamentEngine.getParticipants({}).participants ?? [];
+      const byId: Record<string, any> = {};
+      for (const p of participants) byId[p.participantId] = p;
+      return rows.some((r: any) => byId[r.participantId]?.participantType === 'PAIR');
+    });
+    expect(pairRowFound, 'seed produced no PAIR rows — the doubles case would be untested').toBe(true);
+
+    await page.evaluate((id) => {
+      window.location.hash = `#/tournament/${id}/reports/participant.seedingPerformance`;
+    }, tournamentId);
+
+    const firstRow = page.locator('#tournamentReports .tabulator-row').first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    // Both partners are rendered as independent click targets in the one cell.
+    const names = firstRow.locator('.tmx-i');
+    await expect(names).toHaveCount(2, { timeout: 10_000 });
+
+    const secondName = (await names.nth(1).textContent())?.trim();
+    await names.nth(1).click();
+
+    // Clicking the SECOND partner opens THAT partner's card, not the first's —
+    // which is what proves the click resolves the individual rather than the pair.
+    const modal = page.locator(MODAL);
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    if (secondName) await expect(modal).toContainText(secondName, { timeout: 5_000 });
+  });
+});

--- a/e2e/journeys/107-reports-participant-card.spec.ts
+++ b/e2e/journeys/107-reports-participant-card.spec.ts
@@ -140,4 +140,89 @@ test.describe('Journey 107 — reports participant card', () => {
     await expect(modal).toBeVisible({ timeout: 10_000 });
     if (secondName) await expect(modal).toContainText(secondName, { timeout: 5_000 });
   });
+
+  test('a matchUp-grain report opens the card from either side column', async ({ page }) => {
+    // Match Results names two opponents per row, so neither is "the" participant
+    // of the row and `formatParticipant`'s single `data.participant` key cannot
+    // serve. Both side columns must be independently clickable.
+    const tournamentId = await seedTournament(page, PROFILE_COMPLETED);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    const sideIdsPresent = await page.evaluate(() => {
+      const res: any = dev.factory.tournamentEngine.generateReport({ reportId: 'matchUp.results' });
+      const row = res?.rows?.[0];
+      return !!(row?.side1ParticipantId && row?.side2ParticipantId);
+    });
+    expect(sideIdsPresent, 'Match Results carries no side participant ids').toBe(true);
+
+    await page.evaluate((id) => {
+      window.location.hash = `#/tournament/${id}/reports/matchUp.results`;
+    }, tournamentId);
+
+    const firstRow = page.locator('#tournamentReports .tabulator-row').first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    // Two rendered participants in the row — one per side column.
+    const names = firstRow.locator('.tmx-i');
+    await expect(names).toHaveCount(2, { timeout: 10_000 });
+
+    const secondSideName = (await names.nth(1).textContent())?.trim();
+    await names.nth(1).click();
+
+    const modal = page.locator(MODAL);
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    if (secondSideName) await expect(modal).toContainText(secondSideName, { timeout: 5_000 });
+  });
+
+  test('the recovery report lists a participant and opens the card', async ({ page }) => {
+    const tournamentId = await seedTournament(page, PROFILE_COMPLETED);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    // Give every matchUp a planned time so the timeline has start anchors —
+    // without one, every matchUp is undatable and the report is empty.
+    const computable = await page.evaluate(() => {
+      const engine: any = dev.factory.tournamentEngine;
+      const matchUps = engine.allTournamentMatchUps({}).matchUps ?? [];
+      const startDate = engine.getTournament()?.tournamentRecord?.startDate;
+      for (const matchUp of matchUps) {
+        engine.addMatchUpScheduledDate({
+          matchUpId: matchUp.matchUpId,
+          drawId: matchUp.drawId,
+          scheduledDate: startDate,
+        });
+        engine.addMatchUpScheduledTime({
+          matchUpId: matchUp.matchUpId,
+          drawId: matchUp.drawId,
+          scheduledTime: '09:00',
+        });
+      }
+      const avail: any = engine.getAvailableReports() ?? {};
+      const recovery = (avail.availableReports ?? []).find((r: any) => r.reportId === 'participant.recoveryTime');
+      const res: any = engine.generateReport({ reportId: 'participant.recoveryTime' });
+      return { computableNow: !!recovery?.computableNow, rows: res?.rows?.length ?? 0, error: res?.error };
+    });
+    expect(computable.error, `recovery report errored: ${computable.error}`).toBeFalsy();
+    expect(computable.computableNow).toBe(true);
+    expect(computable.rows).toBeGreaterThan(0);
+
+    await page.evaluate((id) => {
+      window.location.hash = `#/tournament/${id}/reports/participant.recoveryTime`;
+    }, tournamentId);
+
+    const firstRow = page.locator('#tournamentReports .tabulator-row').first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    const name = firstRow.locator('.tmx-i').first();
+    await expect(name).toBeVisible({ timeout: 10_000 });
+    const clicked = (await name.textContent())?.trim();
+    await name.click();
+
+    const modal = page.locator(MODAL);
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    if (clicked) await expect(modal).toContainText(clicked, { timeout: 5_000 });
+  });
 });

--- a/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
+++ b/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
@@ -1,5 +1,6 @@
-import { collectReportParticipantIds, resolveReportParticipantId } from './reportParticipants';
+import { collectReportParticipantIds, PARTICIPANT_ID_KEYS, resolveReportParticipantId } from './reportParticipants';
 import { formatParticipant } from 'components/tables/common/formatters/participantFormatter';
+import { formatSideParticipant } from './sideParticipantFormatter';
 import { participantProfileModal } from 'components/modals/participantProfileModal';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -39,7 +40,19 @@ function estimateColumnWidth(title: string, field: string, rows: Record<string, 
 }
 
 // Row fields that carry IDs for CSV/JSON export but should not display in the table
-const HIDDEN_FIELDS = ['participantId', 'eventId', 'drawId', 'structureId'];
+const HIDDEN_FIELDS = [
+  'participantId',
+  'side1ParticipantId',
+  'side2ParticipantId',
+  'winningParticipantId',
+  'eventId',
+  'drawId',
+  'structureId',
+];
+
+// Side columns whose plain name string is upgraded to a clickable participant
+// when the report carries the matching id.
+const SIDE_COLUMNS: Record<string, string> = { side1: 'side1Participant', side2: 'side2Participant' };
 
 export function createReportsTable({ columns, rows }: { columns: ReportColumn[]; rows: Record<string, any>[] }): {
   table: any;
@@ -55,16 +68,19 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
   // hydration a PAIR cell renders EMPTY rather than falling back to the pair
   // name. Measured — journey 107's doubles case finds 0 rendered names when this
   // flag is dropped. Change the two together or not at all.
-  const hasParticipantId = rows.length > 0 && 'participantId' in rows[0];
-  if (hasParticipantId) {
+  const firstRow = rows[0] ?? {};
+  const presentIdKeys = PARTICIPANT_ID_KEYS.filter(({ idKey }) => idKey in firstRow);
+  const hasParticipantId = presentIdKeys.some(({ idKey }) => idKey === 'participantId');
+  if (presentIdKeys.length) {
     const result: any = tournamentEngine.getParticipants({ withIndividualParticipants: true });
     const pMap: Record<string, any> = {};
     for (const p of result?.participants ?? []) {
       pMap[p.participantId] = p;
     }
     for (const row of rows) {
-      if (row.participantId && pMap[row.participantId]) {
-        row.participant = pMap[row.participantId];
+      for (const { idKey, hydratedKey } of presentIdKeys) {
+        const participant = pMap[row[idKey]];
+        if (participant) row[hydratedKey] = participant;
       }
     }
   }
@@ -104,6 +120,16 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
           // why `formatParticipant(...)` handed straight to `formatter` can never
           // take this branch. Requires the hydration above.
           formatter: (cell: any) => (formatParticipant(onParticipantClick) as any)(cell, undefined, 'sideBySide'),
+          headerSort: true,
+          minWidth: 180,
+        };
+      }
+      const sideKey = SIDE_COLUMNS[col.key];
+      if (sideKey && sideKey in firstRow) {
+        return {
+          title: col.title,
+          field: col.key,
+          formatter: formatSideParticipant(onParticipantClick, sideKey),
           headerSort: true,
           minWidth: 180,
         };

--- a/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
+++ b/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
@@ -1,4 +1,6 @@
+import { collectReportParticipantIds, resolveReportParticipantId } from './reportParticipants';
 import { formatParticipant } from 'components/tables/common/formatters/participantFormatter';
+import { participantProfileModal } from 'components/modals/participantProfileModal';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { destroyTable } from 'pages/tournament/destroyTable';
@@ -44,10 +46,18 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
 } {
   destroyTable({ anchorId: TOURNAMENT_REPORTS });
 
-  // If rows contain participantId, resolve full participant objects for renderParticipant
+  // If rows contain participantId, resolve full participant objects for renderParticipant.
+  // `withIndividualParticipants` is what makes a PAIR row render its two members
+  // as separately clickable names instead of one unclickable pair name.
+  //
+  // It is REQUIRED by the `sideBySide` layout below, not merely complementary:
+  // `renderPairParticipant` iterates `individualParticipants`, so without the
+  // hydration a PAIR cell renders EMPTY rather than falling back to the pair
+  // name. Measured — journey 107's doubles case finds 0 rendered names when this
+  // flag is dropped. Change the two together or not at all.
   const hasParticipantId = rows.length > 0 && 'participantId' in rows[0];
   if (hasParticipantId) {
-    const result: any = tournamentEngine.getParticipants({});
+    const result: any = tournamentEngine.getParticipants({ withIndividualParticipants: true });
     const pMap: Record<string, any> = {};
     for (const p of result?.participants ?? []) {
       pMap[p.participantId] = p;
@@ -58,6 +68,20 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
       }
     }
   }
+
+  // Prev/next inside the card walks the whole table, not just the clicked row.
+  const participantIds = collectReportParticipantIds(rows);
+
+  // `renderIndividual` already calls `pointerEvent.stopPropagation()` before it
+  // invokes this (courthive-components `renderIndividual.ts:90`), so a click on a
+  // name in a draw-navigable report opens the card WITHOUT also firing the
+  // `rowClick` handler below. Do not add a second stopPropagation here — verify
+  // that one is still there instead.
+  const onParticipantClick = (params: any) => {
+    const participantId = resolveReportParticipantId(params);
+    if (!participantId) return;
+    participantProfileModal({ participantId, participantIds });
+  };
 
   const numberCellFormatter = (cell: any) => {
     const value = cell.getValue();
@@ -71,7 +95,15 @@ export function createReportsTable({ columns, rows }: { columns: ReportColumn[];
         return {
           title: col.title,
           field: col.key,
-          formatter: formatParticipant(undefined),
+          // `sideBySide` renders a PAIR as its two individuals, each with its own
+          // click target, so a doubles row resolves unambiguously. Reached by
+          // Seeding Performance, whose rows are PAIRs for a doubles event.
+          //
+          // It must be passed as the formatter's third argument explicitly:
+          // Tabulator's own third argument is `onRendered`, not a layout, which is
+          // why `formatParticipant(...)` handed straight to `formatter` can never
+          // take this branch. Requires the hydration above.
+          formatter: (cell: any) => (formatParticipant(onParticipantClick) as any)(cell, undefined, 'sideBySide'),
           headerSort: true,
           minWidth: 180,
         };

--- a/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
+++ b/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
@@ -1,8 +1,8 @@
 import { collectReportParticipantIds, PARTICIPANT_ID_KEYS, resolveReportParticipantId } from './reportParticipants';
 import { formatParticipant } from 'components/tables/common/formatters/participantFormatter';
-import { formatSideParticipant } from './sideParticipantFormatter';
 import { participantProfileModal } from 'components/modals/participantProfileModal';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
+import { formatSideParticipant } from './sideParticipantFormatter';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { destroyTable } from 'pages/tournament/destroyTable';
 import { tournamentEngine } from 'services/factory/engine';

--- a/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
+++ b/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
@@ -125,6 +125,24 @@ export function renderReportsTab(options: { reportId?: string } = {}): void {
   selectReport(initialReport);
 }
 
+/**
+ * Parameters every factory report is generated with.
+ *
+ * `utcOffsetMinutes` is the venue's offset from UTC (local = UTC + offset),
+ * taken from the runtime rather than a stored value so it is DST-correct for an
+ * operator sitting at the venue. Until now `generateReport` was called with no
+ * parameters at all, so the offset path the factory wrappers already expose was
+ * dead and each report had to localize its own timestamps client-side.
+ *
+ * Caveat for reports that add more time columns: a single offset is the offset
+ * *now*, so a tournament spanning a DST change is off by an hour on the far side
+ * of it. `localizeReportTimes` below converts per instant and does not have that
+ * problem — prefer that shape when a report carries several timestamps.
+ */
+function reportParameters(): Record<string, any> {
+  return { utcOffsetMinutes: -new Date().getTimezoneOffset() };
+}
+
 async function selectReport(report: any): Promise<void> {
   const { reportId, name, source } = report;
   activeReportName = name;
@@ -134,7 +152,7 @@ async function selectReport(report: any): Promise<void> {
   if (source === 'server') {
     await fetchServerReport(reportId);
   } else {
-    const result: any = tournamentEngine.generateReport({ reportId });
+    const result: any = tournamentEngine.generateReport({ reportId, parameters: reportParameters() });
     if (result.error) return;
     localizeReportTimes(result.rows);
     activeReport = { columns: result.columns, rows: result.rows };

--- a/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
+++ b/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
@@ -128,19 +128,24 @@ export function renderReportsTab(options: { reportId?: string } = {}): void {
 /**
  * Parameters every factory report is generated with.
  *
- * `utcOffsetMinutes` is the venue's offset from UTC (local = UTC + offset),
- * taken from the runtime rather than a stored value so it is DST-correct for an
- * operator sitting at the venue. Until now `generateReport` was called with no
- * parameters at all, so the offset path the factory wrappers already expose was
- * dead and each report had to localize its own timestamps client-side.
+ * Both frames are sent. `timeZone` is the IANA identifier the runtime resolves
+ * to, and the factory prefers it: it yields the offset **per instant**, so a
+ * tournament spanning a DST change converts correctly on both sides. A bare
+ * `utcOffsetMinutes` is the offset *now* and would be an hour wrong on the far
+ * side of the change — silently, in reports measured in minutes.
  *
- * Caveat for reports that add more time columns: a single offset is the offset
- * *now*, so a tournament spanning a DST change is off by an hour on the far side
- * of it. `localizeReportTimes` below converts per instant and does not have that
- * problem — prefer that shape when a report carries several timestamps.
+ * `utcOffsetMinutes` is still sent as the fallback for wrappers that predate the
+ * zone parameter, and for the case where the runtime cannot name its zone.
+ *
+ * Until this existed `generateReport` was called with no parameters at all, so
+ * the offset path the factory wrappers already exposed was dead and each report
+ * had to localize its own timestamps client-side.
  */
 function reportParameters(): Record<string, any> {
-  return { utcOffsetMinutes: -new Date().getTimezoneOffset() };
+  return {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    utcOffsetMinutes: -new Date().getTimezoneOffset(),
+  };
 }
 
 async function selectReport(report: any): Promise<void> {

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
@@ -1,0 +1,96 @@
+import { collectReportParticipantIds, resolveReportParticipantId } from './reportParticipants';
+import { describe, expect, it } from 'vitest';
+
+const individual = (participantId: string) => ({ participantId, participantType: 'INDIVIDUAL' });
+const pair = (participantId: string, individuals: any[]) => ({
+  individualParticipants: individuals,
+  participantType: 'PAIR',
+  participantId,
+});
+const team = (participantId: string, individuals: any[]) => ({
+  individualParticipants: individuals,
+  participantType: 'TEAM',
+  participantId,
+});
+
+describe('resolveReportParticipantId', () => {
+  it('resolves an individual clicked directly', () => {
+    expect(resolveReportParticipantId({ individualParticipant: individual('p1') })).toEqual('p1');
+  });
+
+  it('resolves the clicked half of a pair rather than the pair', () => {
+    const p = pair('pair1', [individual('p1'), individual('p2')]);
+    // `sideBySide` layout renders each individual separately, so the click
+    // carries the individual while the row still carries the pair.
+    expect(resolveReportParticipantId({ individualParticipant: individual('p2'), participant: p })).toEqual('p2');
+  });
+
+  it('returns undefined for a pair of two — picking one would be arbitrary', () => {
+    const p = pair('pair1', [individual('p1'), individual('p2')]);
+    // The trap: renderParticipant hands a PAIR through as `individualParticipant`
+    // when there is no matchUp, so the parameter name cannot be trusted.
+    expect(resolveReportParticipantId({ individualParticipant: p })).toBeUndefined();
+  });
+
+  it('resolves a pair holding exactly one individual — the only possible answer', () => {
+    expect(resolveReportParticipantId({ participant: pair('pair1', [individual('p1')]) })).toEqual('p1');
+  });
+
+  it('returns undefined for a team, whose card would be empty', () => {
+    const t = team('team1', [individual('p1'), individual('p2'), individual('p3')]);
+    expect(resolveReportParticipantId({ participant: t })).toBeUndefined();
+  });
+
+  it('returns undefined for missing, empty and id-less input', () => {
+    expect(resolveReportParticipantId()).toBeUndefined();
+    expect(resolveReportParticipantId({})).toBeUndefined();
+    expect(resolveReportParticipantId({ participant: { participantType: 'INDIVIDUAL' } })).toBeUndefined();
+    expect(
+      resolveReportParticipantId({ participant: { participantType: 'INDIVIDUAL', participantId: '' } }),
+    ).toBeUndefined();
+  });
+
+  it('prefers the clicked individual over the row participant', () => {
+    expect(
+      resolveReportParticipantId({
+        individualParticipant: individual('clicked'),
+        participant: individual('row'),
+      }),
+    ).toEqual('clicked');
+  });
+});
+
+describe('collectReportParticipantIds', () => {
+  it('collects individuals in row order', () => {
+    const rows = [{ participant: individual('p1') }, { participant: individual('p2') }];
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2']);
+  });
+
+  it('expands a pair into both of its individuals', () => {
+    const rows = [{ participant: pair('pair1', [individual('p1'), individual('p2')]) }];
+    // Both halves must be reachable by prev/next, and the pair id itself must
+    // NOT appear — the card cannot render it.
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2']);
+  });
+
+  it('dedupes a participant appearing in several rows', () => {
+    const rows = [
+      { participant: individual('p1') },
+      { participant: pair('pair1', [individual('p1'), individual('p2')]) },
+      { participant: individual('p2') },
+    ];
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2']);
+  });
+
+  it('skips rows with no hydrated participant', () => {
+    const rows = [{ participantId: 'p1' }, { participant: individual('p2') }, {}];
+    // participantId alone is not enough — hydration is what proves the
+    // participant exists in this tournament.
+    expect(collectReportParticipantIds(rows)).toEqual(['p2']);
+  });
+
+  it('returns an empty list for empty and missing input', () => {
+    expect(collectReportParticipantIds([])).toEqual([]);
+    expect(collectReportParticipantIds(undefined as any)).toEqual([]);
+  });
+});

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
@@ -1,4 +1,4 @@
-import { collectReportParticipantIds, resolveReportParticipantId } from './reportParticipants';
+import { collectReportParticipantIds, PARTICIPANT_ID_KEYS, resolveReportParticipantId } from './reportParticipants';
 import { describe, expect, it } from 'vitest';
 
 const individual = (participantId: string) => ({ participantId, participantType: 'INDIVIDUAL' });
@@ -92,5 +92,52 @@ describe('collectReportParticipantIds', () => {
   it('returns an empty list for empty and missing input', () => {
     expect(collectReportParticipantIds([])).toEqual([]);
     expect(collectReportParticipantIds(undefined as any)).toEqual([]);
+  });
+});
+
+describe('collectReportParticipantIds — matchUp-grain rows', () => {
+  it('collects both sides, side 1 first', () => {
+    const rows = [{ side1Participant: individual('p1'), side2Participant: individual('p2') }];
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2']);
+  });
+
+  it('expands a doubles side into its partners', () => {
+    const rows = [
+      {
+        side1Participant: pair('pairA', [individual('a1'), individual('a2')]),
+        side2Participant: pair('pairB', [individual('b1'), individual('b2')]),
+      },
+    ];
+    expect(collectReportParticipantIds(rows)).toEqual(['a1', 'a2', 'b1', 'b2']);
+  });
+
+  it('dedupes a participant met on both sides across rows', () => {
+    const rows = [
+      { side1Participant: individual('p1'), side2Participant: individual('p2') },
+      { side1Participant: individual('p2'), side2Participant: individual('p3') },
+    ];
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('handles a row carrying both a row participant and sides', () => {
+    const rows = [{ participant: individual('row'), side1Participant: individual('s1') }];
+    expect(collectReportParticipantIds(rows)).toEqual(['row', 's1']);
+  });
+});
+
+describe('PARTICIPANT_ID_KEYS', () => {
+  it('pairs every id key with the hydrated key the table writes', () => {
+    // The table hydrates by iterating these pairs, and collection reads the
+    // hydrated side — a mismatch would silently produce empty prev/next lists.
+    expect(PARTICIPANT_ID_KEYS.map((k) => k.idKey)).toEqual([
+      'participantId',
+      'side1ParticipantId',
+      'side2ParticipantId',
+    ]);
+    expect(PARTICIPANT_ID_KEYS.map((k) => k.hydratedKey)).toEqual([
+      'participant',
+      'side1Participant',
+      'side2Participant',
+    ]);
   });
 });

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
@@ -1,0 +1,99 @@
+/**
+ * Reports tab — which participant a click in a report table refers to.
+ *
+ * Pure and DOM-free on purpose. TMX has no jsdom test layer, so any decision
+ * that lives inside a Tabulator formatter closure gets no unit coverage at all;
+ * the resolution rules therefore live here and the table only wires them up.
+ *
+ * ── Why this is not simply `params.participant.participantId` ──
+ *
+ * `renderParticipant` decides what to hand a click handler by *matchUpType*,
+ * not by participant type (`renderParticipant.ts:99`):
+ *
+ *     const firstParticipant = isDoubles ? participant?.individualParticipants?.[0] : participant;
+ *
+ * A report row has no matchUp, so `isDoubles` is false and a PAIR arrives as
+ * `individualParticipant` — the name is a lie about the shape. Reports that
+ * carry entries rather than results (Entry Status, Seeding Performance) do have
+ * PAIR rows for every doubles event, so this is a live case rather than a
+ * defensive one.
+ *
+ * `participantProfileModal` is person-oriented throughout — header, ratings,
+ * rankings and fingerprint all read `participant.person` — so opening it on a
+ * PAIR renders a mostly-empty card. Resolution therefore only ever yields an
+ * INDIVIDUAL, and yields nothing when the click cannot name one.
+ */
+
+const INDIVIDUAL = 'INDIVIDUAL';
+
+/** Only the fields click resolution reads. Reports hydrate participants via `getParticipants`. */
+export interface ReportParticipant {
+  individualParticipants?: ReportParticipant[];
+  participantType?: string;
+  participantId?: string;
+}
+
+/** A report row, as the factory report wrappers emit it plus the table's hydration. */
+export interface ReportRow {
+  participant?: ReportParticipant;
+  participantId?: string;
+}
+
+/**
+ * The one individual a candidate names, or undefined.
+ *
+ * A PAIR holding exactly one individual is unambiguous and resolves to that
+ * individual — degenerate data, but there is only one answer. A PAIR holding two
+ * resolves to nothing: picking the first would open a card for whichever partner
+ * happened to be stored first, which is worse than doing nothing.
+ */
+function individualOf(candidate?: ReportParticipant): string | undefined {
+  if (!candidate) return undefined;
+  if (candidate.participantType === INDIVIDUAL) return candidate.participantId || undefined;
+  const individuals = candidate.individualParticipants ?? [];
+  if (individuals.length === 1) return individuals[0]?.participantId || undefined;
+  return undefined;
+}
+
+/**
+ * Resolve the participantId whose card a report click should open.
+ *
+ * Returns undefined when the click cannot name a single individual — the caller
+ * must then do nothing rather than open an empty card.
+ */
+export function resolveReportParticipantId(params?: {
+  individualParticipant?: ReportParticipant;
+  participant?: ReportParticipant;
+}): string | undefined {
+  return individualOf(params?.individualParticipant) ?? individualOf(params?.participant);
+}
+
+/**
+ * Every individual participantId the table holds, in row order and deduped.
+ *
+ * Drives prev/next navigation inside the participant card, so it must span the
+ * whole table rather than the clicked row: a PAIR row contributes both of its
+ * individuals, in the order they are stored.
+ */
+export function collectReportParticipantIds(rows: ReportRow[]): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  const add = (participantId?: string) => {
+    if (!participantId || seen.has(participantId)) return;
+    seen.add(participantId);
+    ids.push(participantId);
+  };
+
+  for (const row of rows ?? []) {
+    const participant = row?.participant;
+    if (!participant) continue;
+    if (participant.participantType === INDIVIDUAL) {
+      add(participant.participantId);
+      continue;
+    }
+    for (const individual of participant.individualParticipants ?? []) add(individual?.participantId);
+  }
+
+  return ids;
+}

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
@@ -35,9 +35,26 @@ export interface ReportParticipant {
 
 /** A report row, as the factory report wrappers emit it plus the table's hydration. */
 export interface ReportRow {
+  side1Participant?: ReportParticipant;
+  side2Participant?: ReportParticipant;
   participant?: ReportParticipant;
+  side1ParticipantId?: string;
+  side2ParticipantId?: string;
   participantId?: string;
 }
+
+/**
+ * Row keys carrying a participant id, and the hydrated key each resolves into.
+ *
+ * `participantId` is the participant-grain reports (one row per participant);
+ * the side keys are the matchUp-grain ones, where a row names two opponents and
+ * neither is "the" participant of the row.
+ */
+export const PARTICIPANT_ID_KEYS = [
+  { idKey: 'participantId', hydratedKey: 'participant' },
+  { idKey: 'side1ParticipantId', hydratedKey: 'side1Participant' },
+  { idKey: 'side2ParticipantId', hydratedKey: 'side2Participant' },
+] as const;
 
 /**
  * The one individual a candidate names, or undefined.
@@ -85,14 +102,19 @@ export function collectReportParticipantIds(rows: ReportRow[]): string[] {
     ids.push(participantId);
   };
 
-  for (const row of rows ?? []) {
-    const participant = row?.participant;
-    if (!participant) continue;
+  const addParticipant = (participant?: ReportParticipant) => {
+    if (!participant) return;
     if (participant.participantType === INDIVIDUAL) {
       add(participant.participantId);
-      continue;
+      return;
     }
     for (const individual of participant.individualParticipants ?? []) add(individual?.participantId);
+  };
+
+  for (const row of rows ?? []) {
+    // Both sides of a matchUp-grain row contribute, side 1 first, so prev/next
+    // walks the table in the order it reads.
+    for (const { hydratedKey } of PARTICIPANT_ID_KEYS) addParticipant((row as any)?.[hydratedKey]);
   }
 
   return ids;

--- a/src/pages/tournament/tabs/reportsTab/sideParticipantFormatter.ts
+++ b/src/pages/tournament/tabs/reportsTab/sideParticipantFormatter.ts
@@ -1,0 +1,76 @@
+/**
+ * Reports tab — render a matchUp-grain report's side column as a clickable
+ * participant instead of a bare name string.
+ *
+ * `participantFormatter.formatParticipant` cannot serve here: it resolves the
+ * participant from `data.participant`, a single row-level key. A matchUp-grain
+ * row names **two** opponents and neither is "the" participant of the row, so the
+ * side being rendered has to be selected explicitly.
+ *
+ * The factory keeps `side1` / `side2` as plain name strings and carries the ids
+ * separately, which matters — the CSV exporter stringifies each cell value, so an
+ * object in `side1` would export as `[object Object]`.
+ */
+
+import { preferencesConfig } from 'config/preferencesConfig';
+import { renderParticipant } from 'courthive-components';
+import { scalesMap } from 'config/scalesConfig';
+
+export function formatSideParticipant(
+  onClick: (params: any) => void,
+  hydratedKey: string,
+): (cell: any) => HTMLElement | string {
+  return (cell: any) => {
+    const data = cell.getRow().getData();
+    const participant = data?.[hydratedKey];
+    // Not hydrated (participant absent from this tournament, or the report
+    // carries no id for this side) — fall back to the plain name the factory
+    // already emitted rather than rendering an empty cell.
+    if (!participant) return cell.getValue() ?? '';
+
+    const scaleAttributes = scalesMap[preferencesConfig.get().activeScale];
+
+    const render = (individual: any) =>
+      renderParticipant({
+        eventHandlers: {
+          participantClick: (params: any) => onClick({ ...params, cell }),
+        },
+        composition: {
+          theme: 'default',
+          configuration: {
+            participantDetail: 'TEAM',
+            genderColor: true,
+            scaleAttributes,
+            flag: false,
+          },
+        },
+        participant: individual,
+      });
+
+    // A PAIR renders each partner as its own click target, matching the
+    // participant-grain columns. `renderParticipant` alone would not: with no
+    // matchUp in scope it treats the pair as a single individual.
+    const individuals = participant.individualParticipants ?? [];
+    if (individuals.length > 1) {
+      const container = document.createElement('div');
+      container.className = 'flexrow flexjustifystart';
+      individuals.forEach((individual: any, index: number) => {
+        const element = render(individual);
+        element.style.maxWidth = 'calc(50% - 0.5em)';
+        element.style.overflow = 'hidden';
+        element.style.whiteSpace = 'nowrap';
+        element.style.textOverflow = 'ellipsis';
+        container.appendChild(element);
+        if (!index) {
+          const spacer = document.createElement('span');
+          spacer.style.width = '1em';
+          spacer.innerHTML = '&nbsp;';
+          container.appendChild(spacer);
+        }
+      });
+      return container;
+    }
+
+    return render(participant);
+  };
+}


### PR DESCRIPTION
Phases A, B and the TMX half of E from [`Mentat/planning/PARTICIPANT_RECOVERY_TIME_REPORT.md`].

> CA: *"the participant column for every report should be able to open the participant card for every participant! This will make it possible to see all participant details because the reports right now just give report detail."*

Pairs with CourtHive/competition-factory#4692, which supplies the ids and the two new reports.

## The gap

`createReportsTable.ts` rendered the participant column with `formatParticipant(undefined)` — the click handler was simply **absent**.

## Three things the resolution has to get right

**1. `individualParticipant` is not necessarily an individual.** `renderParticipant.ts:99` picks what to hand a click handler by **matchUpType**, not participant type:

```ts
const firstParticipant = isDoubles ? participant?.individualParticipants?.[0] : participant;
```

A report row has no matchUp, so `isDoubles` is false and a PAIR arrives as `individualParticipant` — the parameter name is a lie about the shape. `participantProfileModal` is person-oriented throughout, so opening it on a PAIR renders an empty card. Resolution therefore only ever yields an INDIVIDUAL, and yields **nothing** when the click cannot name one rather than picking a partner arbitrarily.

**2. `sideBySide` and `withIndividualParticipants` are coupled, not complementary.** `renderPairParticipant` iterates `individualParticipants`, so without the hydration a PAIR cell renders **empty** rather than falling back to the pair name. Measured: journey 107 finds **0** rendered names when the flag is dropped.

**3. matchUp-grain rows have no single participant.** Match Results, Competitiveness and Call Timing Variance name two opponents, so `formatParticipant`'s single `data.participant` key cannot serve — a dedicated formatter selects the side explicitly. The factory keeps `side1`/`side2` as plain strings and carries ids separately, which matters: the CSV exporter stringifies each cell, so an object in `side1` would export as `[object Object]`.

Resolution lives in a pure module rather than inside the Tabulator formatter closure — TMX has no jsdom layer, so a decision inside a closure gets no unit coverage at all.

## What actually produces PAIR rows

Measured across every local report on a seeded doubles tournament: only **`participant.seedingPerformance`** returns PAIR rows. Entry Status does **not** — mocksEngine enters a doubles event as individuals, so its rows come back INDIVIDUAL even when the tournament holds 8 PAIRs. My first doubles test targeted Entry Status and was **vacuous**; the pre-assert is the only reason I know the PAIR path is reachable rather than speculative.

## No extra `stopPropagation`

`renderIndividual.ts:90` already calls it before invoking `participantClick`, so a name click in a draw-navigable report opens the card **without** also firing `rowClick`. Journey 107 asserts that directly; journey 68 confirms row navigation is unregressed. The plan called for a second guard — it would have been redundant defensive code justified by a comment nobody checked.

## Report parameters

`selectReport` called `generateReport({ reportId })` with **no `parameters` at all**, so the `utcOffsetMinutes` path the factory wrappers already expose was dead. Now carries the runtime offset.

`localizeReportTimes` is deliberately retained: a single offset is the offset *now*, so a tournament spanning a DST change would be an hour off on the far side, while the existing post-pass converts per instant. Noted in-code so the recovery report follows the right shape.

## Falsification

| Reverted | Result |
|---|---|
| `formatParticipant(onParticipantClick)` → `(undefined)` | journey 107 **red** |
| `withIndividualParticipants` dropped | doubles case **red** (0 names, not 2) |
| `sideBySide` dropped | doubles case **red** |

## Gates

lint 0 · check-types 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · **138 files / 1514 tests** (baseline 137/1497) · journeys 68 + 107 (4 cases) green, including an end-to-end check that the new Participant Recovery Time report renders and opens a card.