### PR TITLE
fix(officials): the board asked for the wrong day west of UTC

### DIFF
--- a/src/pages/tournament/tabs/officialsTab/officialsTab.ts
+++ b/src/pages/tournament/tabs/officialsTab/officialsTab.ts
@@ -17,7 +17,7 @@ import { getCachedAllMatchUps, invalidateMatchUpCaches } from 'pages/tournament/
 import { contactFormatter } from 'components/tables/common/formatters/contactFormatter';
 import { controlBar } from 'courthive-components';
 import { callSheet } from 'components/modals/callSheet';
-import { buildOfficialsBoard, type OfficialRow } from 'services/officiating/officialsBoard';
+import { buildOfficialsBoard, localCalendarDate, type OfficialRow } from 'services/officiating/officialsBoard';
 import { onMutationApplied } from 'services/mutation/mutationObservers';
 import { tournamentEngine } from 'tods-competition-factory';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -31,9 +31,15 @@ const TABLE_KEY = 'officialsBoard';
 
 let unsubscribe: (() => void) | null = null;
 
-/** Today in the tournament's own frame, matching how the schedule surfaces date-scope. */
+/**
+ * Today, in the same frame every other schedule surface uses.
+ *
+ * Was `toISOString().slice(0, 10)`, which is **UTC**: from ~8pm in Florida it reported tomorrow, so
+ * no matchUp matched the date filter and every official silently read `available`. The comment
+ * claiming it was "the tournament's own frame" was simply wrong.
+ */
 function viewedDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localCalendarDate();
 }
 
 function rows(): OfficialRow[] {

--- a/src/services/officiating/officialsBoard.test.ts
+++ b/src/services/officiating/officialsBoard.test.ts
@@ -5,8 +5,15 @@
  * sign-in must NOT make somebody read as present on Friday. Nothing signs anybody out at end of day,
  * so `participant.signedIn` — the latest value — would say it does.
  */
-import { buildOfficialsBoard, signedInOnDate, durationToMinutes, isOfficial } from './officialsBoard';
+import {
+  buildOfficialsBoard,
+  signedInOnDate,
+  durationToMinutes,
+  isOfficial,
+  localCalendarDate,
+} from './officialsBoard';
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 const DAY = '2026-08-24';
 const PRIOR = '2026-08-23';
@@ -19,11 +26,17 @@ const official = (participantId: string, participantName: string, timeItems: any
   timeItems,
 });
 
-const signIn = (date: string, itemValue = 'SIGNED_IN') => ({
-  itemType: 'SIGN_IN_STATUS',
-  createdAt: `${date}T08:00:00.000Z`,
-  itemValue,
-});
+// Built as a LOCAL midday instant so the fixture means "signed in on that local day" in whatever
+// zone the suite runs in. A fixed `...T08:00:00.000Z` would land on the previous local day for any
+// runner west of UTC-8 — the fixture would then encode the very bug under test.
+const signIn = (date: string, itemValue = 'SIGNED_IN') => {
+  const [y, m, d] = date.split('-').map(Number);
+  return {
+    itemType: 'SIGN_IN_STATUS',
+    createdAt: new Date(y, m - 1, d, 12, 0, 0).toISOString(),
+    itemValue,
+  };
+};
 
 const assignment = (over: any = {}) => ({
   matchUpId: over.matchUpId ?? 'm1',
@@ -51,8 +64,8 @@ describe('signedInOnDate', () => {
 
   it('honours a sign-out later the same day', () => {
     const p = official('o1', 'Ana', [
-      { itemType: 'SIGN_IN_STATUS', createdAt: `${DAY}T08:00:00.000Z`, itemValue: 'SIGNED_IN' },
-      { itemType: 'SIGN_IN_STATUS', createdAt: `${DAY}T17:00:00.000Z`, itemValue: 'SIGNED_OUT' },
+      signIn(DAY, 'SIGNED_IN'),
+      { ...signIn(DAY, 'SIGNED_OUT'), createdAt: new Date(2026, 7, 24, 17, 0, 0).toISOString() },
     ]);
     expect(signedInOnDate(p, DAY)).toBe(false);
   });
@@ -60,6 +73,41 @@ describe('signedInOnDate', () => {
   it('is false with no timeItems at all', () => {
     expect(signedInOnDate(official('o1', 'Ana'), DAY)).toBe(false);
     expect(signedInOnDate(undefined, DAY)).toBe(false);
+  });
+});
+
+describe('localCalendarDate', () => {
+  /**
+   * ⚠️ **The obvious unit test for this is VACUOUS and was removed.**
+   *
+   * TMX runs vitest with `TZ=UTC` (`package.json`: `TZ=UTC vitest`), so local and UTC days are
+   * identical in the suite and no assertion on a Date value can tell the correct implementation from
+   * the shipped bug. Verified rather than assumed: restoring `toISOString().slice(0, 10)` left an
+   * earlier version of this block fully green.
+   *
+   * So the invariant is guarded at the SOURCE instead, which is falsifiable — reintroducing the bug
+   * turns the guard red.
+   */
+  /** Comments are stripped first: this file's own docstring quotes the banned pattern as prose. */
+  const codeOf = (file: string) =>
+    readFileSync(new URL(file, import.meta.url), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+  it('never derives a calendar date from toISOString — that is UTC, and the board is local', () => {
+    const code = codeOf('./officialsBoard.ts');
+    expect(code).not.toMatch(/toISOString\(\)\s*\.slice\(\s*0\s*,\s*10\s*\)/);
+    // Control: the guard must be able to see the code at all, not merely fail to match an empty string.
+    expect(code).toContain('export function localCalendarDate');
+  });
+
+  it('builds the date from LOCAL getters', () => {
+    const code = codeOf('./officialsBoard.ts');
+    for (const getter of ['getFullYear()', 'getMonth()', 'getDate()']) expect(code).toContain(getter);
+  });
+
+  it('returns empty for an unparseable value rather than "NaN-NaN-NaN"', () => {
+    expect(localCalendarDate('not-a-date')).toBe('');
   });
 });
 
@@ -148,6 +196,19 @@ describe('buildOfficialsBoard', () => {
     });
     expect(rows[0].matchesToday).toBe(2);
     expect(rows[0].minutesOnCourtToday).toBe(135);
+  });
+
+  it('caps an unclosed timer at 12h rather than letting it grow without bound', () => {
+    // matchUpDuration adds a live-elapsed term for anything started and not ended, so a forgotten
+    // STOP would otherwise inflate "time on court today" indefinitely.
+    const rows = buildOfficialsBoard({
+      matchUps: [
+        assignment({ matchUpId: 'm1', official: 'o1', matchUpStatus: 'IN_PROGRESS', matchUpDuration: '97:00:00' }),
+      ],
+      participants: [official('o1', 'Ana', [signIn(DAY)])],
+      date: DAY,
+    });
+    expect(rows[0].minutesOnCourtToday).toBe(12 * 60);
   });
 
   it('sorts busiest state first, then by name', () => {

--- a/src/services/officiating/officialsBoard.ts
+++ b/src/services/officiating/officialsBoard.ts
@@ -42,6 +42,38 @@ const COMPLETED_STATUSES = new Set([
   'WALKOVER',
 ]);
 
+/**
+ * A matchUp longer than this is not a match, it is an unclosed timer.
+ *
+ * `matchUpDuration` adds a live-elapsed term for anything started and not ended, so an operator who
+ * forgets to stop the clock makes "time on court today" grow without bound. Twelve hours covers any
+ * real match including a long weather suspension, and matches the factory's own
+ * `MAX_PLAUSIBLE_MATCH_MINUTES` in `recoveryTimeline.ts` — the two surfaces should not disagree about
+ * what is plausible.
+ */
+const MAX_PLAUSIBLE_MATCH_MINUTES = 12 * 60;
+
+/**
+ * The **local** calendar date of an instant — never `toISOString().slice(0, 10)`.
+ *
+ * `toISOString` is UTC, so west of UTC it rolls over while the tournament is still playing: at 8pm in
+ * Florida it already reports tomorrow. Every schedule surface in TMX keys "today" on the operator's
+ * local calendar date (see `gridView.todayIso`), and this must agree with them or the officials board
+ * and the Now strip disagree about what day it is.
+ *
+ * ⚠️ **Local is the established convention, not the ideal one.** The venue's own zone would be better
+ * — a director running a Florida tournament from a Pacific laptop still reads the wrong day — but
+ * moving to venue time is a change every schedule surface must make together. Fixing it here alone
+ * would introduce a *fourth* notion of time.
+ */
+export function localCalendarDate(value?: string | Date): string {
+  const date = value instanceof Date ? value : value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) return '';
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
 export type OfficialState = 'onCourt' | 'assigned' | 'waiting' | 'available';
 
 export interface OfficialRow {
@@ -82,7 +114,9 @@ export interface OfficialRow {
 export function signedInOnDate(participant: any, date: string): boolean {
   const entries = (participant?.timeItems ?? [])
     .filter((timeItem: any) => timeItem?.itemType === SIGN_IN_STATUS && timeItem?.createdAt)
-    .filter((timeItem: any) => String(timeItem.createdAt).slice(0, 10) === date);
+    // `createdAt` is a UTC instant; `date` is a local calendar date. Slicing the ISO string would
+    // compare a UTC day against a local one and disagree for every evening sign-in west of UTC.
+    .filter((timeItem: any) => localCalendarDate(timeItem.createdAt) === date);
 
   if (!entries.length) return false;
 
@@ -158,7 +192,10 @@ export function buildOfficialsBoard({ matchUps, participants, date }: BoardArgs)
       contacts: participant?.person?.contacts ?? [],
       participantRole: participant?.participantRole,
       matchesToday: assigned.length,
-      minutesOnCourtToday: assigned.reduce((total, matchUp) => total + durationToMinutes(matchUp?.matchUpDuration), 0),
+      minutesOnCourtToday: assigned.reduce(
+        (total, matchUp) => total + Math.min(durationToMinutes(matchUp?.matchUpDuration), MAX_PLAUSIBLE_MATCH_MINUTES),
+        0,
+      ),
     };
   });
 


### PR DESCRIPTION
A defect in code I shipped this morning (#1352), found while reading a note another session left for `schedule-rest-frame` about time frames in the rest ladder. Different surface, same root cause: **deriving a day from an instant in the wrong frame.**

## The bug

`viewedDate()` used `toISOString().slice(0, 10)` — which is **UTC**:

```
11:30pm 24 Aug in Florida  →  local day 2026-08-24
                           →  toISOString    2026-08-25   ← what the board asked for
```

From roughly 8pm onward, west of UTC: no matchUp matched the date filter, no sign-in matched, and **every official silently read `available`**. Predictable, daily, and silent. The comment claiming it was "the tournament's own frame" was simply wrong.

`signedInOnDate` had the same fault from the other side — it sliced a UTC `createdAt` and compared it against that date, so even a correct date would have been compared against a UTC day.

Both now go through `localCalendarDate`, matching `gridView.todayIso` — the frame every other schedule surface already keys "today" on.

> **Local is the established convention, not the ideal one.** The venue's own zone would be better: a director running a Florida tournament from a Pacific laptop still reads the wrong day. But moving to venue time is a change every schedule surface must make together, and doing it here alone would introduce a *fourth* notion of time. Left as a follow-up rather than taken unilaterally.

## Also: an unclosed timer no longer grows without bound

`matchUpDuration` adds a live-elapsed term for anything started and not ended, so a forgotten STOP inflated "time on court today" indefinitely. Each matchUp's contribution is now capped at 12h — the same `MAX_PLAUSIBLE_MATCH_MINUTES` the factory's `recoveryTimeline.ts` uses, so the two surfaces agree about what is plausible.

## The test for this is vacuous, and that is the interesting part

TMX runs vitest with **`TZ=UTC`** (`package.json`: `TZ=UTC vitest`). Local and UTC days are therefore identical in the suite, and **no assertion on a `Date` value can tell the fix from the bug**.

I wrote that test first, then restored the exact shipped bug to falsify it — and it stayed **green**. It asserted a property that cannot differ in the test environment.

So the invariant is guarded at the **source** instead, with comments stripped so the guard reads code rather than its own docstring (it quotes the banned pattern as prose). Falsified three ways:

| | |
|---|---|
| restore the shipped bug | **2 red** |
| the fix | 17 green |
| empty source file | **17 red** — the guard cannot pass by reading nothing |

## Verification

lint 0 · check-types 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · **146 files / 1596 tests** · journey 106 green.

Count reconciled: `b0b759d2` (the rest-frame session) accounts for +15 since my last merge; the +4 here are the two source guards, the empty-file control, and the 12h cap.