### PR TITLE
feat(capability): scoped-access entry point, and a mask that is actually populated

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1412,7 +1412,8 @@
       "notClaimed": "Not claimed",
       "offline": "Offline",
       "online": "Online",
-      "uploadWarning": "Warning: This action will replace the tournament record on the server"
+      "uploadWarning": "Warning: This action will replace the tournament record on the server",
+      "scopedAccess": "Scoped access"
     },
     "manageAccess": {
       "title": "Manage access",

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -1,5 +1,6 @@
 import { burstChart, fromFactoryDrawData, createCourtSvg, CourtSport } from 'courthive-components';
 import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
+import { consoleGrantsRoute, consoleUrl } from 'services/navigation/consoleUrl';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
 import { openRegistrationProfileEditor } from './registrationProfileEditor';
 import { donutChartFromMatchUps } from '@courthive/scoring-visualizations';
@@ -551,9 +552,19 @@ export function createActionsPanel(): HTMLElement {
     );
   }
 
-  // Manage access moved to admin-client (provider admin work belongs there,
-  // not in TMX which is end-user-only). The button used to live here; users
-  // now access it via the admin-client `/admin` page → TournamentDetail panel.
+  // Manage access itself lives in the admin console (provider admin work belongs
+  // there, not in TMX which is end-user-only). What is here is a DEEP LINK, not
+  // a return of that UI: grants are per-tournament, and this panel is the only
+  // place in TMX that already knows which tournament — the avatar menu does not,
+  // which is why the general console icon in homeNavigation cannot serve this.
+  if (tournamentRecord && admin && providerId) {
+    btnContainer.appendChild(
+      createActionButton(t('modals.tournamentActions.scopedAccess'), 'fa-user-shield', () => {
+        const route = consoleGrantsRoute(tournamentRecord.tournamentId);
+        globalThis.open(consoleUrl(globalThis.location.origin, route), '_blank', 'noopener');
+      }),
+    );
+  }
 
   if (providerId) {
     btnContainer.appendChild(

--- a/src/pages/tournament/tournamentDisplay.ts
+++ b/src/pages/tournament/tournamentDisplay.ts
@@ -15,8 +15,10 @@ import { tournamentHeader } from '../../components/popovers/tournamentHeader';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
 import { renderEventsTab } from 'pages/tournament/tabs/eventsTab/eventsTab';
 import { renderVenueTab } from 'pages/tournament/tabs/venuesTab/venuesTab';
+import { loadCallerGrants } from 'services/capability/loadCallerGrants';
 import { renderOverview } from './tabs/overviewTab/renderOverview';
 import { getLoginState } from 'services/authentication/loginState';
+import { clearCallerGrants } from 'services/capability/scopeState';
 import { maybeNudgeActiveDates } from './maybeNudgeActiveDates';
 import { showContent } from 'services/transitions/screenSlaver';
 import { factoryConstants } from 'tods-competition-factory';
@@ -278,7 +280,14 @@ export function loadTournament({ tournamentRecord, config }: { tournamentRecord?
     if (config.tournamentId) {
       const offline = tournamentRecord?.timeItems?.find(({ itemType }: any) => itemType === 'TMX')?.itemValue?.offline;
       if (offline) return tryLocal();
-      requestTournament({ tournamentId: config.tournamentId, silent: true }).then(showResult, tryLocal);
+      // Grants are fetched ALONGSIDE the record rather than after it, so the
+      // first paint is already scoped. Resolving them after the render would
+      // show a scoped recorder every control for a moment and then take them
+      // away, which reads as a bug rather than as a restriction.
+      Promise.all([
+        requestTournament({ tournamentId: config.tournamentId, silent: true }),
+        loadCallerGrants(config.tournamentId),
+      ]).then(([result]) => showResult(result), tryLocal);
     }
   } else {
     // No provider context (logged out / local). If the record is missing — e.g. it was deleted
@@ -286,6 +295,9 @@ export function loadTournament({ tournamentRecord, config }: { tournamentRecord?
     // setState(undefined) and rendering an empty, record-less tournament view that traps the
     // whole nav (every tab renders empty and back-to-list is dead).
     if (!tournamentRecord) return notFound();
+    // No server to ask, so no grants — but the mask is a singleton and the
+    // previous tournament's would otherwise survive the navigation.
+    clearCallerGrants();
     tournamentEngine.setState(tournamentRecord);
     runActiveScaleAutoSwitch();
     renderTournament({ config });

--- a/src/services/capability/loadCallerGrants.test.ts
+++ b/src/services/capability/loadCallerGrants.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getCallerGrants, isScopeUnrestricted, setCallerGrants } from './scopeState';
+import { loadCallerGrants } from './loadCallerGrants';
+
+const post = vi.fn();
+vi.mock('services/apis/baseApi', () => ({ baseApi: { post: (...args: any[]) => post(...args) } }));
+
+const COURT_7 = { capability: 'canEnterScores', scope: { courtIds: ['court-7'] } };
+const CENTRE = { capability: 'canEnterScores', scope: { courtIds: ['centre'] } };
+
+beforeEach(() => {
+  post.mockReset();
+  setCallerGrants([]);
+});
+
+describe('loadCallerGrants', () => {
+  it('populates the mask from the caller own grants', async () => {
+    post.mockResolvedValue({ data: { grants: [COURT_7] } });
+    await loadCallerGrants('t1');
+
+    expect(post).toHaveBeenCalledWith('/factory/my-grants', { tournamentId: 't1' }, expect.anything());
+    expect(getCallerGrants()).toEqual([COURT_7]);
+    expect(isScopeUnrestricted()).toBe(false);
+  });
+
+  // The mask is a module singleton, so without clearing FIRST a failure would
+  // leave the previous tournament's restriction applied to this one.
+  it('clears the previous tournament grants before fetching', async () => {
+    setCallerGrants([CENTRE]);
+    post.mockRejectedValue(new Error('network'));
+
+    await loadCallerGrants('t2');
+
+    expect(getCallerGrants()).toEqual([]);
+    expect(isScopeUnrestricted()).toBe(true);
+  });
+
+  it('replaces rather than merges when a new tournament has its own grants', async () => {
+    setCallerGrants([CENTRE]);
+    post.mockResolvedValue({ data: { grants: [COURT_7] } });
+
+    await loadCallerGrants('t2');
+
+    expect(getCallerGrants()).toEqual([COURT_7]);
+  });
+
+  // Unreachable server, a deployment predating the endpoint, an unmigrated
+  // table — all mean "no scoped restriction", which is what the gate concludes.
+  it('resolves to unrestricted when the request fails, without throwing', async () => {
+    post.mockRejectedValue(new Error('404'));
+    await expect(loadCallerGrants('t1')).resolves.toBeUndefined();
+    expect(isScopeUnrestricted()).toBe(true);
+  });
+
+  it('treats an empty grant list as unrestricted rather than as locked down', async () => {
+    post.mockResolvedValue({ data: { grants: [] } });
+    await loadCallerGrants('t1');
+    expect(isScopeUnrestricted()).toBe(true);
+  });
+
+  it('tolerates a payload without a grants array', async () => {
+    post.mockResolvedValue({ data: {} });
+    await loadCallerGrants('t1');
+    expect(isScopeUnrestricted()).toBe(true);
+  });
+
+  it('does not call the server without a tournament, and still clears', async () => {
+    setCallerGrants([CENTRE]);
+    await loadCallerGrants(undefined);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(isScopeUnrestricted()).toBe(true);
+  });
+});

--- a/src/services/capability/loadCallerGrants.ts
+++ b/src/services/capability/loadCallerGrants.ts
@@ -1,0 +1,48 @@
+/**
+ * Populates the scoped-grant mask for the tournament being opened.
+ *
+ * `canForResource` has shipped since TMX #1344 and every call to it has been a
+ * no-op, because nothing ever called `setCallerGrants` — the mask was
+ * permanently empty, which reads as "unrestricted". Adopting the scoped check at
+ * call sites without this is decorative: it would look done and change nothing.
+ *
+ * ## Clearing first is the load-bearing part
+ *
+ * The mask is a module singleton, so the previous tournament's grants outlive
+ * navigation. Clearing before the fetch means a failure leaves the user
+ * UNRESTRICTED rather than restricted by a grant that applies to a different
+ * tournament — which would hide controls they are entitled to, on a tournament
+ * the grant never mentioned.
+ *
+ * That direction is deliberate throughout this layer: the server is
+ * authoritative, so the worst a stale or missing mask causes is a control
+ * offered and then refused. The opposite — a control wrongly withheld — has no
+ * server-side correction at all.
+ */
+import { clearCallerGrants, setCallerGrants } from 'services/capability/scopeState';
+import { baseApi } from 'services/apis/baseApi';
+
+/**
+ * Fetch the caller's own live grants for `tournamentId`.
+ *
+ * Resolves rather than rejects: an unreachable server, a deployment predating
+ * the endpoint, or a `tournament_grants` table that has not been migrated all
+ * mean the same thing to the client as they do to the gate — no scoped
+ * restriction to apply.
+ */
+export async function loadCallerGrants(tournamentId?: string): Promise<void> {
+  clearCallerGrants();
+  if (!tournamentId) return;
+
+  try {
+    const result: any = await baseApi.post('/factory/my-grants', { tournamentId }, { silenceErrors: true } as any);
+    // No array-shape guard here on purpose: `setCallerGrants` already normalizes
+    // a non-array to empty, and a second copy of that rule was measurably dead —
+    // neutering it changed no test, which is the definition of code that is not
+    // doing anything.
+    setCallerGrants(result?.data?.grants);
+  } catch {
+    // Already cleared — unrestricted, matching what the server's own gate
+    // concludes when it cannot read the table.
+  }
+}

--- a/src/services/navigation/consoleUrl.test.ts
+++ b/src/services/navigation/consoleUrl.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { consoleGrantsRoute, consoleUrl } from './consoleUrl';
+
+describe('consoleUrl', () => {
+  it('returns the console root when no route is given', () => {
+    expect(consoleUrl('https://courthive.net')).toBe('https://courthive.net/console/');
+  });
+
+  // The console routes with Navigo in hash mode, so the route has to land after
+  // the '#' or it resolves against the server instead.
+  it('places a route in the hash, after the trailing slash', () => {
+    expect(consoleUrl('https://courthive.net', '/grants/t1')).toBe('https://courthive.net/console/#/grants/t1');
+  });
+
+  it('works against a dev origin with a port', () => {
+    expect(consoleUrl('http://localhost:8080', '/grants/t1')).toBe('http://localhost:8080/console/#/grants/t1');
+  });
+});
+
+describe('consoleGrantsRoute', () => {
+  it('builds the tournament-scoped grants route', () => {
+    expect(consoleGrantsRoute('3f2504e0-4f89-11d3-9a0c-0305e82c3301')).toBe(
+      '/grants/3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+    );
+  });
+
+  it('encodes an id that would otherwise break the route', () => {
+    expect(consoleGrantsRoute('a/b?c#d')).toBe('/grants/a%2Fb%3Fc%23d');
+  });
+});

--- a/src/services/navigation/consoleUrl.ts
+++ b/src/services/navigation/consoleUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * URLs into the AMS console.
+ *
+ * The console base was spelled out inline in `openConsole`; a second copy for
+ * the tournament Actions deep link would be a second thing to change when the
+ * console moves. Pure, and taking `origin` as an argument rather than reading
+ * `globalThis`, because TMX runs no DOM shim in unit tests — a decision that
+ * reads the global is a decision that gets no coverage.
+ */
+
+/** Console routes are hash routes, mirroring the console's own Navigo setup. */
+export function consoleUrl(origin: string, hashRoute = ''): string {
+  const base = `${origin}/console/`;
+  return hashRoute ? `${base}#${hashRoute}` : base;
+}
+
+/**
+ * Scoped access for one tournament.
+ *
+ * Grants are per-tournament, which is why this deep link lives on the Actions
+ * panel rather than the avatar menu: the avatar carries no tournament context.
+ */
+export function consoleGrantsRoute(tournamentId: string): string {
+  return `/grants/${encodeURIComponent(tournamentId)}`;
+}


### PR DESCRIPTION
The TMX half of scoped grants. Pairs with [CFS #926](https://github.com/CourtHive/competition-factory-server/pull/926) (write API) and [courthive-ams #141](https://github.com/CourtHive/courthive-ams/pull/141) (the console screen this links to).

Two commits, and the second is the one that matters.

## 1. The entry point — a deep link from the Actions panel

Grants are **per-tournament**, and this panel is the only place in TMX that already knows which tournament. The avatar menu carries none, which is why the general console icon in `homeNavigation.ts` cannot serve this and why a third entry point is not wanted. `TMX_LOCKDOWN_AND_ROLE_MODEL.md` §10.5 specifies it here.

**This is a link, not a reversal.** `dashboardPanels.ts` carried a comment recording that Manage Access *moved out* of TMX to the console because provider-admin work belongs there. That still holds — this adds a deep link, not the UI — and the comment now says so, so the next reader does not read the button as the move being undone. Gated on `admin && providerId`: CFS refuses to create a grant on a tournament with no owning provider, so the button does not appear where Save could not succeed.

`consoleUrl` now owns the console base, which was spelled out inline in `openConsole`. It takes `origin` as an argument rather than reading `globalThis` — TMX runs no DOM shim in unit tests, so a decision that reads the global is a decision with no coverage.

## 2. `canForResource` was a guaranteed no-op — this fixes that

`canForResource` shipped in #1344 and `setCallerGrants` **has never been called anywhere outside its own test**. The mask was permanently empty, and an empty mask reads as *unrestricted*. So every scoped check in the app has been answering "yes" unconditionally since it landed.

That is worth stating plainly because §10.5's next item is *"adopt `canForResource` at call sites"* — doing that first would have produced a diff that looks like scope enforcement and enforces nothing.

`loadCallerGrants` fetches `POST /factory/my-grants` **alongside** the tournament record, not after it, so the first paint is already scoped. Resolving later would show a scoped recorder every control for a moment and then remove them, which reads as a bug rather than as a restriction.

**Clearing before the fetch is the load-bearing part.** The mask is a module singleton, so the previous tournament's grants outlive navigation. Clearing first means a failed fetch leaves the user *unrestricted*, rather than restricted by a grant that names a different tournament. That direction is deliberate throughout this layer: the server is authoritative, so a stale or missing mask can only offer a control that is then refused — while a control wrongly withheld has no server-side correction at all. The local and no-provider paths clear too.

## Falsification

| neuter | result |
|---|---|
| clear only when there is no tournamentId (i.e. not before the fetch) | **1 failed / 49 collected** |
| set whatever the payload carried, unguarded | **49 passed** — the guard was dead |

The second one is a finding, not a pass: `setCallerGrants` already normalizes a non-array to empty, so my array-shape check could not change any outcome. Removed rather than kept, with a comment saying why.

## Gates

Run in an isolated worktree off `origin/main` with the `link:` overrides stripped and dependencies installed from the published pins — against factory **6.30.0** and provider-config **0.18.0**, the resolution CI uses, not the local siblings.

`lint 0 · check-types 0 · format:check 0 · attr-audit --ci 0 · i18n-audit --ci 0 · 139 files / 1509 tests` (baseline on `origin/main`: 137 / 1497).

## Deliberately NOT in this PR

**Adopting `canForResource` at scoring / schedule call sites.** It is a bigger change than §10.5 implies, and worth saying why: the capability resolver currently has exactly **one** adopting file (`renderIndividuals.ts`, 4 participant gates). `matchUpActions.ts`, the scoring surfaces and the schedule grid have **no capability gating at all** today — so "adopt the scoped variant" there is really "introduce gating to those surfaces, in its scoped form", which is P2 resolver work on the surfaces §5 describes as the hardest to converge. With the mask now populated, it is a real change rather than a decorative one, and it deserves its own PR and its own decisions about disabled-with-reason vs hidden.
