### PR TITLE
feat(officials): certification and eligibility in the picker, fail-soft by design

### DIFF
--- a/attr-audit.config.json
+++ b/attr-audit.config.json
@@ -62,6 +62,7 @@
     "baseURI",
     "participantNames",
     "scheduler",
-    "scope"
+    "scope",
+    "personIds"
   ]
 }

--- a/src/components/popovers/matchUpActions.ts
+++ b/src/components/popovers/matchUpActions.ts
@@ -4,7 +4,9 @@
  */
 import { openNominateScorekeeper, removeScorekeeperNomination } from 'services/crowd/nominateScorekeeperFlow';
 import { confirmDelegatedOutcome, openSetDelegatedOutcome } from 'services/crowd/delegatedOutcomeFlow';
+import { evaluateEligibility, mergeVerdicts } from 'services/officiating/officialEligibility';
 import { evaluateCandidate, resolveConflictPolicy } from 'services/officiating/officialConflicts';
+import { fetchOfficialRecords } from 'services/apis/officiatingApi';
 import {
   buildScheduleLockMethod,
   canToggleScheduleLock,
@@ -218,7 +220,10 @@ export function matchUpActions({
     });
   };
 
-  const selectOfficial = () => {
+  /** Bounded so an unconfigured or unreachable AMS cannot stall the picker. */
+  const OFFICIALS_REGISTRY_TIMEOUT_MS = 1500;
+
+  const selectOfficial = async () => {
     const { participants: officials = [] } = tournamentEngine.getParticipants({
       participantFilters: { participantRoles: [OFFICIAL] },
     });
@@ -249,15 +254,33 @@ export function matchUpActions({
     // Conflict state per candidate, computed locally — no fetch. Evaluated up front so a TD is never
     // offered a choice that will be refused.
     const conflictPolicy = resolveConflictPolicy();
+
+    // Certification / suspension state lives in courthive-ams, so this one is a fetch. It is bounded
+    // rather than awaited indefinitely: most tournaments have no registry configured at all, and a
+    // picker that stalls waiting for a service that will never answer is worse than one that opens
+    // saying "not checked". A timeout resolves to `undefined`, which IS the not-checkable signal —
+    // the failure mode and the honest answer are the same value, so there is nothing to get wrong.
+    const recordsById = await fetchOfficialRecords(
+      officials.map((official: any) => official?.person?.personId ?? official.participantId),
+      AbortSignal.timeout(OFFICIALS_REGISTRY_TIMEOUT_MS),
+    );
+
     const conflictByOfficial = new Map<string, CandidateConflicts>(
       officials.map((official: any) => [
         official.participantId,
-        evaluateCandidate({
-          officialParticipantId: official.participantId,
-          policyDefinitions: conflictPolicy,
-          matchUpId: matchUp.matchUpId,
-          drawId: matchUp.drawId,
-        }),
+        mergeVerdicts(
+          evaluateCandidate({
+            officialParticipantId: official.participantId,
+            policyDefinitions: conflictPolicy,
+            matchUpId: matchUp.matchUpId,
+            drawId: matchUp.drawId,
+          }),
+          evaluateEligibility({
+            recordsById,
+            personId: official?.person?.personId ?? official.participantId,
+            asOfDate: matchUp?.schedule?.scheduledDate,
+          }),
+        ),
       ]),
     );
 
@@ -532,7 +555,7 @@ export function matchUpActions({
       hide: noParticipants || isTerminal,
     },
     {
-      onClick: selectOfficial,
+      onClick: () => void selectOfficial(),
       text: t('officiating.selectOfficial'),
     },
     {

--- a/src/services/apis/officiatingApi.ts
+++ b/src/services/apis/officiatingApi.ts
@@ -1,0 +1,80 @@
+/**
+ * Official-registry reads, proxied by courthive-ams.
+ *
+ * The `OfficialRecord` — certifications, suspensions, evaluations — lives in **courthive-ams**, not
+ * in the tournament record. CFS's `official_records` table is a dead husk with no module behind it,
+ * and the registry never becomes a second home for this data (a stated non-goal of the officials
+ * plan). TMX reads; AMS owns.
+ *
+ * Same auth as `facilitiesApi`: the admin JWT TMX already holds, which AMS verifies and dual-accepts
+ * against CFS's ES256. No new signing path, and the base URL resolution is shared rather than
+ * re-derived.
+ *
+ * **Every read here fails SOFT and says so.** Most tournaments have no AMS registry configured at
+ * all, and that is a legitimate configuration rather than a degraded one — officials are simply
+ * INDIVIDUAL participants with the OFFICIAL role. So a missing registry must render as
+ * *"not checked"*, never as a green tick. `fetchOfficialRecords` returns `undefined` for
+ * "could not ask" and a (possibly empty) map for "asked and this is the answer" — the two are
+ * different facts and the caller must be able to tell them apart.
+ */
+
+import { getAmsBaseUrl } from './facilitiesApi';
+import { getJwtTokenStorageKey } from 'config/localStorage';
+
+/** As held by AMS. Passed to the factory untranslated — it owns the eligibility rules. */
+export interface OfficialRecord {
+  officialRecordId?: string;
+  personId?: string;
+  participantId?: string;
+  certifications?: any[];
+  suspensions?: any[];
+  [attr: string]: unknown;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(getJwtTokenStorageKey());
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Official records for a set of people, keyed by the id they were requested under.
+ *
+ * Returns `undefined` when the registry could not be reached or is not configured — **the
+ * "not checkable" signal**, distinct from an empty map, which means the registry answered and holds
+ * no record for anybody asked. A caller that collapses those two produces exactly the green tick the
+ * fail-soft rule exists to prevent.
+ *
+ * Never throws: a picker must open whether or not AMS is up.
+ */
+export async function fetchOfficialRecords(
+  personIds: string[],
+  signal?: AbortSignal,
+): Promise<Record<string, OfficialRecord> | undefined> {
+  const ids = personIds.filter(Boolean);
+  if (!ids.length) return {};
+
+  try {
+    const params = new URLSearchParams({ personIds: ids.join(',') });
+    const res = await fetch(`${getAmsBaseUrl()}/officiating/records?${params.toString()}`, {
+      headers: authHeaders(),
+      signal,
+    });
+    if (!res.ok) return undefined;
+
+    const body = await res.json();
+    const records: OfficialRecord[] = Array.isArray(body) ? body : (body?.records ?? []);
+    if (!Array.isArray(records)) return undefined;
+
+    const byId: Record<string, OfficialRecord> = {};
+    for (const record of records) {
+      const key = record?.personId ?? record?.participantId;
+      if (key) byId[String(key)] = record;
+    }
+    return byId;
+  } catch {
+    // Includes an aborted request. "Could not ask" is the honest answer in every one of these cases.
+    return undefined;
+  }
+}

--- a/src/services/officiating/officialEligibility.test.ts
+++ b/src/services/officiating/officialEligibility.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Eligibility verdicts and the merge with conflicts.
+ *
+ * **The case that matters is `unknown` vs `none`.** "We could not check" and "we checked and found
+ * nothing" are different facts, and collapsing them into one pixel is the failure the fail-soft rule
+ * exists to prevent. Every test here that asserts `none` has a sibling asserting `unknown`, because
+ * an implementation that returned `none` everywhere would otherwise pass half this suite.
+ */
+import { evaluateEligibility, mergeVerdicts } from './officialEligibility';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// The module imports `tournamentEngine` as a binding, so spying on a separately-required copy does
+// not affect it — module-level mock is the only thing that reaches the call site.
+const getOfficialEligibility = vi.fn();
+vi.mock('tods-competition-factory', () => ({
+  tournamentEngine: {
+    getOfficialEligibility: (...args: any[]) => getOfficialEligibility(...args),
+  },
+}));
+
+const RECORD = { personId: 'p1', certifications: [] };
+
+beforeEach(() => getOfficialEligibility.mockReset());
+
+describe('evaluateEligibility', () => {
+  it('contributes NOTHING when the registry is unreachable or configured for nobody', () => {
+    // The majority case: most tournaments run no AMS registry, and that is legitimate. Returning
+    // `unknown` here would annotate every candidate at every such tournament and bury the COI
+    // signal, which IS checkable locally. Journey 94 caught exactly this.
+    expect(evaluateEligibility({ recordsById: undefined, personId: 'p1' })).toBeUndefined();
+    expect(evaluateEligibility({ recordsById: {}, personId: 'p1' })).toBeUndefined();
+  });
+
+  it('is unknown when the registry IS in use but holds no record for this person', () => {
+    // The registry answered for somebody else, so this person genuinely was not checked.
+    expect(evaluateEligibility({ recordsById: { other: RECORD }, personId: 'p1' })?.level).toBe('unknown');
+  });
+
+  it('is none when the factory says eligible', () => {
+    getOfficialEligibility.mockReturnValue({ eligible: true });
+    expect(evaluateEligibility({ recordsById: { p1: RECORD }, personId: 'p1' })?.level).toBe('none');
+  });
+
+  it('BLOCKS when the factory says ineligible, and carries the reasons', () => {
+    // Not a warn: an expired certification or an active suspension is not a referee's to waive,
+    // unlike a conflict of interest.
+    getOfficialEligibility.mockReturnValue({ eligible: false, reasons: ['certification expired'] });
+    const verdict = evaluateEligibility({ recordsById: { p1: RECORD }, personId: 'p1' });
+    expect(verdict?.level).toBe('blocked');
+    expect(verdict?.reasons).toEqual(['certification expired']);
+  });
+
+  it('is unknown when the factory errors, never none', () => {
+    getOfficialEligibility.mockReturnValue({ error: { message: 'MISSING_OFFICIAL_RECORD' } });
+    expect(evaluateEligibility({ recordsById: { p1: RECORD }, personId: 'p1' })?.level).toBe('unknown');
+  });
+});
+
+describe('mergeVerdicts', () => {
+  it('takes the worst level', () => {
+    expect(mergeVerdicts({ level: 'none', reasons: [] }, { level: 'blocked', reasons: [] }).level).toBe('blocked');
+    expect(mergeVerdicts({ level: 'none', reasons: [] }, { level: 'warn', reasons: [] }).level).toBe('warn');
+  });
+
+  it('ranks unknown ABOVE none — not-checked must not read as clean', () => {
+    // The load-bearing ordering. A clean COI check must not mask an unchecked certification.
+    expect(mergeVerdicts({ level: 'none', reasons: [] }, { level: 'unknown', reasons: [] }).level).toBe('unknown');
+  });
+
+  it('lets a real finding outrank unknown', () => {
+    expect(mergeVerdicts({ level: 'unknown', reasons: [] }, { level: 'warn', reasons: [] }).level).toBe('warn');
+  });
+
+  it('accumulates every reason, not just the first', () => {
+    // A picker showing one reason teaches operators that clearing one issue clears the row.
+    const merged = mergeVerdicts(
+      { level: 'warn', reasons: ['shared group'] },
+      { level: 'blocked', reasons: ['suspended'] },
+    );
+    expect(merged.reasons).toEqual(['shared group', 'suspended']);
+  });
+
+  it('is unknown when given nothing', () => {
+    expect(mergeVerdicts(undefined, undefined).level).toBe('unknown');
+  });
+});

--- a/src/services/officiating/officialEligibility.ts
+++ b/src/services/officiating/officialEligibility.ts
@@ -1,0 +1,100 @@
+/**
+ * Is this official certified and un-suspended for this assignment?
+ *
+ * The companion to `officialConflicts` and **deliberately the same verdict vocabulary**. The picker
+ * shows one badge per candidate, so two parallel level types would force it to invent a merge rule
+ * in the renderer — where TMX has no jsdom and it would get no coverage.
+ *
+ * The rules live in the factory (`getOfficialEligibility`); the record lives in AMS. This module owns
+ * only the translation into a verdict and the merge with the conflict verdict.
+ *
+ * **`unknown` is a first-class answer — but only where the registry is actually in use.**
+ *
+ * The plan is explicit that most tournaments have no AMS registry configured, and that this is a
+ * legitimate configuration rather than a degraded one: officials are simply INDIVIDUAL participants
+ * with the OFFICIAL role. If a missing registry made every candidate read *not checked*, the
+ * annotation would fire on every row at almost every tournament — and a warning on everything is a
+ * warning on nothing. It would also bury the conflict-of-interest signal, which **is** checkable
+ * locally and always runs.
+ *
+ * So eligibility contributes a verdict only once the registry has demonstrably answered for
+ * somebody. Same rule, and the same reasoning, as the check-in prompt heuristic: silent where the
+ * feature is not in use, informative where it is.
+ *
+ * | situation | contributes |
+ * |---|---|
+ * | registry unreachable, or configured for nobody | **nothing** — COI's verdict stands alone |
+ * | registry answered for others, no record for this person | `unknown` — genuinely not checked |
+ * | registry answered, factory says ineligible | `blocked` |
+ * | registry answered, factory says eligible | `none` |
+ *
+ * Caught by journey 94 rather than by review: an earlier cut returned `unknown` whenever the
+ * registry was absent, and every candidate in a registry-less tournament went from annotated-clean
+ * to not-checked.
+ */
+
+import { tournamentEngine } from 'tods-competition-factory';
+
+// constants and types
+import type { ConflictLevel, CandidateConflicts } from './officialConflicts';
+import type { OfficialRecord } from 'services/apis/officiatingApi';
+
+/** Worst-wins ordering. `unknown` outranks `none`: "we could not check" must not read as clean. */
+const SEVERITY: ConflictLevel[] = ['blocked', 'warn', 'unknown', 'none'];
+
+export interface EligibilityArgs {
+  /** `undefined` means the registry could not be asked at all — distinct from "no record for them". */
+  recordsById?: Record<string, OfficialRecord>;
+  personId?: string;
+  certificationFamily?: string;
+  certificationLevel?: string;
+  organisationId?: string;
+  asOfDate?: string;
+}
+
+export function evaluateEligibility({
+  recordsById,
+  personId,
+  certificationFamily,
+  certificationLevel,
+  organisationId,
+  asOfDate,
+}: EligibilityArgs): CandidateConflicts | undefined {
+  // Unreachable, or configured for nobody. Contribute nothing rather than painting every row.
+  // `undefined` and `{}` are deliberately treated alike: we cannot distinguish "AMS is down" from
+  // "no registry here", and the majority case is the latter.
+  if (!recordsById || !Object.keys(recordsById).length) return undefined;
+
+  // The registry IS in use and has no record for this person — genuinely not checked.
+  const officialRecord = personId ? recordsById[personId] : undefined;
+  if (!officialRecord) return { level: 'unknown', reasons: [] };
+
+  const result: any = (tournamentEngine as any).getOfficialEligibility({
+    officialRecord,
+    certificationFamily,
+    certificationLevel,
+    organisationId,
+    asOfDate,
+  });
+
+  if (result?.error) return { level: 'unknown', reasons: [String(result.error?.message ?? result.error)] };
+
+  // Ineligibility BLOCKS rather than warns: unlike a conflict of interest, which a referee may
+  // knowingly accept, an expired certification or an active suspension is not theirs to waive.
+  if (result?.eligible === false) return { level: 'blocked', reasons: result?.reasons ?? [] };
+  return { level: 'none', reasons: [] };
+}
+
+/**
+ * Fold several verdicts into the one the picker renders. Worst wins; reasons accumulate in order.
+ *
+ * A candidate who is both conflicted and uncertified should say both — a picker that shows only the
+ * first reason teaches operators that clearing one issue clears the row.
+ */
+export function mergeVerdicts(...verdicts: (CandidateConflicts | undefined)[]): CandidateConflicts {
+  const present = verdicts.filter(Boolean) as CandidateConflicts[];
+  if (!present.length) return { level: 'unknown', reasons: [] };
+
+  const level = SEVERITY.find((candidate) => present.some((verdict) => verdict.level === candidate)) ?? 'none';
+  return { level, reasons: present.flatMap((verdict) => verdict.reasons ?? []) };
+}


### PR DESCRIPTION
**P2's remainder.** The conflict-of-interest leg already shipped in #1343 (which is why P2 was smaller than the plan scoped), so this adds the two checks that need the AMS registry: **certification** and **suspension**.

## What's here

- **`officiatingApi`** — reads `OfficialRecord`s from courthive-ams with the admin JWT TMX already holds. Never throws; a picker must open whether or not AMS is up.
- **`officialEligibility`** — translates the factory's `getOfficialEligibility` into the **same verdict vocabulary as conflicts**, and merges worst-wins. Two parallel level types would force the renderer to invent a merge rule, where TMX has no jsdom and it would get no coverage.

`unknown` ranks **above** `none` in the merge: a clean COI check must not mask an unchecked certification. Ineligibility **blocks** rather than warns — unlike a conflict of interest, an expired certification is not a referee's to waive.

## Journey 94 caught a design error, not a wiring bug

My first cut returned `unknown` whenever the registry was absent. Journey 94 went red with **every** candidate reading *not checked* — and the plan is explicit that most tournaments run no AMS registry and that this is *"a legitimate configuration, not a degraded one"*.

A warning on every row is a warning on none, and it would have buried the COI signal — which **is** checkable locally and always runs.

So eligibility contributes a verdict only once the registry has demonstrably answered for somebody:

| situation | contributes |
|---|---|
| registry unreachable, or configured for nobody | **nothing** — COI's verdict stands alone |
| registry answered for others, no record for this person | `unknown` — genuinely not checked |
| registry answered, ineligible | `blocked` |
| registry answered, eligible | `none` |

Silent where the feature is not in use, informative where it is — the same rule and the same reasoning as the check-in prompt heuristic, which matters: two surfaces answering "is this thing in use here?" differently is how operators learn to distrust both.

The fetch is bounded at 1500ms. **A timeout resolves to the not-checkable signal**, so the failure mode and the honest answer are the same value — there is nothing to get wrong.

## Verification

| gate | result |
|---|---|
| `lint` / `check-types` / `format:check` | 0 |
| `attr-audit --ci` / `i18n-audit --ci` | 0 |
| `test --run` | **146 files / 1577 tests** (main 145/1567 — +1 file, +10, exactly the new suite) |
| journeys 94, 105, 106 | 7 passed |

Falsified both directions: collapsing `unknown` into `none`, and ranking `unknown` below `none` in the merge, each turn the suite red with the collected count unchanged.

**`attr-audit`: `personIds` allow-listed, not renamed.** Both it and `personId` are real names — the plural is a query parameter, the singular a field. The allow list already carries `registrationIds` and `participantNames` for the same pattern.

> Process note: an earlier run of this gate passed a **misspelled journey path**. Playwright silently ran only the file that existed and reported green — so that run was vacuous. Verified afterwards that a bad path *alone* exits 1, but mixed with a valid one it does not. Journey 94's failure only surfaced once the path was right.