### PR TITLE
feat(officials): reach the official you can see — contact column and call sheet

### DIFF
--- a/e2e/journeys/106-officials-board.spec.ts
+++ b/e2e/journeys/106-officials-board.spec.ts
@@ -35,7 +35,12 @@ async function seedOfficials(page: Page): Promise<string> {
           participantName: 'Ada Signed',
           participantType: 'INDIVIDUAL',
           participantRole: 'OFFICIAL',
-          person: { standardFamilyName: 'Signed', standardGivenName: 'Ada' },
+          person: {
+            standardFamilyName: 'Signed',
+            standardGivenName: 'Ada',
+            // isPublic false on purpose: D6 is mark-don't-hide, so this must still RENDER.
+            contacts: [{ contactType: 'MOBILE', mobileTelephone: '+15550100', isPublic: false }],
+          },
         },
         {
           participantId: 'official-absent',
@@ -81,5 +86,24 @@ test.describe('Journey 106 — officials board', () => {
     // D5: signed in today and unassigned = waiting; not signed in = available.
     await expect(signedInRow.locator('[data-official-state]')).toHaveAttribute('data-official-state', 'waiting');
     await expect(absentRow.locator('[data-official-state]')).toHaveAttribute('data-official-state', 'available');
+  });
+
+  test('an un-consented mobile still renders on the board (D6 — mark, do not hide)', async ({ page }) => {
+    const tournamentId = await seedOfficials(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await page.locator(S.NAV_OFFICIALS).click();
+
+    const board = page.locator(S.TOURNAMENT_OFFICIALS);
+    const signedInRow = board.locator('.tabulator-row').filter({ hasText: 'Ada Signed' }).first();
+    await expect(signedInRow).toBeVisible({ timeout: 10_000 });
+
+    // The tappable affordance, not merely the digits — a number a director cannot press is not a
+    // call sheet. Ada's contact is isPublic:false, so this also pins D6.
+    await expect(signedInRow.locator('a[href^="tel:"]').first()).toBeVisible();
+
+    // Bo has no contact at all: absence must read as absence, never as a dead link.
+    const absentRow = board.locator('.tabulator-row').filter({ hasText: 'Bo Absent' }).first();
+    await expect(absentRow.locator('a[href^="tel:"]')).toHaveCount(0);
   });
 });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2636,7 +2636,10 @@
       "court": "Court",
       "next": "Next",
       "matches": "Matches",
-      "onCourt": "On court"
-    }
+      "onCourt": "On court",
+      "contact": "Contact"
+    },
+    "callSheet": "Call sheet",
+    "callSheetSubtitle": "Officials"
   }
 }

--- a/src/pages/tournament/tabs/officialsTab/officialsTab.ts
+++ b/src/pages/tournament/tabs/officialsTab/officialsTab.ts
@@ -14,6 +14,9 @@
  */
 
 import { getCachedAllMatchUps, invalidateMatchUpCaches } from 'pages/tournament/tabs/scheduleViews/schedule2DataCache';
+import { contactFormatter } from 'components/tables/common/formatters/contactFormatter';
+import { controlBar } from 'courthive-components';
+import { callSheet } from 'components/modals/callSheet';
 import { buildOfficialsBoard, type OfficialRow } from 'services/officiating/officialsBoard';
 import { onMutationApplied } from 'services/mutation/mutationObservers';
 import { tournamentEngine } from 'tods-competition-factory';
@@ -22,7 +25,7 @@ import { context } from 'services/context';
 import { t } from 'i18n';
 
 // constants and types
-import { TOURNAMENT_OFFICIALS } from 'constants/tmxConstants';
+import { OFFICIALS_CONTROL, TOURNAMENT_OFFICIALS, RIGHT } from 'constants/tmxConstants';
 
 const TABLE_KEY = 'officialsBoard';
 
@@ -73,6 +76,15 @@ function columns(): any[] {
     { title: t('officials.columns.next'), field: 'nextScheduledTime', hozAlign: 'center', headerSort: true },
     { title: t('officials.columns.matches'), field: 'matchesToday', hozAlign: 'center', headerSort: true },
     {
+      // D6 (mark, don't hide) lives inside contactFormatter — every contact renders, with a marker
+      // on the un-consented ones. A second isPublic gate here would silently disagree with the
+      // participants call sheet.
+      title: t('officials.columns.contact'),
+      field: 'contacts',
+      formatter: contactFormatter,
+      headerSort: false,
+    },
+    {
       title: t('officials.columns.onCourt'),
       field: 'minutesOnCourtToday',
       hozAlign: 'center',
@@ -100,12 +112,50 @@ export function renderOfficialsTab(): void {
   });
 
   context.tables[TABLE_KEY] = table;
+  mountControlBar(table);
 
   // Every column here is derived from matchUp state, so a score or a reschedule behind this board
   // silently invalidates all of it.
   unsubscribe = onMutationApplied(() => {
     invalidateMatchUpCaches();
     context.tables[TABLE_KEY]?.replaceData(rows());
+  });
+}
+
+/**
+ * Call sheet over the board.
+ *
+ * Selection wins when there is one; otherwise the sheet covers the rows the current filters leave
+ * visible. `getRows('active')` rather than `getData()` is load-bearing — `getData()` returns the
+ * unfiltered set, so a director who filtered to the officials still waiting and pressed Call sheet
+ * would get the whole crew. Same rule the participants sheet documents.
+ *
+ * The rows go through verbatim: `buildCallSheet` owns who is reachable and who is not, and
+ * re-deriving personnel here is exactly the drift its header warns about.
+ */
+function openCallSheet(table: any): void {
+  const selected = table?.getSelectedData?.() ?? [];
+  const visible = (table?.getRows('active') ?? []).map((row: any) => row.getData());
+  const rows = selected.length ? selected : visible;
+  callSheet({ rows, subtitle: t('officials.callSheetSubtitle') });
+}
+
+function mountControlBar(table: any): void {
+  const target = document.getElementById(OFFICIALS_CONTROL);
+  if (!target) return;
+  target.innerHTML = '';
+  controlBar({
+    table,
+    target,
+    items: [
+      {
+        label: t('officials.callSheet'),
+        onClick: () => openCallSheet(table),
+        location: RIGHT,
+        id: 'officialsCallSheet',
+        intent: 'none',
+      },
+    ],
   });
 }
 

--- a/src/services/officiating/officialsBoard.ts
+++ b/src/services/officiating/officialsBoard.ts
@@ -55,6 +55,16 @@ export interface OfficialRow {
   nextScheduledTime?: string;
   matchesToday: number;
   minutesOnCourtToday: number;
+  /**
+   * Carried through verbatim for the contact column and the call sheet (P1).
+   *
+   * **Not filtered here.** `contactFormatter` and `buildCallSheet` already own the D6 rule — every
+   * contact is shown with a marker on the un-consented ones, and `isPublic` gates public surfaces
+   * only. Filtering in this module would be a second gate on top of a decided one, and it would
+   * silently disagree with the participants call sheet.
+   */
+  contacts?: any[];
+  participantRole?: string;
 }
 
 /**
@@ -145,6 +155,8 @@ export function buildOfficialsBoard({ matchUps, participants, date }: BoardArgs)
       courtName: current?.schedule?.courtName,
       matchUpId: current?.matchUpId,
       nextScheduledTime: live ? undefined : upcoming[0]?.schedule?.scheduledTime,
+      contacts: participant?.person?.contacts ?? [],
+      participantRole: participant?.participantRole,
       matchesToday: assigned.length,
       minutesOnCourtToday: assigned.reduce((total, matchUp) => total + durationToMinutes(matchUp?.matchUpDuration), 0),
     };


### PR DESCRIPTION
**P1** of [`TMX_OFFICIALS_COORDINATION.md`](https://github.com/CourtHive/Mentat/blob/main/planning/TMX_OFFICIALS_COORDINATION.md) — the officials board now answers *"how do I reach this person?"*, not just *"where are they?"*.

## P1 was almost entirely built already

Fourth stale premise in this plan set. The call sheet (`components/modals/{callSheet,buildCallSheet}.ts`), its pure data layer, `services/contact/contactLinks.ts`, the `tel:`/`sms:`/`mailto:` affordances in `contactFormatter.ts`, and D6's mark-don't-hide all shipped with the participants work — and **none of it is participant-specific**: `buildCallSheet` takes the table's own rows.

So this PR is wiring, not building:

- The board carries `person.contacts` through **verbatim** and renders the existing `contactFormatter` as a column.
- A **Call sheet** control hands the board's rows to the existing modal.

## Two rules inherited rather than re-decided

**No second `isPublic` gate.** D6 (mark, don't hide) already lives inside `contactFormatter`/`isPublicContact`. Adding a gate here would silently disagree with the participants call sheet — two answers to one decided question.

**Selection wins, then filters — `getRows('active')`, never `getData()`.** `getData()` returns the unfiltered set, so a director who filtered to the officials still waiting and pressed Call sheet would get the whole crew. Same rule the participants sheet documents.

And per `buildCallSheet`'s own header, the rows go through untouched: re-deriving who counts as personnel is the drift that once hid SCOREKEEPER and TIMEKEEPER from the Staff view for months.

## Verification

| gate | result |
|---|---|
| `lint` / `check-types` / `format:check` | 0 |
| `attr-audit --ci` / `i18n-audit --ci` | 0 |
| `test --run` | **145 files / 1567 tests** — unchanged, correctly: this adds journey cases, not unit tests |
| journeys 104 + 106 | 5 passed |

Journey 106's new case seeds a contact with **`isPublic: false`**, so it pins D6 rather than merely rendering a number, and asserts the **tappable `tel:` affordance** rather than the digits — a number a director cannot press is not a call sheet. Bo, who has no contact, must show **no link at all**: absence reads as absence, never as a dead link. Falsified by dropping `contacts` from the row — the journey goes red.

> The unchanged test count was reconciled rather than assumed: an earlier gate reported 1565 for identical code. Stashing this change and re-running gives 1567 both with and without it, matching main. My *backgrounded* gate harness has now under-reported the collected count three times while foreground runs stay stable — noted so nobody reads a count from that harness as authoritative without a re-run.