### PR TITLE
feat(reports): open the participant card from the draw structure winner

### DIFF
--- a/e2e/journeys/107-reports-participant-card.spec.ts
+++ b/e2e/journeys/107-reports-participant-card.spec.ts
@@ -225,4 +225,37 @@ test.describe('Journey 107 — reports participant card', () => {
     await expect(modal).toBeVisible({ timeout: 10_000 });
     if (clicked) await expect(modal).toContainText(clicked, { timeout: 5_000 });
   });
+
+  test('the Draw Structure report opens the card from its winner column', async ({ page }) => {
+    // The winner was the one name in the reports surface with no reachable card.
+    // Its id is a PERSON id upstream, so this also proves the factory resolves it
+    // to a participantId rather than passing the personId through.
+    const tournamentId = await seedTournament(page, PROFILE_COMPLETED);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+
+    const winner = await page.evaluate(() => {
+      const res: any = dev.factory.tournamentEngine.generateReport({ reportId: 'structure.drawReport' });
+      const row = (res?.rows ?? []).find((r: any) => r.winner);
+      return row ? { name: row.winner as string, id: row.winningParticipantId as string } : null;
+    });
+    expect(winner, 'no structure reported a winner — the case would be untested').toBeTruthy();
+    expect(winner!.id, 'structure report carries no winningParticipantId').toBeTruthy();
+
+    await page.evaluate((id) => {
+      window.location.hash = `#/tournament/${id}/reports/structure.drawReport`;
+    }, tournamentId);
+
+    const firstRow = page.locator('#tournamentReports .tabulator-row').first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    const name = firstRow.locator('.tmx-i').first();
+    await expect(name).toBeVisible({ timeout: 10_000 });
+    await name.click();
+
+    const modal = page.locator(MODAL);
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+    await expect(modal).toContainText(winner!.name, { timeout: 5_000 });
+  });
 });

--- a/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
+++ b/src/pages/tournament/tabs/reportsTab/createReportsTable.ts
@@ -50,9 +50,19 @@ const HIDDEN_FIELDS = [
   'structureId',
 ];
 
-// Side columns whose plain name string is upgraded to a clickable participant
+// Name-bearing columns whose plain string is upgraded to a clickable participant
 // when the report carries the matching id.
-const SIDE_COLUMNS: Record<string, string> = { side1: 'side1Participant', side2: 'side2Participant' };
+//
+// `winner` (Draw Structure) is here because it is the ONLY participant that
+// report names — without it a champion is unreachable. Match Results' equivalent
+// column, `winnerName`, is deliberately NOT here: that row already renders both
+// opponents as click targets, so converting it would add a third identical chip
+// and reach nobody new. The id is still emitted for export and other consumers.
+const SIDE_COLUMNS: Record<string, string> = {
+  side1: 'side1Participant',
+  side2: 'side2Participant',
+  winner: 'winnerParticipant',
+};
 
 export function createReportsTable({ columns, rows }: { columns: ReportColumn[]; rows: Record<string, any>[] }): {
   table: any;

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.test.ts
@@ -133,11 +133,34 @@ describe('PARTICIPANT_ID_KEYS', () => {
       'participantId',
       'side1ParticipantId',
       'side2ParticipantId',
+      'winningParticipantId',
     ]);
     expect(PARTICIPANT_ID_KEYS.map((k) => k.hydratedKey)).toEqual([
       'participant',
       'side1Participant',
       'side2Participant',
+      'winnerParticipant',
     ]);
+  });
+});
+
+describe('collectReportParticipantIds — winner columns', () => {
+  it('collects a winner who appears in no other column', () => {
+    // The Draw Structure report names ONLY a winner — no sides, no row
+    // participant — so without the winner key those rows contribute nothing and
+    // prev/next would skip every champion in the table.
+    const rows = [{ winnerParticipant: individual('champ') }];
+    expect(collectReportParticipantIds(rows)).toEqual(['champ']);
+  });
+
+  it('does not double-count a winner who is also a side', () => {
+    const rows = [
+      {
+        side1Participant: individual('p1'),
+        side2Participant: individual('p2'),
+        winnerParticipant: individual('p1'),
+      },
+    ];
+    expect(collectReportParticipantIds(rows)).toEqual(['p1', 'p2']);
   });
 });

--- a/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
+++ b/src/pages/tournament/tabs/reportsTab/reportParticipants.ts
@@ -35,8 +35,10 @@ export interface ReportParticipant {
 
 /** A report row, as the factory report wrappers emit it plus the table's hydration. */
 export interface ReportRow {
+  winnerParticipant?: ReportParticipant;
   side1Participant?: ReportParticipant;
   side2Participant?: ReportParticipant;
+  winningParticipantId?: string;
   participant?: ReportParticipant;
   side1ParticipantId?: string;
   side2ParticipantId?: string;
@@ -48,12 +50,15 @@ export interface ReportRow {
  *
  * `participantId` is the participant-grain reports (one row per participant);
  * the side keys are the matchUp-grain ones, where a row names two opponents and
- * neither is "the" participant of the row.
+ * neither is "the" participant of the row. `winningParticipantId` is the winner
+ * columns — one hydrated key serves both Match Results and the Draw Structure
+ * report, since a row has exactly one winner.
  */
 export const PARTICIPANT_ID_KEYS = [
   { idKey: 'participantId', hydratedKey: 'participant' },
   { idKey: 'side1ParticipantId', hydratedKey: 'side1Participant' },
   { idKey: 'side2ParticipantId', hydratedKey: 'side2Participant' },
+  { idKey: 'winningParticipantId', hydratedKey: 'winnerParticipant' },
 ] as const;
 
 /**


### PR DESCRIPTION
Closes the one gap left open by [#1347](https://github.com/CourtHive/TMX/pull/1347): phase E made the matchUp-grain **side** columns clickable but left the **winner** columns alone.

The Draw Structure report names exactly one participant per row — the winner — and it was the last name in the reports surface with no reachable card.

Pairs with CourtHive/competition-factory#4693, which emits the id.

## Match Results is deliberately NOT converted

Its equivalent column (`winnerName`) already sits in a row that renders **both opponents** as click targets, so converting it would add a third identical chip and reach nobody new.

Journey 107's side-column case caught this directly rather than by argument: converting both columns took the first Match Results row from **two** rendered participants to **three**, and the existing `toHaveCount(2)` assertion failed. The id is still emitted there for export and other consumers.

## Graceful until the factory publishes

Hydration is keyed on the id being present in the row (`idKey in firstRow`), so until factory 6.31.x ships `winningParticipantId`, the column falls back to the plain name the report already carried. No broken state.

## Falsification

Dropping `winner` from the column map turns the new journey case red (5 → 4 passing).

## Gates

lint 0 · check-types 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · **142 files / 1544 tests** · journey 107 (5 cases) green.