### PR TITLE
feat(schedule): on/off/auto call-to-court prompts, and a check-in badge on the strip

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2609,6 +2609,15 @@
     "badgePartial_one": "{{count}} participant has not checked in yet",
     "badgePartial_other": "{{count}} participants have not checked in yet",
     "callOnDropBeforeCheckIn_one": "{{count}} participant has not checked in. Call this match to court anyway?",
-    "callOnDropBeforeCheckIn_other": "{{count}} participants have not checked in. Call this match to court anyway?"
+    "callOnDropBeforeCheckIn_other": "{{count}} participants have not checked in. Call this match to court anyway?",
+    "promptMode": {
+      "label": "Check-in prompts",
+      "off": "Off",
+      "on": "On",
+      "auto": "Auto",
+      "offHint": "Never ask before calling a match to court.",
+      "onHint": "Always ask when someone has not checked in.",
+      "autoHint": "Ask only when this tournament is using check-in today."
+    }
   }
 }

--- a/src/pages/tournament/tabs/scheduleViews/checkInModeToggle.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/checkInModeToggle.test.ts
@@ -1,0 +1,30 @@
+import { nextCheckInPromptMode, checkInModeGlyph } from './checkInModeToggle';
+import { describe, expect, it } from 'vitest';
+
+describe('nextCheckInPromptMode', () => {
+  it('cycles off to on to auto and back', () => {
+    // The two definite answers come first; auto is the clever one you arrive at last.
+    expect(nextCheckInPromptMode('off')).toBe('on');
+    expect(nextCheckInPromptMode('on')).toBe('auto');
+    expect(nextCheckInPromptMode('auto')).toBe('off');
+  });
+
+  it('returns every mode exactly once before repeating', () => {
+    // Guards the modulo: an off-by-one would strand a mode as unreachable from the button.
+    const seen = new Set();
+    let mode = 'off' as ReturnType<typeof nextCheckInPromptMode>;
+    for (let i = 0; i < 3; i++) {
+      seen.add(mode);
+      mode = nextCheckInPromptMode(mode);
+    }
+    expect([...seen].sort()).toEqual(['auto', 'off', 'on']);
+    expect(mode).toBe('off');
+  });
+});
+
+describe('checkInModeGlyph', () => {
+  it('gives each mode a distinct glyph', () => {
+    const glyphs = ['off', 'on', 'auto'].map((m) => checkInModeGlyph(m as any));
+    expect(new Set(glyphs).size).toBe(3);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/checkInModeToggle.ts
+++ b/src/pages/tournament/tabs/scheduleViews/checkInModeToggle.ts
@@ -1,0 +1,67 @@
+/**
+ * Header control for the call-to-court prompt mode (On / Off / Auto).
+ *
+ * A single cycling button rather than three radios or a select: it is a rarely-touched preference
+ * whose current value matters more than its options, and the grid header is a dense row where a
+ * select would cost width the court columns need.
+ *
+ * **Off is the default and the resting state**, so the button must read as inert there — the desk
+ * that never opens this should not see a lit control implying something is switched on. Only `on`
+ * and `auto` carry colour.
+ *
+ * The mode gates *prompting only*. The `1/2` badge is deliberately never gated by it: it is already
+ * self-gating, appearing only once somebody has checked in. See `checkInPromptMode.ts`.
+ */
+
+import { CHECK_IN_PROMPT_MODES } from 'services/checkIn/checkInPromptMode';
+import { readCheckInPromptMode, writeCheckInPromptMode } from './gridViewStorage';
+import { t } from 'i18n';
+
+// constants and types
+import type { CheckInPromptMode } from 'services/checkIn/checkInPromptMode';
+
+/** Next mode in the cycle. Pure so the ordering is testable without a DOM. */
+export function nextCheckInPromptMode(current: CheckInPromptMode): CheckInPromptMode {
+  const index = CHECK_IN_PROMPT_MODES.indexOf(current);
+  return CHECK_IN_PROMPT_MODES[(index + 1) % CHECK_IN_PROMPT_MODES.length];
+}
+
+/** Glyph per mode — a filled bell for on, a struck bell for off, a half bell for auto. */
+export function checkInModeGlyph(mode: CheckInPromptMode): string {
+  if (mode === 'on') return '\u{1F514}';
+  if (mode === 'auto') return '\u{1F50D}';
+  return '\u{1F515}';
+}
+
+function paint(button: HTMLButtonElement, mode: CheckInPromptMode): void {
+  button.dataset.checkInMode = mode;
+  button.className = `tmx-checkin-mode-toggle is-${mode}`;
+  button.textContent = checkInModeGlyph(mode);
+  // Keys hoisted out of the template: sonarjs/no-nested-template-literals, and it reads better.
+  const label = t('checkIn.promptMode.label');
+  const name = t(`checkIn.promptMode.${mode}`);
+  const hint = t(`checkIn.promptMode.${mode}Hint`);
+  const summary = `${label}: ${name}`;
+
+  button.title = `${summary}\n${hint}`;
+  button.setAttribute('aria-label', summary);
+}
+
+/**
+ * The header button. `onChange` lets the caller repaint anything mode-dependent; the badge is not
+ * mode-dependent, so today nothing needs it beyond persistence.
+ */
+export function buildCheckInModeToggle(onChange?: (mode: CheckInPromptMode) => void): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  paint(button, readCheckInPromptMode());
+
+  button.addEventListener('click', () => {
+    const mode = nextCheckInPromptMode(readCheckInPromptMode());
+    writeCheckInPromptMode(mode);
+    paint(button, mode);
+    onChange?.(mode);
+  });
+
+  return button;
+}

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -271,11 +271,14 @@ import {
   writeScheduledGroupBy,
   readScheduledFilters,
   writeScheduledFilters,
+  readCheckInPromptMode,
   readInspectorVisible,
   writeInspectorVisible,
   type SidebarTab,
 } from './gridViewStorage';
+import { checkInInUse, shouldPromptOnCall } from 'services/checkIn/checkInPromptMode';
 import { callToCourtPrompt } from 'services/checkIn/callToCourtPrompt';
+import { buildCheckInModeToggle } from './checkInModeToggle';
 import { renderInspectorSections } from './inspectorReadiness';
 import { renderCheckInBadge } from './checkInBadge';
 import { renderRestBadge } from './restBadge';
@@ -365,7 +368,13 @@ export function renderGridView(
       renderCell: (matchUp) => {
         const cellData = matchUp.payload as any;
         if (!cellData) return null;
-        return buildScheduleGridCell(mapMatchUpToCellData(cellData), DEFAULT_SCHEDULE_CELL_CONFIG);
+        const cell = buildScheduleGridCell(mapMatchUpToCellData(cellData), DEFAULT_SCHEDULE_CELL_CONFIG);
+        // The strip is where the call-to-court gesture happens, so the check-in state has to be
+        // legible HERE and not only back on the catalog card. Never gated by the prompt mode:
+        // `off` means "do not interrupt me", not "show me nothing".
+        const badge = renderCheckInBadge(matchUp.matchUpId);
+        if (badge) cell.appendChild(badge);
+        return cell;
       },
     },
   );
@@ -397,7 +406,10 @@ export function renderGridView(
     scheduleDates,
     issues,
     courtGridElement: gridWrapper,
-    headerActions: options?.headerActions,
+    // Built here rather than by each caller: three entry points (schedulingTab, planView,
+    // profileView) thread headerActions, and the prompt mode belongs to the schedule surface itself
+    // rather than to any one of them.
+    headerActions: [buildCheckInModeToggle(), ...(options?.headerActions ?? [])],
     titleLeadingActions: options?.titleLeadingActions,
     titleSlot: options?.titleSlot,
     // Seed the store with the persisted visibility so the very first click
@@ -2930,10 +2942,19 @@ function commitActiveStripDrop(
   const dropped = getCachedAllMatchUps()?.matchUps?.find(
     (matchUp: any) => matchUp?.matchUpId === payload.matchUp.matchUpId,
   );
-  const prompt = callToCourtPrompt(dropped, { onlyWhenPartial: true });
-  const message =
-    prompt && `${t('checkIn.callOnDropBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`;
-  if (message && !globalThis.confirm(message)) return;
+  const prompt = callToCourtPrompt(dropped);
+  const gated =
+    prompt &&
+    shouldPromptOnCall({
+      mode: readCheckInPromptMode(),
+      inUse: checkInInUse(getCachedAllMatchUps()?.matchUps, currentDate),
+      awaitingCount: prompt.awaitingCount,
+    });
+  if (
+    gated &&
+    !globalThis.confirm(`${t('checkIn.callOnDropBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`)
+  )
+    return;
 
   const methods: any[] = [];
 

--- a/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridViewStorage.ts
@@ -1,3 +1,10 @@
+import { isCheckInPromptMode, DEFAULT_CHECK_IN_PROMPT_MODE } from 'services/checkIn/checkInPromptMode';
+
+// constants and types
+import type { CheckInPromptMode } from 'services/checkIn/checkInPromptMode';
+
+const CHECK_IN_PROMPT_MODE_KEY = 'tmx.schedule.checkInPromptMode';
+
 /**
  * `gridView.ts` persists five pieces of view state across page reloads via
  * `localStorage`:
@@ -136,4 +143,23 @@ export function writeInspectorVisible(visible: boolean): void {
   } catch {
     // storage unavailable
   }
+}
+
+/**
+ * Call-to-court prompt mode (On / Off / Auto). Defaults to `off`.
+ *
+ * **localStorage is a deliberate v1 choice with a known limitation.** "Does this tournament run a
+ * check-in desk?" is a property of operating practice, not of this browser, so two desks at the same
+ * tournament can disagree. That is tolerable only because the default is `off`: a lost or divergent
+ * setting degrades to "no prompts", which is the safe direction. The durable home is a sanctioning
+ * policy on the tournament record — see the note in TMX_PRESENCE_AND_CHECK_IN — and when that lands
+ * it should take precedence over this, with `auto` retiring.
+ */
+export function readCheckInPromptMode(): CheckInPromptMode {
+  const stored = globalThis.localStorage?.getItem(CHECK_IN_PROMPT_MODE_KEY);
+  return isCheckInPromptMode(stored) ? stored : DEFAULT_CHECK_IN_PROMPT_MODE;
+}
+
+export function writeCheckInPromptMode(mode: CheckInPromptMode): void {
+  globalThis.localStorage?.setItem(CHECK_IN_PROMPT_MODE_KEY, mode);
 }

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -8,6 +8,9 @@
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
+import { checkInInUse, shouldPromptOnCall } from 'services/checkIn/checkInPromptMode';
+import { readCheckInPromptMode } from './gridViewStorage';
+import { getCachedAllMatchUps } from './schedule2DataCache';
 import { callToCourtPrompt } from 'services/checkIn/callToCourtPrompt';
 import { collectStartAllRestWarning, type StartAllRestWarning } from './startAllRestGuard';
 import { buildScheduleLockMethod, isScheduleLocked } from './scheduleLocks';
@@ -336,8 +339,18 @@ function showMatchUpCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
     // rang ahead, an official who waved them through — and a hard block would teach operators to check
     // everyone in pre-emptively, which destroys the signal the check-in is there to carry.
     const prompt = callToCourtPrompt(matchUp);
-    const message = prompt && `${t('checkIn.callBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`;
-    if (message && !globalThis.confirm(message)) return;
+    const gated =
+      prompt &&
+      shouldPromptOnCall({
+        mode: readCheckInPromptMode(),
+        inUse: checkInInUse(getCachedAllMatchUps()?.matchUps, scheduledDate),
+        awaitingCount: prompt.awaitingCount,
+      });
+    if (
+      gated &&
+      !globalThis.confirm(`${t('checkIn.callBeforeCheckIn', { count: prompt.awaitingCount })}\n\n${prompt.names}`)
+    )
+      return;
 
     executeMethods(
       [{ method: SET_MATCHUP_CALLED_AT, params: { matchUpId, drawId, calledAt: new Date().toISOString() } }],

--- a/src/services/checkIn/callToCourtPrompt.test.ts
+++ b/src/services/checkIn/callToCourtPrompt.test.ts
@@ -60,28 +60,6 @@ describe('callToCourtPrompt', () => {
     expect(callToCourtPrompt(doublesMatchUp([]))?.awaitingCount).toBe(4);
   });
 
-  describe('onlyWhenPartial — the drag-to-strip gesture', () => {
-    it('stays silent when nobody has checked in', () => {
-      // The 9am case, and the whole-week case at a tournament not using check-in. A prompt here
-      // fires on EVERY drop, which is the reflexive dismissal D4d exists to avoid.
-      expect(callToCourtPrompt(doublesMatchUp([]), { onlyWhenPartial: true })).toBeNull();
-    });
-
-    it('still warns on a partial — somebody is here and somebody is not', () => {
-      expect(callToCourtPrompt(doublesMatchUp(['p1']), { onlyWhenPartial: true })?.awaitingCount).toBe(3);
-    });
-
-    it('stays silent when everyone has checked in', () => {
-      expect(callToCourtPrompt(doublesMatchUp(['p1', 'p2', 'p3', 'p4']), { onlyWhenPartial: true })).toBeNull();
-    });
-
-    it('differs from the default ONLY at zero', () => {
-      // The control: if this passed with the option ignored, the option would be untested.
-      expect(callToCourtPrompt(doublesMatchUp([]))?.awaitingCount).toBe(4);
-      expect(callToCourtPrompt(doublesMatchUp([]), { onlyWhenPartial: true })).toBeNull();
-    });
-  });
-
   it('does not warn for a matchUp with no participants', () => {
     // An unfilled draw position: nobody COULD check in, so there is nothing to warn about.
     expect(callToCourtPrompt({ sides: [] })).toBeNull();

--- a/src/services/checkIn/callToCourtPrompt.ts
+++ b/src/services/checkIn/callToCourtPrompt.ts
@@ -11,6 +11,10 @@
  * **not** carry `checkedInParticipantIds`) and supply their own wording — the cell menu and the
  * active-strip drop phrase the question differently because they are different gestures.
  *
+ * **Content only — the gating lives in [`checkInPromptMode`](./checkInPromptMode.ts).** This answers
+ * *"who is missing?"*; that answers *"should we interrupt for it?"*. Keeping them apart is what lets
+ * the On/Off/Auto decision be unit-tested without a DOM.
+ *
  * ⚠️ **This is not consulted by `runAutoCallPass`, and that is deliberate (D4f).** Autocall is
  * timer-driven and batched, so there is nobody standing there to answer a prompt. It calls and marks:
  * the badge carries the incomplete state instead. A silent skip would stall the schedule for a reason
@@ -18,22 +22,6 @@
  */
 
 import { getMatchUpCheckInState, awaitingCheckIn } from './checkInState';
-
-export interface CallToCourtPromptOptions {
-  /**
-   * Suppress the prompt when NOBODY has checked in yet.
-   *
-   * For a high-frequency gesture — dragging onto the Now strip — a prompt at zero fires on every
-   * single drop before the desk has checked anyone in, which at the start of a day is every match,
-   * and at a tournament not using check-in at all is every match all week. That is the reflexive
-   * dismissal D4d exists to avoid, so the drop asks only when the count is PARTIAL: somebody is
-   * demonstrably at the desk for this match and somebody else is not, which is real information.
-   *
-   * An explicit "Call to court" from the cell menu leaves this off: the operator asked to call this
-   * one match, so "nobody is here" is exactly what they need to be told.
-   */
-  onlyWhenPartial?: boolean;
-}
 
 export interface CallToCourtPrompt {
   /** How many of the matchUp's individuals are not yet at the desk. Always ≥ 1. */
@@ -46,10 +34,9 @@ export interface CallToCourtPrompt {
  * Returns null when the call needs no warning — either everyone is checked in, or the matchUp has no
  * participants who could check in (an unfilled draw position).
  */
-export function callToCourtPrompt(matchUp?: any, options: CallToCourtPromptOptions = {}): CallToCourtPrompt | null {
+export function callToCourtPrompt(matchUp?: any): CallToCourtPrompt | null {
   const state = getMatchUpCheckInState(matchUp);
   if (!state.hasParticipants) return null;
-  if (options.onlyWhenPartial && state.checkedInCount === 0) return null;
 
   const awaiting = awaitingCheckIn(state);
   if (!awaiting.length) return null;

--- a/src/services/checkIn/checkInPromptMode.test.ts
+++ b/src/services/checkIn/checkInPromptMode.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Call-to-court prompt gating: On / Off / Auto.
+ *
+ * The case that drove the whole design is `auto` + `0` checked in for this match while somebody
+ * elsewhere HAS checked in today. The rule this replaced (`onlyWhenPartial`, #1349) was silent
+ * there — and "nobody came" is the most alarming state a desk running check-in can be in.
+ */
+import { checkInInUse, shouldPromptOnCall, DEFAULT_CHECK_IN_PROMPT_MODE } from './checkInPromptMode';
+import { describe, expect, it } from 'vitest';
+
+const DAY = '2026-08-24';
+const OTHER = '2026-08-25';
+
+const matchUp = (checkedInParticipantIds: string[], scheduledDate = DAY) => ({
+  checkedInParticipantIds,
+  schedule: { scheduledDate },
+});
+
+describe('DEFAULT_CHECK_IN_PROMPT_MODE', () => {
+  it('is off — the feature ships dark and is opted into', () => {
+    expect(DEFAULT_CHECK_IN_PROMPT_MODE).toBe('off');
+  });
+});
+
+describe('checkInInUse', () => {
+  it('is false when nobody has checked in anywhere', () => {
+    expect(checkInInUse([matchUp([]), matchUp([])], DAY)).toBe(false);
+  });
+
+  it('is true once anybody has checked in to any match that day', () => {
+    // One check-in anywhere is the evidence that a desk is running check-in at all.
+    expect(checkInInUse([matchUp([]), matchUp(['p1'])], DAY)).toBe(true);
+  });
+
+  it('ignores check-ins on a DIFFERENT date', () => {
+    // Load-bearing: without the date filter, Monday's check-ins arm prompts all Tuesday.
+    expect(checkInInUse([matchUp(['p1'], OTHER)], DAY)).toBe(false);
+  });
+
+  it('spans dates when no date is supplied', () => {
+    expect(checkInInUse([matchUp(['p1'], OTHER)])).toBe(true);
+  });
+
+  it('is false for missing or empty input', () => {
+    expect(checkInInUse(undefined, DAY)).toBe(false);
+    expect(checkInInUse([], DAY)).toBe(false);
+  });
+});
+
+describe('shouldPromptOnCall', () => {
+  it('off never prompts, even when nobody has checked in', () => {
+    expect(shouldPromptOnCall({ mode: 'off', inUse: true, awaitingCount: 4 })).toBe(false);
+  });
+
+  it('on always prompts when somebody is missing, in use or not', () => {
+    expect(shouldPromptOnCall({ mode: 'on', inUse: false, awaitingCount: 1 })).toBe(true);
+  });
+
+  it('auto prompts at ZERO checked in when the desk is using check-in', () => {
+    // THE case the tournament-scoped heuristic exists for, and the one `onlyWhenPartial` missed.
+    expect(shouldPromptOnCall({ mode: 'auto', inUse: true, awaitingCount: 4 })).toBe(true);
+  });
+
+  it('auto stays silent at a tournament not using check-in', () => {
+    // The 9am case, and the all-week case. This is what `onlyWhenPartial` got right and must survive.
+    expect(shouldPromptOnCall({ mode: 'auto', inUse: false, awaitingCount: 4 })).toBe(false);
+  });
+
+  it('never prompts when everyone is already checked in, in any mode', () => {
+    for (const mode of ['off', 'auto', 'on'] as const) {
+      expect(shouldPromptOnCall({ mode, inUse: true, awaitingCount: 0 })).toBe(false);
+    }
+  });
+});

--- a/src/services/checkIn/checkInPromptMode.ts
+++ b/src/services/checkIn/checkInPromptMode.ts
@@ -1,0 +1,76 @@
+/**
+ * When should calling a matchUp to court interrupt the operator?
+ *
+ * Three modes, named for operator **intent** rather than for the mechanism behind them (CA,
+ * 2026-08-24). "heuristic" would have leaked the implementation into a control and asked the desk to
+ * reason about our inference rules.
+ *
+ * | mode | behaviour |
+ * |---|---|
+ * | `off` | never prompt. **The default.** |
+ * | `auto` | prompt only when check-in is demonstrably in use on the viewed date |
+ * | `on` | always prompt when somebody has not checked in |
+ *
+ * **Why `off` is the default.** Most tournaments do not run a check-in desk at all, and for them any
+ * prompt is pure interruption. The feature therefore ships dark and is opted into — CA: *"Auto is for
+ * the curious to explore our deep capabilities."* `off` silences **both** call sites, including the
+ * cell-menu warn that shipped unconditionally in #1340.
+ *
+ * **`off` means "do not interrupt me", not "show me nothing".** The `1/2` badge is never gated by
+ * this mode. It is already self-gating: it renders only once somebody has checked in, which only
+ * happens at a desk that is using check-in. A passive marker costs an operator nothing.
+ *
+ * Pure and DOM-free — TMX has no jsdom, so a decision made at a `confirm()` call site is untestable.
+ */
+
+export type CheckInPromptMode = 'off' | 'auto' | 'on';
+
+/** Cycle order for the toggle: the two definite answers first, then the clever one. */
+export const CHECK_IN_PROMPT_MODES: CheckInPromptMode[] = ['off', 'on', 'auto'];
+
+export const DEFAULT_CHECK_IN_PROMPT_MODE: CheckInPromptMode = 'off';
+
+export function isCheckInPromptMode(value: unknown): value is CheckInPromptMode {
+  return value === 'off' || value === 'auto' || value === 'on';
+}
+
+/**
+ * Is check-in actually being used on this date?
+ *
+ * **Tournament-scoped on purpose, and DATE-scoped within that.** "Is this desk running a check-in
+ * table?" is a fact about operating practice, not about any one match — which is exactly why the
+ * per-matchUp rule this replaces was silent at `0/2`, the most alarming state at a desk that does
+ * use check-in.
+ *
+ * Scoping to the viewed date rather than the whole tournament is load-bearing: an unfiltered read
+ * would arm prompts on Tuesday because somebody checked in on Monday. It also handles "check-in on
+ * finals day but not qualifying" for free.
+ *
+ * Known limitation, accepted rather than designed around: a tournament running check-in for juniors
+ * but not for a concurrent adult event arms prompts for both. Scoping to the event would fix it and
+ * costs more than the misfire is worth.
+ */
+export function checkInInUse(matchUps: any[] | undefined, scheduledDate?: string): boolean {
+  if (!Array.isArray(matchUps)) return false;
+
+  return matchUps.some((matchUp) => {
+    if (scheduledDate && matchUp?.schedule?.scheduledDate !== scheduledDate) return false;
+    return Boolean(matchUp?.checkedInParticipantIds?.length);
+  });
+}
+
+export interface PromptDecision {
+  mode: CheckInPromptMode;
+  /** Whether check-in is in use on the viewed date. Ignored unless the mode is `auto`. */
+  inUse: boolean;
+  /** How many individuals have not checked in. Zero means there is nothing to say. */
+  awaitingCount: number;
+}
+
+/** Whether to interrupt before stamping `calledAt`. */
+export function shouldPromptOnCall({ mode, inUse, awaitingCount }: PromptDecision): boolean {
+  if (awaitingCount <= 0) return false;
+  if (mode === 'off') return false;
+  if (mode === 'on') return true;
+  return inUse;
+}

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -596,3 +596,41 @@
   color: var(--tmx-accent-green);
   background: transparent;
 }
+
+/* Call-to-court prompt mode toggle (On / Off / Auto) in the grid header.
+   Off is the default and the resting state, so it must read as INERT — a desk that
+   never opens this should not see a lit control implying something is switched on.
+   Only on/auto carry colour. Tokens mirror the badges beside it. */
+.tmx-checkin-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 0.35rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--tmx-text-primary);
+  opacity: 0.55;
+}
+
+.tmx-checkin-mode-toggle:hover {
+  opacity: 1;
+  background: var(--sp-chip-bg, rgba(128, 128, 128, 0.12));
+}
+
+.tmx-checkin-mode-toggle.is-on {
+  opacity: 1;
+  color: var(--tmx-accent-green);
+  border-color: var(--tmx-accent-green);
+}
+
+.tmx-checkin-mode-toggle.is-auto {
+  opacity: 1;
+  color: var(--tmx-accent-orange);
+  border-color: var(--tmx-accent-orange);
+}


### PR DESCRIPTION
Follow-up to #1349, on CA's review of the flow-gesture finding. Three changes, all TMX-only — no components change, no publish, no cascade.

## 1. The heuristic becomes tournament- and date-scoped

#1349 prompted only on a **partial**. That was right about the 9am noise problem and wrong at the other end: at a tournament that *does* run a check-in table, `0/2` means **nobody came**, and the partial-only rule was silent exactly then.

The question a desk is actually asking is *"is check-in in use here"* — a fact about operating practice, not about one match. `checkInInUse()` answers it from the matchUps already in hand.

**Date-scoping is load-bearing:** unfiltered, Monday's check-ins would arm prompts all Tuesday. It also handles "check-in on finals day but not qualifying" for free. Known limit, accepted rather than designed around: juniors-with, adults-without on the same day arms both.

## 2. On / Off / Auto, default Off

Named for operator intent, not mechanism — "heuristic" would have put the implementation in a control and asked the desk to reason about our inference rules.

| mode | behaviour |
|---|---|
| **Off** *(default)* | never prompt |
| **On** | always prompt when someone has not checked in |
| **Auto** | prompt only when check-in is in use on the viewed date |

**Off silences both call sites**, including the cell-menu warn that shipped unconditionally in #1340 — a deliberate, confirmed change. Most tournaments run no check-in desk, so the feature ships dark and is opted into.

The toggle is built inside `renderGridView` rather than by each caller, so all three entry points (schedulingTab, planView, profileView) get it without three edits.

## 3. Badge on the strip cell, never gated by the mode

**Off means "don't interrupt me", not "show me nothing."** The badge is already self-gating: it appears only once somebody has checked in, which only happens where check-in is used. It now renders on the strip cell — where the call-to-court gesture actually happens — via TMX's existing `renderCell`; previously it reached only the catalog card.

## Superseded, not weakened

#1349's four `onlyWhenPartial` cases encoded a rule this replaces. They are same-session and mine. The case they existed for — silence at a tournament not using check-in — is covered by `auto` + not-in-use, asserted directly.

## Verification

| gate | result |
|---|---|
| `lint` / `check-types` / `format:check` | 0 |
| `attr-audit --ci` / `i18n-audit --ci` | 0 |
| `test --run` | **144 files / 1552 tests** (main 142/1542) |
| journeys 55, 61, 105 | 7 passed, 0 `ERR_CONNECTION_REFUSED` |

The test delta reconciles three ways — `1542 − 9 + 19`, `1533 (all other files) + 19`, and a static `+10` on the changed files. One intermediate run reported 1554, which reconciled no way and did not reproduce; it was discarded rather than reported.

An earlier run also collected **zero** tests (`Failed to resolve entry for tods-competition-factory`) because a concurrent factory `pnpm verify` was mid-`rimraf dist`. Read as neither pass nor fail, and re-run once `dist` was whole.

## Note for the reviewer

`localStorage` for the mode is a deliberate v1 with a known limit: two desks at one tournament can disagree. That is tolerable **only** because the default is Off, so divergence degrades to "no prompts" — the safe direction. The durable home is a sanctioning policy on the tournament record; `POLICY_TYPE_SANCTIONING` already exists in factory with `GENERIC`/`ITF`/`USTA` fixtures and is currently read by nothing but a types test. When that lands it should take precedence over this, and `Auto` can retire.