### PR TITLE
feat(schedule): surface check-in at call-to-court, and pin autocall to call-and-mark

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2603,6 +2603,12 @@
     "callBeforeCheckIn_one": "{{count}} participant has not checked in. Call to court anyway?",
     "callBeforeCheckIn_other": "{{count}} participants have not checked in. Call to court anyway?",
     "columnHeader": "Checked in",
-    "columnTooltip": "Participants who have presented at the desk for this match"
+    "columnTooltip": "Participants who have presented at the desk for this match",
+    "badgeComplete_one": "The participant has checked in",
+    "badgeComplete_other": "All {{count}} participants have checked in",
+    "badgePartial_one": "{{count}} participant has not checked in yet",
+    "badgePartial_other": "{{count}} participants have not checked in yet",
+    "callOnDropBeforeCheckIn_one": "{{count}} participant has not checked in. Call this match to court anyway?",
+    "callOnDropBeforeCheckIn_other": "{{count}} participants have not checked in. Call this match to court anyway?"
   }
 }

--- a/src/pages/tournament/tabs/scheduleViews/autoCallDueMatches.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/autoCallDueMatches.test.ts
@@ -19,6 +19,41 @@ const column = (courtId: string, cells: any[]): StripColumn => ({ courtId, cells
 const NOW = '12:00';
 
 describe('computeAutoCalls', () => {
+  // ── D4f: autocall CALLS AND MARKS; it never skips on incomplete check-in ──
+  //
+  // These pin a decision, not a mechanism. `computeAutoCalls` has no check-in filter today, so they
+  // pass trivially against current source — that is the point: they exist so that adding one turns
+  // red. CA, 2026-08-24: a silent skip stalls the schedule for a reason no operator can see, and
+  // `runAutoCallPass` is timer-driven and batched, so there is nobody standing there to warn.
+  //
+  // The interactive sites warn instead (D4d) — a test routed through `schedule2CellActions` would
+  // pass identically whether or not autocall skips, and would prove nothing about this decision.
+
+  // Self-contained rather than extending `ready()`: the check-in field belongs to this decision
+  // alone, and widening the shared fixture would imply every autocall case cares about it.
+  const withCheckIn = (checkedInParticipantIds: string[]) => ({
+    drawId: 'd',
+    matchUpId: 'M1',
+    matchUpStatus: 'TO_BE_PLAYED',
+    participantIds: ['p1', 'p2'],
+    payload: {
+      sides: [{ participantId: 'p1' }, { participantId: 'p2' }],
+      schedule: {},
+      checkedInParticipantIds,
+    },
+  });
+
+  it('calls a match on which NOBODY has checked in', () => {
+    expect(computeAutoCalls([column('C1', [withCheckIn([])])], NOW)).toEqual([{ matchUpId: 'M1', drawId: 'd' }]);
+  });
+
+  it('calls a match on which only ONE of two participants has checked in', () => {
+    // The partial — the state the badge exists to surface. Autocall stamps calledAt anyway and
+    // lets the badge carry it; the operator sees "called, 1/2 here" rather than a match that
+    // silently never appeared on the strip.
+    expect(computeAutoCalls([column('C1', [withCheckIn(['p1'])])], NOW)).toEqual([{ matchUpId: 'M1', drawId: 'd' }]);
+  });
+
   it('auto-calls a free court next match with no scheduledTime', () => {
     const cols = [column('C1', [ready({ matchUpId: 'M1', matchUpStatus: 'TO_BE_PLAYED' })])];
     expect(computeAutoCalls(cols, NOW)).toEqual([{ matchUpId: 'M1', drawId: 'd' }]);

--- a/src/pages/tournament/tabs/scheduleViews/checkInBadge.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/checkInBadge.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Catalog check-in badge — the pure model.
+ *
+ * **Every case is built through `getMatchUpCheckInState` rather than by hand-writing a
+ * `MatchUpCheckInState` literal.** A literal would let this suite pass against a badge that reads a
+ * field the real derivation never populates; routing through the real function means the fixture is a
+ * matchUp shape the factory actually produces.
+ *
+ * **And every meaningful case is DOUBLES.** The partial — one of two partners at the desk — is the
+ * whole reason the badge exists. A singles fixture cannot express it, so a singles-only suite would
+ * pass against an implementation that rendered a plain tick.
+ */
+import { checkInBadgeModel } from './checkInBadge';
+import { getMatchUpCheckInState } from 'services/checkIn/checkInState';
+import { describe, expect, it } from 'vitest';
+
+const doublesMatchUp = (checkedInParticipantIds: string[] = []) => ({
+  checkedInParticipantIds,
+  sides: [
+    {
+      sideNumber: 1,
+      participant: {
+        participantId: 'pair1',
+        participantName: 'Rivas/Cole',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p1', participantName: 'Ana Rivas' },
+          { participantId: 'p2', participantName: 'Sam Cole' },
+        ],
+      },
+    },
+    {
+      sideNumber: 2,
+      participant: {
+        participantId: 'pair2',
+        participantName: 'Patel/Nkemelu',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p3', participantName: 'Raj Patel' },
+          { participantId: 'p4', participantName: 'Ike Nkemelu' },
+        ],
+      },
+    },
+  ],
+});
+
+const modelFor = (checkedIn: string[]) => checkInBadgeModel(getMatchUpCheckInState(doublesMatchUp(checkedIn)));
+
+describe('checkInBadgeModel', () => {
+  it('renders the partial as a count, never as a tick — the state the desk manages', () => {
+    const model = modelFor(['p1']);
+    expect(model).not.toBeNull();
+    expect(model?.text).toBe('1/4');
+    expect(model?.tone).toBe('partial');
+    expect(model?.count).toBe(1);
+    expect(model?.total).toBe(4);
+  });
+
+  it('distinguishes three-of-four from complete', () => {
+    // The case a boolean collapses: everyone but one partner is standing at the desk.
+    expect(modelFor(['p1', 'p2', 'p3'])?.tone).toBe('partial');
+    expect(modelFor(['p1', 'p2', 'p3'])?.text).toBe('3/4');
+    expect(modelFor(['p1', 'p2', 'p3', 'p4'])?.tone).toBe('complete');
+    expect(modelFor(['p1', 'p2', 'p3', 'p4'])?.text).toBe('4/4');
+  });
+
+  it('says nothing when nobody has checked in yet', () => {
+    // At the start of a day this is every match in the catalog. A 0/4 on all of them is noise
+    // exactly when the operator most needs to scan.
+    expect(modelFor([])).toBeNull();
+  });
+
+  it('says nothing for a matchUp with no participants', () => {
+    // An unfilled draw position: nobody COULD check in, so the absence is not a signal.
+    expect(checkInBadgeModel(getMatchUpCheckInState({ sides: [] }))).toBeNull();
+  });
+
+  it('counts each half of a pair independently, not the PAIR', () => {
+    // D4c: TMX writes individuals only. A PAIR-level id must not satisfy the count — if it did,
+    // `1/4` and `2/4` would be indistinguishable for a desk that checked in one pair.
+    expect(modelFor(['pair1'])).toBeNull();
+    expect(modelFor(['p1', 'p2'])?.text).toBe('2/4');
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/checkInBadge.ts
+++ b/src/pages/tournament/tabs/scheduleViews/checkInBadge.ts
@@ -1,0 +1,98 @@
+/**
+ * Schedule2 — compact check-in badge for catalog matchUp cards and strip cells.
+ *
+ * Answers *"is everyone for this match actually at the desk?"* at the moment the
+ * operator is deciding which match to call next — while scanning the catalog,
+ * before any card is selected and before the drag starts. The matchUp actions
+ * popover carries the per-participant detail and the toggle; this is the
+ * headline only.
+ *
+ * **Why a badge and not only a warn (D4d/D4f).** Of the three places a matchUp
+ * is called to court, one — `runAutoCallPass` — is timer-driven and batched, so
+ * there is nobody standing there to warn. D4f decides that autocall **calls and
+ * marks** rather than skipping: a silent skip would stall the schedule for a
+ * reason no operator can see. The badge is what "marks" means, so it has to be
+ * a standing signal on the card rather than an interruption at call time.
+ *
+ * Rendered through `renderCardExtra` rather than by post-processing the card
+ * DOM: the catalog rebuilds its cards on every state change, so an externally
+ * appended node would be wiped rather than reused. Same contract as
+ * `restBadge.ts` — return a freshly created element per call, or null.
+ *
+ * The pure model lives in `checkInBadgeModel` because TMX's unit suite runs in
+ * the vitest `node` environment with no jsdom: a decision made inside the
+ * element builder would get no coverage.
+ */
+
+import { getMatchUpCheckInState, checkInSummary } from 'services/checkIn/checkInState';
+import { getCachedAllMatchUps } from './schedule2DataCache';
+import { t } from 'i18n';
+
+// constants and types
+import type { MatchUpCheckInState } from 'services/checkIn/checkInState';
+
+export type CheckInTone = 'none' | 'partial' | 'complete';
+
+export interface CheckInBadgeModel {
+  /** `1/2` — never a bare tick. The partial IS the state the desk manages. */
+  text: string;
+  tone: CheckInTone;
+  count: number;
+  total: number;
+}
+
+/**
+ * What the badge should say, or null for "say nothing".
+ *
+ * **Silent when nobody has checked in.** A `0/2` on every uncalled match would
+ * paint the whole catalog with a warning that carries no information — at the
+ * start of a day nobody has checked in anywhere, so the signal would be pure
+ * noise exactly when the operator most needs to scan. The badge earns its space
+ * only once someone has actually presented at the desk, at which point the
+ * difference between `1/2` and `2/2` is the decision.
+ *
+ * Also silent for a matchUp with no participants (an unfilled draw position):
+ * there is nobody who *could* check in, so an absence is not a signal.
+ */
+export function checkInBadgeModel(state: MatchUpCheckInState): CheckInBadgeModel | null {
+  if (!state.hasParticipants) return null;
+  if (state.checkedInCount === 0) return null;
+
+  return {
+    text: checkInSummary(state),
+    tone: state.allCheckedIn ? 'complete' : 'partial',
+    count: state.checkedInCount,
+    total: state.total,
+  };
+}
+
+/** Resolve the hydrated matchUp — `checkedInParticipantIds` is attached by `addMatchUpContext`. */
+function hydratedMatchUp(matchUpId: string): any {
+  const matchUps = getCachedAllMatchUps()?.matchUps ?? [];
+  return matchUps.find((matchUp: any) => matchUp?.matchUpId === matchUpId);
+}
+
+/**
+ * The `renderCardExtra` implementation. Returns a fresh element per call, or
+ * null when there is nothing worth saying.
+ */
+export function renderCheckInBadge(matchUpId: string): HTMLElement | null {
+  if (!matchUpId) return null;
+
+  const matchUp = hydratedMatchUp(matchUpId);
+  if (!matchUp) return null;
+
+  const model = checkInBadgeModel(getMatchUpCheckInState(matchUp));
+  if (!model) return null;
+
+  const badge = document.createElement('span');
+  badge.className = `tmx-checkin-badge is-${model.tone}`;
+  badge.dataset.checkInTone = model.tone;
+  badge.dataset.checkInCount = String(model.count);
+  badge.textContent = model.text;
+  badge.title =
+    model.tone === 'complete'
+      ? t('checkIn.badgeComplete', { count: model.total })
+      : t('checkIn.badgePartial', { count: model.total - model.count });
+  return badge;
+}

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -275,7 +275,9 @@ import {
   writeInspectorVisible,
   type SidebarTab,
 } from './gridViewStorage';
+import { callToCourtPrompt } from 'services/checkIn/callToCourtPrompt';
 import { renderInspectorSections } from './inspectorReadiness';
+import { renderCheckInBadge } from './checkInBadge';
 import { renderRestBadge } from './restBadge';
 
 /** Distinct, sorted, locale-aware values of an accessor across catalog items.
@@ -410,10 +412,11 @@ export function renderGridView(
     // matchUp. A render hook rather than an external append — the Inspector rebuilds its
     // body on every store tick and would wipe anything appended from outside.
     renderInspectorExtra: (matchUp, state) => renderInspectorSections(matchUp.matchUpId, state.selectedDate),
-    // The rest headline goes on the card itself: the "which do I call next"
-    // decision is made while scanning the catalog, before any card is selected
+    // The rest and check-in headlines go on the card itself: the "which do I call
+    // next" decision is made while scanning the catalog, before any card is selected
     // and before the drag starts, so the Inspector is one interaction too late.
-    renderCardExtra: (matchUp) => renderRestBadge(matchUp.matchUpId, currentDate),
+    // Rest asks whether they are fit to be called, check-in whether they are here.
+    renderCardExtra: (matchUp) => renderCardBadges(matchUp.matchUpId, currentDate),
     // Restore catalog filter state captured from a previous mount within
     // this tournament session. Cleared on tournament load (see loadTournament).
     initialCatalogState: context.scheduleCatalogState,
@@ -2917,6 +2920,21 @@ function commitActiveStripDrop(
   refresh: () => void,
 ): void {
   const courtOrder = target.rowIndex + 1;
+
+  // WARN and proceed, never block (D4d). The active-strip drop IS the call to court, so declining
+  // cancels the whole drop rather than landing the match uncalled — a half-applied drop would leave
+  // the grid asserting a placement the operator did not choose.
+  //
+  // The catalog payload cannot answer this: `CatalogMatchUpItem` carries no `checkedInParticipantIds`,
+  // so the hydrated matchUp has to be resolved. Autocall deliberately skips this prompt (D4f).
+  const dropped = getCachedAllMatchUps()?.matchUps?.find(
+    (matchUp: any) => matchUp?.matchUpId === payload.matchUp.matchUpId,
+  );
+  const prompt = callToCourtPrompt(dropped, { onlyWhenPartial: true });
+  const message =
+    prompt && `${t('checkIn.callOnDropBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`;
+  if (message && !globalThis.confirm(message)) return;
+
   const methods: any[] = [];
 
   if (payload.type === 'GRID_MATCHUP') {
@@ -3617,4 +3635,23 @@ function dateRange(start: string, end: string): string[] {
     current.setDate(current.getDate() + 1);
   }
   return dates;
+}
+
+/**
+ * Both catalog card badges, composed into the single element `renderCardExtra` accepts.
+ *
+ * Rest answers *"are these players fit to be called?"*; check-in answers *"are they actually here?"*.
+ * They are independent questions and an operator scanning the catalog needs both, so neither may
+ * suppress the other. Returns null only when both decline to render, so a card with nothing to say
+ * still gets no empty wrapper.
+ */
+function renderCardBadges(matchUpId: string, viewedDate: string | null): HTMLElement | null {
+  const badges = [renderRestBadge(matchUpId, viewedDate), renderCheckInBadge(matchUpId)].filter(Boolean);
+  if (!badges.length) return null;
+  if (badges.length === 1) return badges[0];
+
+  const wrap = document.createElement('span');
+  wrap.className = 'tmx-card-badges';
+  wrap.append(...(badges as HTMLElement[]));
+  return wrap;
 }

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -8,7 +8,7 @@
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
-import { awaitingCheckIn, getMatchUpCheckInState } from 'services/checkIn/checkInState';
+import { callToCourtPrompt } from 'services/checkIn/callToCourtPrompt';
 import { collectStartAllRestWarning, type StartAllRestWarning } from './startAllRestGuard';
 import { buildScheduleLockMethod, isScheduleLocked } from './scheduleLocks';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
@@ -335,15 +335,9 @@ function showMatchUpCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
     // WARN and proceed, never block (D4d). The desk knows things the record does not — a player who
     // rang ahead, an official who waved them through — and a hard block would teach operators to check
     // everyone in pre-emptively, which destroys the signal the check-in is there to carry.
-    const checkInState = getMatchUpCheckInState(matchUp);
-    const awaiting = awaitingCheckIn(checkInState);
-    if (checkInState.hasParticipants && awaiting.length) {
-      const names = awaiting
-        .map((participant) => participant.participantName)
-        .filter(Boolean)
-        .join(', ');
-      if (!globalThis.confirm(`${t('checkIn.callBeforeCheckIn', { count: awaiting.length })}\n\n${names}`)) return;
-    }
+    const prompt = callToCourtPrompt(matchUp);
+    const message = prompt && `${t('checkIn.callBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`;
+    if (message && !globalThis.confirm(message)) return;
 
     executeMethods(
       [{ method: SET_MATCHUP_CALLED_AT, params: { matchUpId, drawId, calledAt: new Date().toISOString() } }],

--- a/src/services/checkIn/callToCourtPrompt.test.ts
+++ b/src/services/checkIn/callToCourtPrompt.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The call-to-court warning decision (D4d).
+ *
+ * DOUBLES throughout: the case that matters is one partner of a pair still absent, and a singles
+ * fixture cannot express it. A suite built on singles would pass against an implementation that
+ * ignored `individualParticipants` entirely — which is the exact mechanism under test.
+ */
+import { callToCourtPrompt } from './callToCourtPrompt';
+import { describe, expect, it } from 'vitest';
+
+const doublesMatchUp = (checkedInParticipantIds: string[] = []) => ({
+  checkedInParticipantIds,
+  sides: [
+    {
+      sideNumber: 1,
+      participant: {
+        participantId: 'pair1',
+        participantName: 'Rivas/Cole',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p1', participantName: 'Ana Rivas' },
+          { participantId: 'p2', participantName: 'Sam Cole' },
+        ],
+      },
+    },
+    {
+      sideNumber: 2,
+      participant: {
+        participantId: 'pair2',
+        participantName: 'Patel/Nkemelu',
+        participantType: 'PAIR',
+        individualParticipants: [
+          { participantId: 'p3', participantName: 'Raj Patel' },
+          { participantId: 'p4', participantName: 'Ike Nkemelu' },
+        ],
+      },
+    },
+  ],
+});
+
+describe('callToCourtPrompt', () => {
+  it('names exactly the participants who are missing', () => {
+    const prompt = callToCourtPrompt(doublesMatchUp(['p1', 'p3']));
+    expect(prompt?.awaitingCount).toBe(2);
+    expect(prompt?.names).toBe('Sam Cole, Ike Nkemelu');
+  });
+
+  it('warns when one partner of a pair is absent', () => {
+    // The state the desk actually manages — and the one a boolean would collapse.
+    expect(callToCourtPrompt(doublesMatchUp(['p1', 'p2', 'p3']))?.awaitingCount).toBe(1);
+  });
+
+  it('does not warn when everyone has checked in', () => {
+    expect(callToCourtPrompt(doublesMatchUp(['p1', 'p2', 'p3', 'p4']))).toBeNull();
+  });
+
+  it('warns when nobody has checked in', () => {
+    // Distinct from the badge, which stays silent at 0 to avoid painting the whole catalog.
+    // At the moment of calling, "nobody is here" is precisely what the operator must be told.
+    expect(callToCourtPrompt(doublesMatchUp([]))?.awaitingCount).toBe(4);
+  });
+
+  describe('onlyWhenPartial — the drag-to-strip gesture', () => {
+    it('stays silent when nobody has checked in', () => {
+      // The 9am case, and the whole-week case at a tournament not using check-in. A prompt here
+      // fires on EVERY drop, which is the reflexive dismissal D4d exists to avoid.
+      expect(callToCourtPrompt(doublesMatchUp([]), { onlyWhenPartial: true })).toBeNull();
+    });
+
+    it('still warns on a partial — somebody is here and somebody is not', () => {
+      expect(callToCourtPrompt(doublesMatchUp(['p1']), { onlyWhenPartial: true })?.awaitingCount).toBe(3);
+    });
+
+    it('stays silent when everyone has checked in', () => {
+      expect(callToCourtPrompt(doublesMatchUp(['p1', 'p2', 'p3', 'p4']), { onlyWhenPartial: true })).toBeNull();
+    });
+
+    it('differs from the default ONLY at zero', () => {
+      // The control: if this passed with the option ignored, the option would be untested.
+      expect(callToCourtPrompt(doublesMatchUp([]))?.awaitingCount).toBe(4);
+      expect(callToCourtPrompt(doublesMatchUp([]), { onlyWhenPartial: true })).toBeNull();
+    });
+  });
+
+  it('does not warn for a matchUp with no participants', () => {
+    // An unfilled draw position: nobody COULD check in, so there is nothing to warn about.
+    expect(callToCourtPrompt({ sides: [] })).toBeNull();
+    expect(callToCourtPrompt(undefined)).toBeNull();
+  });
+});

--- a/src/services/checkIn/callToCourtPrompt.ts
+++ b/src/services/checkIn/callToCourtPrompt.ts
@@ -1,0 +1,64 @@
+/**
+ * Should calling this matchUp to court warn first, and what does the warning say?
+ *
+ * **Warn and proceed, never block (D4d).** The desk knows things the record does not — a player who
+ * rang ahead, an official who waved them through — and a hard block would teach operators to check
+ * everyone in pre-emptively, which destroys the very signal check-in exists to carry.
+ *
+ * Pure and DOM-free so it gets unit coverage: TMX's suite runs in the vitest `node` environment with
+ * no jsdom, so a decision made inside a `confirm()` call site would be untestable. Callers resolve
+ * their own hydrated matchUp (the schedule surfaces have a cache for this; a catalog item alone does
+ * **not** carry `checkedInParticipantIds`) and supply their own wording — the cell menu and the
+ * active-strip drop phrase the question differently because they are different gestures.
+ *
+ * ⚠️ **This is not consulted by `runAutoCallPass`, and that is deliberate (D4f).** Autocall is
+ * timer-driven and batched, so there is nobody standing there to answer a prompt. It calls and marks:
+ * the badge carries the incomplete state instead. A silent skip would stall the schedule for a reason
+ * no operator can see.
+ */
+
+import { getMatchUpCheckInState, awaitingCheckIn } from './checkInState';
+
+export interface CallToCourtPromptOptions {
+  /**
+   * Suppress the prompt when NOBODY has checked in yet.
+   *
+   * For a high-frequency gesture — dragging onto the Now strip — a prompt at zero fires on every
+   * single drop before the desk has checked anyone in, which at the start of a day is every match,
+   * and at a tournament not using check-in at all is every match all week. That is the reflexive
+   * dismissal D4d exists to avoid, so the drop asks only when the count is PARTIAL: somebody is
+   * demonstrably at the desk for this match and somebody else is not, which is real information.
+   *
+   * An explicit "Call to court" from the cell menu leaves this off: the operator asked to call this
+   * one match, so "nobody is here" is exactly what they need to be told.
+   */
+  onlyWhenPartial?: boolean;
+}
+
+export interface CallToCourtPrompt {
+  /** How many of the matchUp's individuals are not yet at the desk. Always ≥ 1. */
+  awaitingCount: number;
+  /** Their names, comma-joined, for the body of the prompt. */
+  names: string;
+}
+
+/**
+ * Returns null when the call needs no warning — either everyone is checked in, or the matchUp has no
+ * participants who could check in (an unfilled draw position).
+ */
+export function callToCourtPrompt(matchUp?: any, options: CallToCourtPromptOptions = {}): CallToCourtPrompt | null {
+  const state = getMatchUpCheckInState(matchUp);
+  if (!state.hasParticipants) return null;
+  if (options.onlyWhenPartial && state.checkedInCount === 0) return null;
+
+  const awaiting = awaitingCheckIn(state);
+  if (!awaiting.length) return null;
+
+  return {
+    awaitingCount: awaiting.length,
+    names: awaiting
+      .map((participant) => participant.participantName)
+      .filter(Boolean)
+      .join(', '),
+  };
+}

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -551,3 +551,48 @@
   margin-top: 2px;
   border-top: 1px solid var(--tmx-border-primary);
 }
+
+/* Catalog card badge row — rest and check-in sit side by side; see renderCardBadges.
+   Both are independent signals, so the row wraps rather than truncating one away. */
+.tmx-card-badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+/* Check-in badge — "how many of this match's players are at the desk" (D4d/D4f).
+   Rendered ONLY once someone has checked in: a 0/2 on every card at 9am is noise
+   exactly when the operator most needs to scan.
+
+   Deliberately mirrors .tmx-rest-badge's shape and token set rather than inventing
+   its own palette — the two sit side by side on the same card, and they are already
+   proven in both light and dark. */
+.tmx-checkin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.4;
+  padding: 1px 7px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  color: var(--tmx-text-primary);
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+}
+
+/* Partial is the state the whole feature exists to surface, so it is the one that
+   carries colour. Complete stays quiet — it is the expected case, and a catalog of
+   green ticks is as unscannable as a catalog of warnings. */
+.tmx-checkin-badge.is-partial {
+  border-color: var(--tmx-accent-orange);
+  color: var(--tmx-accent-orange);
+  background: transparent;
+}
+
+.tmx-checkin-badge.is-complete {
+  border-color: var(--tmx-accent-green);
+  color: var(--tmx-accent-green);
+  background: transparent;
+}


### PR DESCRIPTION
Completes **D4d/D4f** of [`TMX_PRESENCE_AND_CHECK_IN.md`](https://github.com/CourtHive/Mentat/blob/main/planning/TMX_PRESENCE_AND_CHECK_IN.md) — the remainder of phase (b). Phase (b) shipped the desk workflow in #1340 with the warn on the cell-menu "Call to court"; this adds the two places a match is called that had **no check-in awareness at all**.

## What changed

**A catalog card badge** (`1/2`) showing how many of a match's individuals are at the desk, rendered through courthive-components' existing `renderCardExtra` hook alongside the rest badge.

**No courthive-components change.** The catalog lives there, but `renderCardExtra` is an existing consumer hook TMX already drives from `gridView.ts`. `CatalogMatchUpItem` carries no `checkedInParticipantIds`, so the badge resolves the hydrated matchUp itself — exactly as `restBadge.ts` resolves rest state. No publish, no cascade.

**The badge stays silent until somebody has checked in.** A `0/2` on every card at 9am is noise precisely when the operator most needs to scan, and it is every card all week at a tournament that does not use check-in.

**D4f — autocall calls and marks** rather than skipping. `runAutoCallPass` is timer-driven and batched, so there is nobody to prompt, and a silent skip would stall the schedule for a reason no operator can see.

**The active-strip drop warns only on a PARTIAL.** See the finding below.

**Refactor:** the prompt decision the cell menu inlined is extracted to a shared pure module, so both call sites share one rule and it gets unit coverage. TMX has no jsdom, so a decision made at a `confirm()` call site is untestable.

## Two findings worth reading

**1. Prompting on every drop was wrong, and journey 55 caught it.** My first cut warned on any incomplete check-in at the active-strip drop. Journey 55 failed — the unhandled `confirm` cancelled the drop — and its fixture has *nobody* checked in, which is the 9am state of every match. A modal on every drag is the reflexive dismissal D4d exists to avoid.

The drop now warns only on a **partial**: somebody is demonstrably at the desk for this match and somebody else is not. The explicit cell-menu call still warns at zero, because there the operator asked to call this one match and "nobody is here" is the answer they need.

Journey 55 **passes as written** — no dialog handler was added. The fix made the existing journey legitimate again rather than weakening it.

> This narrows D4d as recorded ("warn at the two interactive sites"). The distinction that actually matters is not interactive vs unattended but **explicit call action vs high-frequency flow gesture**. Flagging for confirmation — it is a one-line revert.

**2. The D4f tests pass trivially against current source, and that is their purpose.** `computeAutoCalls` has no check-in filter today. The tests exist so that *adding* one turns red. Verified by adding a filter and confirming both fail — under a `-t` filter so only those two ran — then reverting.

## Verification

| gate | result |
|---|---|
| `lint` / `check-types` / `format:check` | 0 |
| `attr-audit --ci` / `i18n-audit --ci` | 0 |
| `test --run` | **142 files / 1542 tests** (baseline 140/1526) |
| journeys 55, 61, 105 | 7 passed, 0 `ERR_CONNECTION_REFUSED` |

Every new suite falsified — neutered the implementation, confirmed red with the **collected count unchanged** so a compile break could not read as a pass, then restored green.

## Caveats

- **Journeys are local-only evidence** — PR CI does not run `e2e/journeys/`.
- ⚠️ The factory checkout is on `feat/report-parameters` (PR CourtHive/competition-factory#4692, still open) with `dist/` built from that branch, so these numbers are taken against that `dist` rather than master's. This work needs **no new factory API** — `SET_MATCHUP_CALLED_AT` and `toggleParticipantCheckInState` are long-published — so the risk is a false green, not a false red. Not mine, not touched.