### PR TITLE
fix(schedule): rest reads the score entry it was already given

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.15.0",
+    "courthive-components": "3.15.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.15.1",
+    "courthive-components": "3.15.0",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1021,6 +1021,14 @@
           "calledAt": "projected from call to court (est.)",
           "scheduledTime": "projected from scheduled time (est.)"
         },
+        "discarded": "Could not read: {{sources}}",
+        "discardedName": {
+          "endTime": "recorded end time",
+          "scoredTime": "score entry",
+          "startTime": "start time",
+          "calledAt": "call to court",
+          "scheduledTime": "scheduled time"
+        },
         "skip": {
           "generic": "Rest cannot be evaluated for this matchUp.",
           "bye": "A BYE needs no rest.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1021,7 +1021,7 @@
           "calledAt": "projected from call to court (est.)",
           "scheduledTime": "projected from scheduled time (est.)"
         },
-        "discarded": "Could not read: {{sources}}",
+        "discarded": "Could not read: {{rungs}}",
         "discardedName": {
           "endTime": "recorded end time",
           "scoredTime": "score entry",

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -429,6 +429,18 @@ export function renderGridView(
     // and before the drag starts, so the Inspector is one interaction too late.
     // Rest asks whether they are fit to be called, check-in whether they are here.
     renderCardExtra: (matchUp) => renderCardBadges(matchUp.matchUpId, currentDate),
+    // The store owns `selectedDate`, which the Inspector reads; `currentDate` is
+    // what every other surface here reads. They must never name different days —
+    // rest computed against day one while the card beside it computed against
+    // today is the failure this closes. TMX collapses the component's own date
+    // strip, so this fires only if that panel is ever surfaced; wiring it anyway
+    // is what makes "one viewed date" a property of the page rather than of the
+    // current layout.
+    onDateSelected: (date: string) => {
+      if (!date || date === currentDate) return;
+      currentDate = date;
+      refresh();
+    },
     // Restore catalog filter state captured from a previous mount within
     // this tournament session. Cleared on tournament load (see loadTournament).
     initialCatalogState: context.scheduleCatalogState,

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
@@ -1,7 +1,9 @@
 import {
+  describeDiscarded,
   describeRest,
   instantLocalDate,
   normalizeTimes,
+  restDateFor,
   toDayMinutesFromClock,
   toDayMinutesFromInstant,
 } from './inspectorRest';
@@ -237,6 +239,51 @@ describe('end to end: a real score entry against a past-dated schedule day', () 
   it('projects a readyAt from the anchor it actually used', () => {
     // 10:38 + 60 minutes of recovery.
     expect(analyze().rows.find((row) => row.participantId === 'p-alice')?.readyAt).toBe('11:38');
+  });
+});
+
+/**
+ * The structural half of the two-viewed-dates fix. Syncing the store's
+ * `selectedDate` (courthive-components 3.15.1) makes the two surfaces agree
+ * today; taking the date off the matchUp makes them unable to disagree.
+ */
+describe('restDateFor — a scheduled matchUp carries its own day', () => {
+  it("prefers the matchUp's own scheduledDate over the ambient viewed date", () => {
+    const matchUp: ReadinessMatchUp = { matchUpId: 'm1', schedule: { scheduledDate: DATE } };
+    expect(restDateFor(matchUp, '2026-01-01')).toBe(DATE);
+  });
+
+  it('falls back to the viewed date for an unscheduled catalog card', () => {
+    expect(restDateFor({ matchUpId: 'm1', schedule: {} }, DATE)).toBe(DATE);
+    expect(restDateFor(undefined, DATE)).toBe(DATE);
+  });
+
+  it('returns null only when neither the matchUp nor the page names a day', () => {
+    expect(restDateFor({ matchUpId: 'm1', schedule: {} }, null)).toBeNull();
+  });
+});
+
+describe('describeDiscarded — a dropped rung is named, not buried', () => {
+  const base: RestRow = {
+    participantId: 'p1',
+    participantName: 'Alice',
+    status: 'resting',
+    requiredMinutes: 60,
+    typeChange: false,
+    load: { singles: 1, doubles: 0, total: 1, ordinal: 2, atLimit: [] },
+  };
+
+  it('says nothing when nothing was dropped', () => {
+    expect(describeDiscarded(base)).toBe('');
+    expect(describeDiscarded({ ...base, discardedSources: [] })).toBe('');
+  });
+
+  it('names each dropped rung in plain words rather than provenance phrasing', () => {
+    const text = describeDiscarded({ ...base, discardedSources: ['endTime', 'scoredTime'] });
+    expect(text).toContain('recorded end time');
+    expect(text).toContain('score entry');
+    // The `source.*` labels are provenance claims and read as nonsense here.
+    expect(text).not.toContain('from score entry (est.)');
   });
 });
 

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
@@ -1,4 +1,11 @@
-import { describeRest, normalizeTimes, toDayMinutesFromClock, toDayMinutesFromInstant } from './inspectorRest';
+import {
+  describeRest,
+  instantLocalDate,
+  normalizeTimes,
+  toDayMinutesFromClock,
+  toDayMinutesFromInstant,
+} from './inspectorRest';
+import { analyzeParticipantRest } from './participantRest';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
@@ -6,6 +13,8 @@ import type { ReadinessMatchUp } from './matchUpReadiness';
 import type { RestRow } from './participantRest';
 
 const DATE = '2026-08-22';
+const NEXT_DAY = '2026-08-23';
+const UNPARSEABLE = 'not-a-date';
 
 /**
  * `pnpm test` pins `TZ=UTC`, but these assertions are deliberately written to
@@ -62,14 +71,57 @@ describe('toDayMinutesFromInstant — UTC instant against local midnight of the 
   });
 
   it('returns a value ABOVE 1439 for an instant on the following day', () => {
-    expect(toDayMinutesFromInstant(localInstant('2026-08-23', '00:30'), DATE)).toBe(1470);
+    expect(toDayMinutesFromInstant(localInstant(NEXT_DAY, '00:30'), DATE)).toBe(1470);
   });
 
   it('returns undefined for a missing instant, a missing date, or an unparseable stamp', () => {
     expect(toDayMinutesFromInstant(undefined, DATE)).toBeUndefined();
     expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), null)).toBeUndefined();
-    expect(toDayMinutesFromInstant('not-a-date', DATE)).toBeUndefined();
-    expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), 'not-a-date')).toBeUndefined();
+    expect(toDayMinutesFromInstant(UNPARSEABLE, DATE)).toBeUndefined();
+    expect(toDayMinutesFromInstant(localInstant(DATE, '13:48'), UNPARSEABLE)).toBeUndefined();
+  });
+});
+
+describe('instantLocalDate — the LOCAL calendar day of an instant', () => {
+  it('names the local day, not the UTC one', () => {
+    expect(instantLocalDate(localInstant(DATE, '00:05'))).toBe(DATE);
+    expect(instantLocalDate(localInstant(DATE, '23:55'))).toBe(DATE);
+    expect(instantLocalDate(localInstant(NEXT_DAY, '12:00'))).toBe(NEXT_DAY);
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(instantLocalDate(localInstant('2026-01-05', '12:00'))).toBe('2026-01-05');
+  });
+
+  it('returns undefined rather than a guess for a missing or unparseable stamp', () => {
+    expect(instantLocalDate(undefined)).toBeUndefined();
+    expect(instantLocalDate(UNPARSEABLE)).toBeUndefined();
+  });
+});
+
+/**
+ * The regression that took the whole feature dark for anyone operating a
+ * tournament whose scheduled dates are not the operator's calendar today —
+ * which `resolveScheduleDate()` produces automatically once every tournament
+ * date is in the past.
+ */
+describe('toDayMinutesFromInstant — a stamp more than a day away reads as its time of day', () => {
+  it('reports the time of day, NOT the elapsed interval, for a stamp days after the viewed date', () => {
+    // Four days on from the viewed day. The elapsed reading was 4 * 1440 + 638.
+    expect(toDayMinutesFromInstant(localInstant('2026-08-26', '10:38'), DATE)).toBe(638);
+  });
+
+  it('does the same for a stamp days BEFORE the viewed date', () => {
+    expect(toDayMinutesFromInstant(localInstant('2026-08-18', '10:38'), DATE)).toBe(638);
+  });
+
+  it('leaves a score entered minutes ago BEHIND a now projected onto the viewed day', () => {
+    // The defect in one line: today 10:38, schedule open on a past tournament
+    // date, operator looking at 11:19. Rest is 41 minutes and must be readable.
+    const scored = toDayMinutesFromInstant(localInstant('2026-08-26', '10:38'), DATE);
+    const projectedNow = 11 * 60 + 19;
+    expect(scored).toBeLessThan(projectedNow);
+    expect(projectedNow - (scored ?? 0)).toBe(41);
   });
 });
 
@@ -94,6 +146,7 @@ describe('normalizeTimes', () => {
     expect(result).toEqual({
       endMinutes: 726,
       scoredMinutes: 731,
+      scoredDate: DATE,
       startMinutes: 607,
       calledMinutes: 595,
       scheduledMinutes: 600,
@@ -102,7 +155,7 @@ describe('normalizeTimes', () => {
 
   it('rolls endTime onto the next day when END_DATE says the match crossed midnight', () => {
     const result = normalizeTimes(
-      matchUp({ scheduledDate: DATE, scheduledTime: '22:30', endTime: '00:40', endDate: '2026-08-23' }),
+      matchUp({ scheduledDate: DATE, scheduledTime: '22:30', endTime: '00:40', endDate: NEXT_DAY }),
       DATE,
     );
     expect(result.endMinutes).toBe(1480);
@@ -123,6 +176,67 @@ describe('normalizeTimes', () => {
   it('yields nothing usable for a matchUp with no schedule at all', () => {
     const result = normalizeTimes({ matchUpId: 'm1', schedule: null }, DATE);
     expect(Object.values(result).every((value) => value === undefined)).toBe(true);
+  });
+});
+
+/**
+ * The two halves joined, on the scenario that was reported: a backdraw final at
+ * 12:00, its semifinals at 09:00 with scores entered from the operator's real
+ * clock — and a schedule open on a tournament date that is not that clock's
+ * calendar today, which `resolveScheduleDate()` produces for any tournament
+ * whose dates have all passed.
+ *
+ * Neither module could catch this alone. `normalizeTimes` looked right in
+ * isolation and `analyzeParticipantRest` behaved correctly on the numbers it was
+ * handed; the defect lived entirely in the frame they exchanged.
+ */
+describe('end to end: a real score entry against a past-dated schedule day', () => {
+  const VIEWED = '2026-08-20';
+  const TODAY = '2026-08-24';
+  const TIMING = { averageMinutes: 90, recoveryMinutes: 60, typeChangeRecoveryMinutes: 30 };
+  const NOW = 11 * 60 + 11; // 11:11, projected onto the viewed day
+
+  const semi: ReadinessMatchUp = {
+    matchUpId: 'm-semi',
+    matchUpType: 'SINGLES',
+    matchUpStatus: 'COMPLETED',
+    winningSide: 1,
+    sides: [{ participantId: 'p-alice', participantName: 'Alice' }, { participantId: 'p-chen' }],
+    schedule: { scheduledDate: VIEWED, scheduledTime: '09:00', scoredTime: localInstant(TODAY, '10:38') },
+  };
+  const final: ReadinessMatchUp = {
+    matchUpId: 'm-final',
+    matchUpType: 'SINGLES',
+    sides: [{ participantId: 'p-alice', participantName: 'Alice' }, { participantId: 'p-bob' }],
+    schedule: { scheduledDate: VIEWED, scheduledTime: '12:00' },
+  };
+
+  function analyze() {
+    const result = analyzeParticipantRest({
+      matchUpId: 'm-final',
+      matchUps: [final, semi],
+      scheduledDate: VIEWED,
+      asOfMinutes: NOW,
+      timingFor: () => TIMING,
+      timesFor: (matchUp) => normalizeTimes(matchUp, VIEWED),
+    });
+    if (!result.evaluated) throw new Error('expected evaluation');
+    return result;
+  }
+
+  it('measures rest from the score entry rather than reporting it unmeasurable', () => {
+    const alice = analyze().rows.find((row) => row.participantId === 'p-alice');
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 33, source: 'scoredTime' });
+    expect(alice?.anchorUnreliable).toBeUndefined();
+  });
+
+  it('counts the semifinal as load, so the final is the second match of the day', () => {
+    expect(analyze().rows.find((row) => row.participantId === 'p-alice')?.load.ordinal).toBe(2);
+  });
+
+  it('projects a readyAt from the anchor it actually used', () => {
+    // 10:38 + 60 minutes of recovery.
+    expect(analyze().rows.find((row) => row.participantId === 'p-alice')?.readyAt).toBe('11:38');
   });
 });
 

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -24,6 +24,24 @@
  * Treating `scoredTime` as a wall clock — or `endTime` as an instant — produces
  * a rest figure wrong by the UTC offset, which is worse than showing nothing.
  *
+ * ── The frame every value ends up in: the VIEWED DAY'S wall clock ──
+ *
+ * `nowDayMinutes()` projects today's time-of-day onto whichever day is on
+ * screen, and the three wall-clock fields are already read against that day. So
+ * the instants have to land in the same frame, and `toDayMinutesFromInstant`
+ * puts them there: local time-of-day, plus a full day for a genuine midnight
+ * crossing, and NOT the raw elapsed interval from the viewed day's midnight.
+ *
+ * The distinction is invisible while the viewed day is the operator's own
+ * calendar today, and decisive the moment it isn't — which is not an exotic
+ * case. `resolveScheduleDate()` opens the schedule on the tournament's LAST
+ * date once all of its dates are past, so anyone operating a past-dated
+ * tournament in real time is in it permanently. Under the elapsed-interval
+ * reading a score entered minutes ago normalized to `+1440·n` and therefore sat
+ * in the "future" against a projected now, which `latestAnchor` can only report
+ * as unmeasurable: the whole rest feature went dark, on every row, for exactly
+ * the operator who is running matches right now.
+ *
  * **Assumption, stated rather than assumed:** browser-local time is venue-local
  * time. This is the convention every other schedule2 surface already uses
  * (`todayIso()`, `effectiveNowOnStripDate()`, the reports tab's `calledAtIso`
@@ -60,20 +78,66 @@ export function toDayMinutesFromClock(value?: string): number | undefined {
 }
 
 /**
- * A UTC ISO instant → minutes from local midnight of `viewedDate`. A stamp from
- * a different calendar day lands outside `0..1439`, which is what the rest
- * arithmetic needs in order to say "ended yesterday" rather than silently
- * wrapping.
+ * An instant → its LOCAL calendar date, `YYYY-MM-DD`. Deliberately not
+ * `toISOString().slice(0, 10)`, which reports the UTC day and so names the wrong
+ * date for every evening stamp west of Greenwich and every early-morning one
+ * east of it. This is what dates a matchUp that carries no `scheduledDate`.
+ */
+export function instantLocalDate(iso?: string): string | undefined {
+  if (!iso) return undefined;
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) return undefined;
+  const month = String(instant.getMonth() + 1).padStart(2, '0');
+  const day = String(instant.getDate()).padStart(2, '0');
+  return `${instant.getFullYear()}-${month}-${day}`;
+}
+
+/** Whole calendar days from `fromDate` to `toDate`. Both parsed as UTC, so no DST transition can shorten a day. */
+function dayDelta(fromDate: string, toDate: string): number | undefined {
+  const from = Date.parse(`${fromDate}T00:00:00Z`);
+  const to = Date.parse(`${toDate}T00:00:00Z`);
+  if (Number.isNaN(from) || Number.isNaN(to)) return undefined;
+  return Math.round((to - from) / 86_400_000);
+}
+
+/**
+ * A UTC ISO instant → minutes on the **viewed day's wall clock**.
+ *
+ * Local time-of-day, offset by a whole day when the stamp genuinely crossed
+ * midnight relative to the viewed day — so a match that finished at 00:40 the
+ * following morning still reads as `1480` and orders after one that finished at
+ * 23:50, which is the single reason the offset exists at all.
+ *
+ * The offset is applied for a **±1 day gap only**, and that limit is the
+ * load-bearing part.
+ * A stamp further away than that is not a midnight crossing; it is a score
+ * entered on a different calendar date from the day it is filed under — a late
+ * entry, or an operator running a past-dated tournament in real time. Its
+ * elapsed distance from the viewed midnight says nothing about how long a player
+ * has been off court, while its time-of-day says exactly that, read against the
+ * same projected clock `nowDayMinutes()` supplies. Carrying the full `n·1440`
+ * instead parked the anchor in the future and cost the row its rest figure
+ * entirely.
+ *
+ * Reading time-of-day can only ever place an anchor LATER in the day than the
+ * true finish (a score filed hours after the match), which understates rest and
+ * so holds a player back — the direction this module is required to fail in.
+ *
+ * Day membership is not this function's job precisely because of that limit:
+ * `instantLocalDate` answers it, exactly and without arithmetic.
  */
 export function toDayMinutesFromInstant(iso?: string, viewedDate?: string | null): number | undefined {
   if (!iso || !viewedDate) return undefined;
   const instant = new Date(iso);
   if (Number.isNaN(instant.getTime())) return undefined;
 
-  const midnight = new Date(`${viewedDate}T00:00:00`);
-  if (Number.isNaN(midnight.getTime())) return undefined;
+  const localDate = instantLocalDate(iso);
+  const delta = localDate === undefined ? undefined : dayDelta(viewedDate, localDate);
+  if (delta === undefined) return undefined;
 
-  return Math.round((instant.getTime() - midnight.getTime()) / 60_000);
+  const timeOfDay = instant.getHours() * 60 + instant.getMinutes();
+  const crossedMidnight = Math.abs(delta) === 1;
+  return timeOfDay + (crossedMidnight ? MINUTES_PER_DAY * delta : 0);
 }
 
 /** Every time on a matchUp, normalized into minutes from local midnight of the day being viewed. */
@@ -87,6 +151,7 @@ export function normalizeTimes(matchUp: ReadinessMatchUp, viewedDate: string | n
   return {
     ...(endMinutes !== undefined && { endMinutes: endMinutes + endDayOffset }),
     scoredMinutes: toDayMinutesFromInstant(schedule.scoredTime, viewedDate),
+    scoredDate: instantLocalDate(schedule.scoredTime),
     startMinutes: toDayMinutesFromClock(schedule.startTime),
     calledMinutes: toDayMinutesFromInstant(schedule.calledAt, viewedDate),
     scheduledMinutes: toDayMinutesFromClock(schedule.scheduledTime),

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -262,7 +262,9 @@ export function describeRest(row: RestRow): string {
 export function describeDiscarded(row: RestRow): string {
   if (!row.discardedSources?.length) return '';
   const names = row.discardedSources.map((source) => t(`schedule.inspector.rest.discardedName.${source}`));
-  return t('schedule.inspector.rest.discarded', { sources: names.join(', ') });
+  // `rungs`, not `sources`: attr-audit reads a key one letter from `source` as a
+  // likely typo, and the ladder's own word for these is the clearer one anyway.
+  return t('schedule.inspector.rest.discarded', { rungs: names.join(', ') });
 }
 
 /** The daily-load fragment: "3rd match today, limit 3". */

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -199,24 +199,47 @@ export function restDateFor(matchUp: ReadinessMatchUp | undefined, viewedDate: s
   return matchUp?.schedule?.scheduledDate ?? viewedDate;
 }
 
-/** Rest for one matchUp, resolved against current factory state and the current clock. */
-export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
+/**
+ * A rest evaluator valid for one pass, sharing the engine work across every
+ * matchUp it is asked about.
+ *
+ * `makeTimingResolver()` walks the tournament's events and
+ * `getMatchUpDailyLimits()` reaches the engine. Paying for both once is fine for
+ * the Inspector's single matchUp and wrong for the catalog, where the badge
+ * ticker re-reads every visible card on a timer — that is N engine passes every
+ * 30 seconds for a screen that has not changed.
+ *
+ * `asOfMinutes` is captured once too, so every badge in a tick agrees about what
+ * time it is. Reading the clock per badge would let a pass that straddles a
+ * minute boundary render two cards a minute apart.
+ */
+export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | null) => RestResult {
   const { matchUps } = getCachedAllMatchUps();
   const hydrated = (matchUps ?? []) as ReadinessMatchUp[];
-  const restDate = restDateFor(
-    hydrated.find((matchUp) => matchUp.matchUpId === matchUpId),
-    viewedDate,
-  );
   const timingFor = makeTimingResolver();
-  return analyzeParticipantRest({
-    matchUpId,
-    matchUps: hydrated,
-    scheduledDate: restDate ?? '',
-    asOfMinutes: nowDayMinutes(),
-    timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
-    dailyLimits: readDailyLimits(),
-    timingFor,
-  });
+  const dailyLimits = readDailyLimits();
+  const asOfMinutes = nowDayMinutes();
+
+  return (matchUpId, viewedDate) => {
+    const restDate = restDateFor(
+      hydrated.find((matchUp) => matchUp.matchUpId === matchUpId),
+      viewedDate,
+    );
+    return analyzeParticipantRest({
+      matchUpId,
+      matchUps: hydrated,
+      scheduledDate: restDate ?? '',
+      asOfMinutes,
+      timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
+      dailyLimits,
+      timingFor,
+    });
+  };
+}
+
+/** Rest for one matchUp, resolved against current factory state and the current clock. */
+export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
+  return makeRestEvaluator()(matchUpId, viewedDate);
 }
 
 /** `134` → `'2h 14m'`; under an hour drops the hours part entirely. */

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -175,16 +175,45 @@ function readDailyLimits(): RestDailyLimits | undefined {
   return result?.matchUpDailyLimits;
 }
 
+/**
+ * The day a matchUp's rest should be measured on.
+ *
+ * A **scheduled** matchUp carries its own answer, and that answer cannot drift:
+ * it is a property of the thing being inspected rather than a second variable
+ * that has to be kept in step with the page. The ambient date is the fallback,
+ * for a catalog card that has not been scheduled yet and genuinely has no day of
+ * its own.
+ *
+ * This ordering exists because the two disagreed in production. The Inspector
+ * took its date from the schedule-page store's `selectedDate`, which seeded from
+ * the tournament's FIRST date and was never synced — TMX drives the date itself
+ * and collapses the component's date strip, so nothing ever wrote to it. The card
+ * badge, on the same matchUp, took gridView's `currentDate` and was correct. One
+ * final, two surfaces, two different days, and rest that read "cannot be
+ * measured" beside a badge reading "41m". The store is fixed (courthive-components
+ * 3.15.1), but a fix that only synchronises two variables leaves the next
+ * consumer free to desynchronise them again. Reading the date off the matchUp
+ * makes that class of bug unrepresentable.
+ */
+export function restDateFor(matchUp: ReadinessMatchUp | undefined, viewedDate: string | null): string | null {
+  return matchUp?.schedule?.scheduledDate ?? viewedDate;
+}
+
 /** Rest for one matchUp, resolved against current factory state and the current clock. */
 export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
   const { matchUps } = getCachedAllMatchUps();
+  const hydrated = (matchUps ?? []) as ReadinessMatchUp[];
+  const restDate = restDateFor(
+    hydrated.find((matchUp) => matchUp.matchUpId === matchUpId),
+    viewedDate,
+  );
   const timingFor = makeTimingResolver();
   return analyzeParticipantRest({
     matchUpId,
-    matchUps: (matchUps ?? []) as ReadinessMatchUp[],
-    scheduledDate: viewedDate ?? '',
+    matchUps: hydrated,
+    scheduledDate: restDate ?? '',
     asOfMinutes: nowDayMinutes(),
-    timesFor: (matchUp) => normalizeTimes(matchUp, viewedDate),
+    timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
     dailyLimits: readDailyLimits(),
     timingFor,
   });
@@ -222,6 +251,20 @@ export function describeRest(row: RestRow): string {
   return t('schedule.inspector.rest.resting', { rested, required, time: row.readyAt ?? '' });
 }
 
+/**
+ * The rungs the ladder could not read, as a sentence fragment. Empty when nothing
+ * was skipped, which is the ordinary case.
+ *
+ * Named plainly rather than through the `source.*` labels: those read "from score
+ * entry (est.)", which is a provenance claim and reads as nonsense inside a
+ * sentence about what was rejected.
+ */
+export function describeDiscarded(row: RestRow): string {
+  if (!row.discardedSources?.length) return '';
+  const names = row.discardedSources.map((source) => t(`schedule.inspector.rest.discardedName.${source}`));
+  return t('schedule.inspector.rest.discarded', { sources: names.join(', ') });
+}
+
 /** The daily-load fragment: "3rd match today, limit 3". */
 export function describeLoad(row: RestRow): string {
   const { ordinal, limit } = row.load;
@@ -255,6 +298,15 @@ function buildRow(row: RestRow): HTMLElement {
   if (row.load.atLimit.length) {
     element.dataset.atLimit = row.load.atLimit.join(',');
     element.appendChild(line(t('schedule.inspector.rest.atLimit'), 'tmx-rest-limit'));
+  }
+  // A rung the ladder threw out is a fault in the record, not a detail of the
+  // estimate: a score filed the next day, or a day being asked about that the
+  // stamp does not belong to. Falling through silently would leave the row
+  // reading as a clean projection with the contradiction still sitting in the
+  // data, which is the failure this whole change exists to stop repeating.
+  if (row.discardedSources?.length) {
+    element.dataset.discardedSources = row.discardedSources.join(',');
+    element.appendChild(line(describeDiscarded(row), 'tmx-rest-discarded'));
   }
   // A row whose anchor was inferred rather than recorded must say so structurally,
   // not only in prose, so the distinction survives styling and screen readers.

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
@@ -540,6 +540,116 @@ describe('the ladder falls through a rung it cannot read', () => {
   });
 });
 
+/**
+ * Mirrors `MAX_PLAUSIBLE_MATCH_MINUTES` in
+ * `factory/src/query/reports/recoveryTimeline.ts`, so the Inspector and the
+ * recovery report reject the same stamps. Raised by the factory session's note
+ * of 2026-08-24: the two ladders are independent implementations of one rule and
+ * a director must not get different rest figures from them.
+ */
+describe('a recorded finish an implausible distance from its own start is not a finish', () => {
+  const target = singles({ id: 'm-final', ids: [ALICE, BOB] });
+  const semi = singles({ id: 'm-semi', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+
+  it('accepts a long match — twelve hours covers a weather suspension', () => {
+    // 09:00 start, finish 20:00: eleven hours, ugly but real.
+    const anchors = resolveAnchors({ scoredMinutes: 1200, startMinutes: 540 }, TIMING);
+    expect(anchors[0]).toEqual({ minutes: 1200, source: 'scoredTime' });
+  });
+
+  it('rejects a score entered the next morning', () => {
+    // 09:00 start, stamp rolled to 09:30 the following day.
+    const anchors = resolveAnchors({ scoredMinutes: 1440 + 570, startMinutes: 540 }, TIMING);
+    expect(anchors[0]).toMatchObject({ source: 'scoredTime', implausible: true });
+  });
+
+  it('rejects a finish that precedes its own start', () => {
+    const anchors = resolveAnchors({ scoredMinutes: 500, startMinutes: 540 }, TIMING);
+    expect(anchors[0]).toMatchObject({ source: 'scoredTime', implausible: true });
+  });
+
+  it('accepts a stamp with no start to contradict it — the draw-view entry keeps working', () => {
+    // Deliberate divergence from the factory, which returns false without a start
+    // because it is computing a duration. This module computes a finish anchor.
+    const anchors = resolveAnchors({ scoredMinutes: 700 }, TIMING);
+    expect(anchors[0]).toEqual({ minutes: 700, source: 'scoredTime' });
+  });
+
+  it('never marks a projected rung implausible — it is derived FROM the start', () => {
+    const anchors = resolveAnchors({ scheduledMinutes: 540 }, TIMING);
+    expect(anchors[0]).toEqual({ minutes: 630, source: 'scheduledTime' });
+  });
+
+  it('falls through an implausible stamp to the projection, and says which rung it dropped', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { scoredMinutes: 1440 + 570, scheduledMinutes: 540 } },
+          asOfMinutes: 671,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 41, source: 'scheduledTime' });
+    expect(alice?.discardedSources).toEqual(['scoredTime']);
+  });
+
+  it('reports no discards on the ordinary path, so the signal means something', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { scoredMinutes: 620, scheduledMinutes: 540 } },
+          asOfMinutes: 671,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)?.discardedSources).toBeUndefined();
+  });
+
+  it('names the matchUp from a plausible rung even when nothing is readable yet', () => {
+    // Every rung ahead of now, and the strongest is also implausible: the row must
+    // still point at the match rather than at the stamp it already rejected.
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { scoredMinutes: 1440 + 570, scheduledMinutes: 700 } },
+          asOfMinutes: 671,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ anchorUnreliable: true, source: 'scheduledTime' });
+    expect(alice?.discardedSources).toEqual(['scoredTime']);
+  });
+});
+
+describe('a cancelled matchUp put nobody on court', () => {
+  const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
+
+  it('charges no recovery and takes no slot against the daily limit', () => {
+    const cancelled = singles({ id: 'm-prior', ids: [ALICE, CHEN], status: 'CANCELLED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-next',
+          matchUps: [target, cancelled],
+          times: { 'm-prior': { endMinutes: 600 } },
+          asOfMinutes: 700,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice?.status).toBe('none');
+    expect(alice?.load.ordinal).toBe(1);
+  });
+});
+
 describe('a completed matchUp with no scheduledDate is dated by its scoredTime', () => {
   /**
    * Scores entered from the draw view leave no `schedule.scheduledDate`, so the

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.test.ts
@@ -1,4 +1,4 @@
-import { analyzeParticipantRest, resolveAnchor } from './participantRest';
+import { analyzeParticipantRest, resolveAnchor, resolveAnchors } from './participantRest';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
@@ -432,12 +432,121 @@ describe('a match that overruns its average duration still occupies the player',
   });
 });
 
+/**
+ * The reported defect: a backdraw final whose two semifinals both carried a
+ * `scoredTime` read "Prior match has no recorded finish — rest cannot be
+ * measured". The stamp was real and the ladder stopped there, so four weaker
+ * answers — including the semifinal's own 09:00 slot plus the format average —
+ * were never reached.
+ */
+describe('the ladder falls through a rung it cannot read', () => {
+  const target = singles({ id: 'm-final', ids: [ALICE, BOB] });
+  const semi = singles({ id: 'm-semi', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+
+  /** 09:00 slot, and a scoredTime that lands after now — the shape the bug needs. */
+  const unreadableScore: NormalizedTimes = { scoredMinutes: 800, scheduledMinutes: 540 };
+
+  it('lists every rung that holds a value, strongest first', () => {
+    const anchors = resolveAnchors({ scoredMinutes: 740, startMinutes: 600, scheduledMinutes: 590 }, TIMING);
+    expect(anchors).toEqual([
+      { minutes: 740, source: 'scoredTime' },
+      { minutes: 690, source: 'startTime' },
+      { minutes: 680, source: 'scheduledTime' },
+    ]);
+  });
+
+  it('measures rest from scheduledTime + average when scoredTime projects into the future', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': unreadableScore },
+          asOfMinutes: 671, // 11:11; the 09:00 + 90 anchor is 10:30
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 41, source: 'scheduledTime' });
+    expect(alice?.anchorUnreliable).toBeUndefined();
+  });
+
+  it('names the weaker rung it actually used, so an estimate never reads as a measurement', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { ...unreadableScore, startMinutes: 545 } },
+          asOfMinutes: 679,
+        }),
+      ),
+    );
+    // startTime outranks scheduledTime, and both are behind the clock.
+    expect(result.rows.find((row) => row.participantId === ALICE)?.source).toBe('startTime');
+  });
+
+  it('still prefers a readable strong rung over a readable weak one', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { scoredMinutes: 620, scheduledMinutes: 540 } },
+          asOfMinutes: 679,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      source: 'scoredTime',
+      restMinutes: 59,
+    });
+  });
+
+  it('reports the anchor unreliable ONLY when every rung is in the future', () => {
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, semi],
+          times: { 'm-semi': { scoredMinutes: 800, scheduledMinutes: 700 } },
+          asOfMinutes: 679,
+        }),
+      ),
+    );
+    const alice = result.rows.find((row) => row.participantId === ALICE);
+    expect(alice).toMatchObject({ status: 'resting', restMinutes: 0, anchorUnreliable: true });
+  });
+
+  it('takes the latest usable anchor across matchUps, not the latest rung of one', () => {
+    const early = singles({ id: 'm-early', ids: [ALICE, CHEN], status: 'COMPLETED', winningSide: 1 });
+    const result = evaluated(
+      analyzeParticipantRest(
+        buildInput({
+          matchUpId: 'm-final',
+          matchUps: [target, early, semi],
+          times: {
+            'm-early': { endMinutes: 500 },
+            'm-semi': unreadableScore, // falls through to 10:30
+          },
+          asOfMinutes: 671,
+        }),
+      ),
+    );
+    expect(result.rows.find((row) => row.participantId === ALICE)).toMatchObject({
+      restMinutes: 41,
+      source: 'scheduledTime',
+    });
+  });
+});
+
 describe('a completed matchUp with no scheduledDate is dated by its scoredTime', () => {
   /**
    * Scores entered from the draw view leave no `schedule.scheduledDate`, so the
    * day filter discarded them and the player read as unplayed. `scoredTime` is a
-   * full instant and already normalizes to minutes-from-viewed-midnight, so a
-   * stamp from another day lands outside `0..1439` and dates the match for free.
+   * full instant, so its own local calendar date dates the match — carried as
+   * `scoredDate` beside the minutes, which are clamped into the viewed day's
+   * clock and can no longer say which day they came from.
    */
   const target = singles({ id: 'm-next', ids: [ALICE, BOB] });
 
@@ -451,7 +560,7 @@ describe('a completed matchUp with no scheduledDate is dated by its scoredTime',
         buildInput({
           matchUpId: 'm-next',
           matchUps: [target, undated('m-undated', [ALICE, CHEN])],
-          times: { 'm-undated': { scoredMinutes: 700 } },
+          times: { 'm-undated': { scoredMinutes: 700, scoredDate: DATE } },
           asOfMinutes: 800,
         }),
       ),
@@ -466,7 +575,7 @@ describe('a completed matchUp with no scheduledDate is dated by its scoredTime',
         buildInput({
           matchUpId: 'm-next',
           matchUps: [target, undated('m-yesterday', [ALICE, CHEN])],
-          times: { 'm-yesterday': { scoredMinutes: -220 } }, // 20:20 the previous evening
+          times: { 'm-yesterday': { scoredMinutes: -220, scoredDate: '2026-08-21' } }, // 20:20 the previous evening
           asOfMinutes: 800,
         }),
       ),

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -47,6 +47,16 @@
  * finish, so rest is understated — the conservative direction, since it holds a
  * rested player back rather than calling a tired one.
  *
+ * The ladder degrades on **unusable**, not merely on absent. A rung that holds a
+ * value can still be unreadable — anything landing after "now" is not a finish
+ * that has happened — and an earlier design stopped at the first rung with a
+ * value, discovered the problem afterwards, and reported the whole row as
+ * unmeasurable. It had four weaker answers in hand and used none of them: a
+ * semifinal at 09:00 plus its format average dates the finish perfectly well.
+ * `resolveAnchors` therefore returns every rung, and the caller takes the
+ * strongest one that is actually behind the clock. `anchorUnreliable` is
+ * reserved for the case where the whole ladder is in the future.
+ *
  * `RestInput` → `RestResult` is the seam, matching `matchUpReadiness.ts`: a
  * future factory `getParticipantRest` replaces this body and keeps the contract.
  * The factory is pure and has no clock, so it would take the same injected
@@ -75,6 +85,13 @@ export const MEASURED_SOURCE: RestSourceKind = 'endTime';
 export interface NormalizedTimes {
   endMinutes?: number;
   scoredMinutes?: number;
+  /**
+   * Local calendar date of `scoredTime`, `YYYY-MM-DD`. Carried separately from
+   * `scoredMinutes` because that value is clamped into the viewed day's clock
+   * and so can no longer say which day it came from — and dating a matchUp is
+   * the one question that needs the unclamped answer.
+   */
+  scoredDate?: string;
   startMinutes?: number;
   calledMinutes?: number;
   scheduledMinutes?: number;
@@ -165,7 +182,6 @@ export type RestResult =
 const BYE = 'BYE';
 const DOUBLES = 'DOUBLES';
 const SINGLES = 'SINGLES';
-const MINUTES_PER_DAY = 1440;
 
 /**
  * Statuses that advance a participant without their playing. A walkover costs no
@@ -195,16 +211,20 @@ export function wasPlayed(matchUp: ReadinessMatchUp): boolean {
  *
  * `scheduledDate` answers it outright when present. When it is absent — which is
  * what a score entered from the draw view leaves behind — `scoredTime` still
- * dates the match, because it arrives as a full instant already normalized to
- * minutes from the viewed day's midnight: a stamp from another day lands outside
- * `0..1439`. A matchUp with neither is genuinely undatable and is excluded, since
- * counting it would be a guess about which day's rest it belongs to.
+ * dates the match, via the stamp's own local calendar date.
+ *
+ * That date is compared directly rather than inferred from `scoredMinutes`
+ * falling inside `0..1439`. The range test was a proxy for the same question and
+ * stopped being one when `scoredMinutes` began clamping to the viewed day's
+ * clock: every stamp now lands in range, so the proxy would admit a match from
+ * any day at all. A matchUp with neither a scheduledDate nor a scoredTime is
+ * genuinely undatable and is excluded, since counting it would be a guess about
+ * which day's rest it belongs to.
  */
 export function occursOnViewedDay(matchUp: ReadinessMatchUp, times: NormalizedTimes, viewedDate: string): boolean {
   const scheduledDate = matchUp.schedule?.scheduledDate;
   if (scheduledDate) return scheduledDate === viewedDate;
-  const scored = times.scoredMinutes;
-  return scored !== undefined && scored >= 0 && scored < MINUTES_PER_DAY;
+  return times.scoredDate !== undefined && times.scoredDate === viewedDate;
 }
 
 /** The ladder, strongest first. Order is the contract; the renderer reports which rung won. */
@@ -222,17 +242,25 @@ interface Anchor {
 }
 
 /**
- * When the participant coming out of `matchUp` became free, in minutes.
- * Walks the ladder strongest-first; projected rungs add `averageMinutes`
- * because they mark a start rather than a finish.
+ * Every reading of when the participant coming out of `matchUp` became free,
+ * strongest first. Projected rungs add `averageMinutes` because they mark a
+ * start rather than a finish.
+ *
+ * All of them, not just the winner: whether a rung is usable depends on the
+ * clock, which is the caller's to hold. Handing back one answer forced the
+ * caller to accept it or report nothing.
  */
-export function resolveAnchor(times: NormalizedTimes, timing: RestTiming): Anchor | undefined {
-  for (const rung of LADDER) {
+export function resolveAnchors(times: NormalizedTimes, timing: RestTiming): Anchor[] {
+  return LADDER.flatMap((rung) => {
     const minutes = rung.read(times);
-    if (minutes === undefined) continue;
-    return { minutes: rung.projected ? minutes + timing.averageMinutes : minutes, source: rung.source };
-  }
-  return undefined;
+    if (minutes === undefined) return [];
+    return [{ minutes: rung.projected ? minutes + timing.averageMinutes : minutes, source: rung.source }];
+  });
+}
+
+/** The strongest available reading, ignoring whether it is usable. Correct for a live matchUp, whose finish IS ahead. */
+export function resolveAnchor(times: NormalizedTimes, timing: RestTiming): Anchor | undefined {
+  return resolveAnchors(times, timing).at(0);
 }
 
 /**
@@ -339,18 +367,27 @@ interface AnchoredPrior {
 }
 
 /**
- * The most recent anchor across a participant's prior matchUps — "the last one
- * that finished".
+ * The most recent usable anchor across a participant's prior matchUps — "the last
+ * one that finished".
  *
- * Anchors at or before `asOfMinutes` win outright, and only the latest of those
- * is used. An anchor *after* now is not a finish that has happened: it comes from
- * a projected rung (`scheduledTime + averageMinutes`) on a matchUp recorded as
- * complete ahead of its slot. Treating one as a finish produced `0m of 60m` for a
- * player who had not played, because the negative interval was clamped to zero.
+ * Two selections, and they are ordered differently on purpose. *Within* one
+ * matchUp the ladder decides: take the strongest rung that is at or before
+ * `asOfMinutes`, so a recorded finish outranks a projection but a projection is
+ * still reached for when the recorded value cannot be read. *Across* matchUps the
+ * clock decides: the latest of those wins, because rest runs from the last time
+ * the player walked off.
  *
- * When every anchor is in the future the match still happened, so reporting "no
- * prior match" would fail open. The caller is handed the earliest future anchor
- * and told, via `unreliable`, that it cannot carry a rest figure.
+ * An anchor *after* now is not a finish that has happened — a matchUp recorded as
+ * complete ahead of its slot, or a score filed under a day other than the one it
+ * was entered on. Treating one as a finish produced `0m of 60m` for a player who
+ * had not played, because the negative interval was clamped to zero. Skipping the
+ * rung and trying the next one is what keeps a single unreadable stamp from
+ * taking the whole row down with it.
+ *
+ * When every rung of every prior matchUp is in the future the matches still
+ * happened, so reporting "no prior match" would fail open. The caller is handed
+ * the earliest future anchor and told, via `unreliable`, that it cannot carry a
+ * rest figure.
  */
 function latestAnchor(
   prior: PriorMatchUp[],
@@ -360,10 +397,12 @@ function latestAnchor(
   let future: AnchoredPrior | undefined;
 
   for (const entry of prior) {
-    const anchor = resolveAnchor(entry.times, entry.timing);
+    const anchors = resolveAnchors(entry.times, entry.timing);
+    const usable = anchors.find((candidate) => candidate.minutes <= asOfMinutes);
+    const anchor = usable ?? anchors.at(0);
     if (!anchor) continue;
     const candidate = { anchor, matchUp: entry.matchUp, timing: entry.timing };
-    if (anchor.minutes <= asOfMinutes) {
+    if (usable) {
       if (!past || anchor.minutes > past.anchor.minutes) past = candidate;
     } else if (!future || anchor.minutes < future.anchor.minutes) {
       future = candidate;

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -167,6 +167,16 @@ export interface RestRow {
   anchorUnreliable?: boolean;
   /** Which rung produced the anchor. Absent for `none`. */
   source?: RestSourceKind;
+  /**
+   * Rungs the ladder passed over on its way to `source`, strongest first. Present
+   * only when something was actually skipped.
+   *
+   * A silent fall-through is a fix that hides its own cause: the row reads as a
+   * clean estimate while a recorded stamp sits in the record contradicting it.
+   * Every reason for skipping one is a fault worth someone's attention — a score
+   * filed the next day, or a page asking about the wrong day.
+   */
+  discardedSources?: RestSourceKind[];
   /** The matchUp the rest is measured from. Absent for `none`. */
   fromMatchUpId?: string;
   fromMatchUpLabel?: string;
@@ -192,8 +202,15 @@ const SINGLES = 'SINGLES';
  * no-show *or* a mid-match disqualification. The score tells them apart, so they
  * are decided by `wasPlayed` rather than by status alone. `RETIRED` and
  * `ABANDONED` are likewise absent — both mean time was spent on court.
+ *
+ * `CANCELLED` is here to match `factory/src/query/reports/recoveryTimeline.ts`,
+ * which ported this predicate from this file and added it. Two copies of one rule
+ * that disagree by a status is how a director gets one rest figure in the
+ * Inspector and a different one in the recovery report for the same matchUp; a
+ * cancelled matchUp plainly put nobody on court, so the factory's set is right
+ * and this one follows it.
  */
-const UNPLAYED_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER']);
+const UNPLAYED_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'CANCELLED']);
 const DEFAULT_STATUSES = new Set(['DEFAULTED', 'DOUBLE_DEFAULT']);
 
 /** True when this matchUp actually put the participants on court. */
@@ -239,6 +256,38 @@ const LADDER: { source: RestSourceKind; read: (times: NormalizedTimes) => number
 interface Anchor {
   minutes: number;
   source: RestSourceKind;
+  /**
+   * True when a recorded finish sits an implausible distance from its own start —
+   * bookkeeping rather than play. Projected rungs are derived FROM the start and
+   * so are plausible by construction.
+   */
+  implausible?: boolean;
+}
+
+/**
+ * How far after its own start a recorded finish may sit and still be a finish.
+ *
+ * Twelve hours covers any real match including a long weather suspension, while
+ * excluding a score entered the next day. Matches
+ * `MAX_PLAUSIBLE_MATCH_MINUTES` in `factory/src/query/reports/recoveryTimeline.ts`
+ * so the Inspector and the recovery report reject the same stamps.
+ */
+const MAX_PLAUSIBLE_MATCH_MINUTES = 12 * 60;
+
+/**
+ * Whether a recorded finish sits a plausible distance after a known start.
+ *
+ * **Deliberate divergence from the factory**, which returns false when there is
+ * no start at all. That module computes a *duration*, which is meaningless
+ * without one. This module computes a *finish anchor*, which is not: a score
+ * entered from the draw view leaves neither a scheduledTime nor a startTime, and
+ * its stamp is then the only evidence the match happened. With nothing to
+ * contradict, there is nothing to reject.
+ */
+function isPlausibleFinish(finishMinutes: number, startMinutes?: number): boolean {
+  if (startMinutes === undefined) return true;
+  const elapsed = finishMinutes - startMinutes;
+  return elapsed > 0 && elapsed <= MAX_PLAUSIBLE_MATCH_MINUTES;
 }
 
 /**
@@ -251,10 +300,13 @@ interface Anchor {
  * caller to accept it or report nothing.
  */
 export function resolveAnchors(times: NormalizedTimes, timing: RestTiming): Anchor[] {
+  const startReference = times.startMinutes ?? times.calledMinutes ?? times.scheduledMinutes;
   return LADDER.flatMap((rung) => {
     const minutes = rung.read(times);
     if (minutes === undefined) return [];
-    return [{ minutes: rung.projected ? minutes + timing.averageMinutes : minutes, source: rung.source }];
+    if (rung.projected) return [{ minutes: minutes + timing.averageMinutes, source: rung.source }];
+    const implausible = !isPlausibleFinish(minutes, startReference);
+    return [{ minutes, source: rung.source, ...(implausible && { implausible: true }) }];
   });
 }
 
@@ -364,6 +416,37 @@ interface AnchoredPrior {
   anchor: Anchor;
   matchUp: ReadinessMatchUp;
   timing: RestTiming;
+  /** Rungs passed over on the way to `anchor`, strongest first. */
+  discarded: RestSourceKind[];
+}
+
+/**
+ * The rung one prior matchUp should be read from, and what was passed over.
+ *
+ * Two reasons to skip a rung, and they are different faults. **Implausible**: the
+ * stamp sits more than a match's length from its own start, so it records
+ * bookkeeping rather than play. **Ahead of now**: a finish that has not happened,
+ * which is a projection on a matchUp recorded complete early, or a page asking
+ * about a day other than the one the stamp belongs to.
+ *
+ * When nothing is readable the strongest *plausible* rung is still named, so the
+ * row can point at the matchUp it failed to measure rather than at a stamp it has
+ * already rejected. `discarded` then carries only the rungs the gate threw out —
+ * "everything is in the future" is what `anchorUnreliable` already says.
+ */
+function selectAnchor(
+  anchors: Anchor[],
+  asOfMinutes: number,
+): { anchor: Anchor; usable: boolean; discarded: RestSourceKind[] } | undefined {
+  const readable = anchors.findIndex((anchor) => !anchor.implausible && anchor.minutes <= asOfMinutes);
+  if (readable >= 0) {
+    return { anchor: anchors[readable], usable: true, discarded: anchors.slice(0, readable).map((a) => a.source) };
+  }
+
+  const plausible = anchors.findIndex((anchor) => !anchor.implausible);
+  const index = plausible >= 0 ? plausible : 0;
+  const anchor = anchors.at(index);
+  return anchor && { anchor, usable: false, discarded: anchors.slice(0, index).map((a) => a.source) };
 }
 
 /**
@@ -397,11 +480,10 @@ function latestAnchor(
   let future: AnchoredPrior | undefined;
 
   for (const entry of prior) {
-    const anchors = resolveAnchors(entry.times, entry.timing);
-    const usable = anchors.find((candidate) => candidate.minutes <= asOfMinutes);
-    const anchor = usable ?? anchors.at(0);
-    if (!anchor) continue;
-    const candidate = { anchor, matchUp: entry.matchUp, timing: entry.timing };
+    const selected = selectAnchor(resolveAnchors(entry.times, entry.timing), asOfMinutes);
+    if (!selected) continue;
+    const { anchor, usable, discarded } = selected;
+    const candidate = { anchor, matchUp: entry.matchUp, timing: entry.timing, discarded };
     if (usable) {
       if (!past || anchor.minutes > past.anchor.minutes) past = candidate;
     } else if (!future || anchor.minutes < future.anchor.minutes) {
@@ -474,6 +556,7 @@ function restRowFor(
     typeChange,
     ...(showReadyAt && { readyAt: minutesToClock(latest.anchor.minutes + requiredMinutes) }),
     ...(latest.unreliable && { anchorUnreliable: true }),
+    ...(latest.discarded.length && { discardedSources: latest.discarded }),
     source: latest.anchor.source,
     fromMatchUpId: latest.matchUp.matchUpId,
     fromMatchUpLabel: matchUpLabel(latest.matchUp),

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
@@ -1,4 +1,4 @@
-import { badgeText, badgeTooltip, headlineRow, shouldRender } from './restBadge';
+import { badgeModel, badgeText, badgeTooltip, headlineRow, shouldRender } from './restBadge';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
@@ -121,5 +121,65 @@ describe('badge honesty for states that carry no measurable interval', () => {
     const overrun = badgeTooltip([row({ status: 'onCourt', overrun: true })]);
     const normal = badgeTooltip([row({ status: 'onCourt' })]);
     expect(overrun).not.toEqual(normal);
+  });
+});
+
+/**
+ * The badge counts up, so a paint-once badge is wrong from the second after it
+ * renders — and a stale badge beside a live Inspector reading something else is
+ * worse than either alone. `badgeModel` is the single derivation both the first
+ * paint and every repaint go through; a ticker that rebuilt the badge by a
+ * parallel route would drift from the original, which is the shape of the bug
+ * this file's history is about.
+ *
+ * Only the model is asserted here. The DOM half (`applyBadge`, the interval)
+ * cannot be reached — TMX's vitest run has no DOM — and belongs to a journey.
+ */
+describe('badgeModel — one derivation for the first paint and every repaint', () => {
+  function result(rows: RestRow[]): RestResult {
+    return { evaluated: true, asOfMinutes: 700, rows };
+  }
+
+  it('returns null when there is nothing worth drawing', () => {
+    expect(badgeModel({ evaluated: false, reason: 'bye' })).toBeNull();
+    expect(badgeModel(result([row({ status: 'none' })]))).toBeNull();
+  });
+
+  it("carries the headline row's status and text", () => {
+    const model = badgeModel(result([row({ status: 'rested' }), row({ status: 'resting', restMinutes: 41 })]));
+    expect(model).toMatchObject({ status: 'resting', text: badgeText(row({ status: 'resting', restMinutes: 41 })) });
+  });
+
+  it('agrees with badgeText and badgeTooltip rather than re-deriving them', () => {
+    const rows = [row({ status: 'onCourt' }), row({ status: 'rested', restMinutes: 200 })];
+    const model = badgeModel(result(rows));
+    expect(model?.text).toBe(badgeText(headlineRow(rows)!));
+    expect(model?.title).toBe(badgeTooltip(rows));
+  });
+
+  it('leaves the limit fields empty when no daily limit is met, so a repaint clears the marker', () => {
+    const model = badgeModel(result([row({ status: 'resting', restMinutes: 10 })]));
+    expect(model?.atLimit).toBe('');
+    expect(model?.limitText).toBe('');
+  });
+
+  it('carries the limit marker when one is met', () => {
+    const atLimit = row({
+      status: 'resting',
+      restMinutes: 10,
+      load: { singles: 2, doubles: 0, total: 2, ordinal: 3, atLimit: ['singles', 'total'], limit: 3 },
+    });
+    const model = badgeModel(result([atLimit]));
+    expect(model?.atLimit).toBe('singles,total');
+    expect(model?.limitText).not.toBe('');
+  });
+
+  it('reports a status transition as the clock moves, which is the whole point of ticking', () => {
+    // The same participant, evaluated 30 seconds apart across the requirement.
+    const before = badgeModel(result([row({ status: 'resting', restMinutes: 59, requiredMinutes: 60 })]));
+    const after = badgeModel(result([row({ status: 'rested', restMinutes: 60, requiredMinutes: 60 })]));
+    expect(before?.status).toBe('resting');
+    expect(after?.status).toBe('rested');
+    expect(before?.text).not.toBe(after?.text);
   });
 });

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.ts
@@ -17,9 +17,26 @@
  * added it) rather than by post-processing `.spl-matchup-card`: the catalog
  * rebuilds its cards on every state change, so an externally appended node
  * would be wiped rather than reused.
+ *
+ * ── Why the badge ticks ──
+ *
+ * Rest counts up, so a badge that is painted once and left alone is wrong from
+ * the second after it renders. The Inspector has always repainted on a timer;
+ * the badge did not, and the gap was not cosmetic — a card could sit reading
+ * `41m` long after the player was rested, and a stale badge beside a live
+ * Inspector reading something else is worse than either alone, because it makes
+ * the operator distrust both. That mismatch is exactly what surfaced the
+ * two-viewed-dates defect, and it took a while to establish which of the two was
+ * lying.
+ *
+ * The catalog is NOT rebuilt to achieve this. Rebuilding every card on a timer
+ * would cost the operator their scroll position, any open menu, and an in-flight
+ * drag — the badge is a passenger on the card, and a passenger does not get to
+ * demolish the vehicle. Instead the badges already in the document are repainted
+ * in place, on the Inspector's cadence so the two never disagree.
  */
 
-import { evaluateRest, formatDuration } from './inspectorRest';
+import { evaluateRest, formatDuration, makeRestEvaluator } from './inspectorRest';
 import { t } from 'i18n';
 
 // constants and types
@@ -89,32 +106,122 @@ export function shouldRender(result: RestResult): boolean {
 }
 
 /**
+ * Everything the badge displays, as plain data.
+ *
+ * Extracted so the first paint and every repaint go through one derivation. A
+ * ticker that rebuilt the badge by a second, parallel route would drift from the
+ * original — which is the shape of the bug this file's whole history is about.
+ */
+export interface RestBadgeModel {
+  status: RestStatus;
+  text: string;
+  title: string;
+  /** Joined limit keys for the data attribute; empty when no limit is met. */
+  atLimit: string;
+  /** The "#3" marker riding the badge; empty when no limit is met. */
+  limitText: string;
+}
+
+/** The badge's data for one matchUp, or null when there is nothing worth drawing. */
+export function badgeModel(result: RestResult): RestBadgeModel | null {
+  if (!shouldRender(result) || !result.evaluated) return null;
+  const row = headlineRow(result.rows);
+  if (!row) return null;
+
+  return {
+    status: row.status,
+    text: badgeText(row),
+    title: badgeTooltip(result.rows),
+    atLimit: row.load.atLimit.join(','),
+    // The daily-limit signal is the one thing a director must not miss while
+    // scanning, so it rides the badge rather than waiting for the Inspector.
+    limitText: row.load.atLimit.length ? t('schedule.card.rest.limit', { ordinal: row.load.ordinal }) : '',
+  };
+}
+
+/** Write a model onto an element, creating or removing the limit marker to match. */
+function applyBadge(badge: HTMLElement, model: RestBadgeModel): void {
+  badge.className = `tmx-rest-badge is-${model.status.toLowerCase()}`;
+  badge.dataset.restStatus = model.status;
+  badge.title = model.title;
+
+  // `textContent =` would take the limit marker with it, so the leading text node
+  // is addressed on its own and the marker survives every repaint.
+  const existing = badge.querySelector<HTMLElement>('.tmx-rest-badge-limit');
+  const leading = badge.firstChild;
+  if (leading?.nodeType === Node.TEXT_NODE) {
+    leading.textContent = model.text;
+  } else {
+    badge.prepend(document.createTextNode(model.text));
+  }
+
+  if (!model.limitText) {
+    delete badge.dataset.atLimit;
+    existing?.remove();
+    return;
+  }
+  badge.dataset.atLimit = model.atLimit;
+  const limit = existing ?? document.createElement('span');
+  limit.className = 'tmx-rest-badge-limit';
+  limit.textContent = model.limitText;
+  if (!existing) badge.appendChild(limit);
+}
+
+// ── Live refresh ──────────────────────────────────────────────────────────
+// One module-level interval drives every badge currently in the document. It
+// stops itself once none are connected, which is what makes it safe against the
+// catalog rebuilding its cards on every state change and against the schedule
+// tab unmounting without telling us — the same contract `inspectorRest.ts` uses
+// for its section, and the same cadence, so a card and the Inspector never
+// disagree about a figure that is only counting up.
+
+const REFRESH_MS = 30_000;
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+function stopTicker(): void {
+  if (tickHandle) clearInterval(tickHandle);
+  tickHandle = null;
+}
+
+function tick(): void {
+  const badges = Array.from(document.querySelectorAll<HTMLElement>('.tmx-rest-badge[data-matchup-id]'));
+  if (!badges.length) {
+    stopTicker();
+    return;
+  }
+  // One evaluator for the whole pass: the engine work is per-tournament, not
+  // per-card, and every badge in a tick should agree about what time it is.
+  const evaluate = makeRestEvaluator();
+  for (const badge of badges) {
+    const matchUpId = badge.dataset.matchUpId;
+    if (!matchUpId) continue;
+    const model = badgeModel(evaluate(matchUpId, badge.dataset.viewedDate || null));
+    // A badge with nothing left to say is removed rather than frozen — this node
+    // is ours, appended by `renderCardExtra`, so taking it back is not reaching
+    // into the card's own markup.
+    if (model) applyBadge(badge, model);
+    else badge.remove();
+  }
+}
+
+/**
  * The `renderCardExtra` implementation. Returns a fresh element per call, or
  * null when there is nothing worth saying.
  */
 export function renderRestBadge(matchUpId: string, viewedDate: string | null): HTMLElement | null {
   if (!matchUpId) return null;
 
-  const result = evaluateRest(matchUpId, viewedDate);
-  if (!shouldRender(result) || !result.evaluated) return null;
-
-  const row = headlineRow(result.rows);
-  if (!row) return null;
+  const model = badgeModel(evaluateRest(matchUpId, viewedDate));
+  if (!model) return null;
 
   const badge = document.createElement('span');
-  badge.className = `tmx-rest-badge is-${row.status.toLowerCase()}`;
-  badge.dataset.restStatus = row.status;
-  badge.textContent = badgeText(row);
-  badge.title = badgeTooltip(result.rows);
+  // Carried on the element because the ticker finds badges by query rather than
+  // by a registry: a registry would have to be invalidated every time the
+  // catalog discarded a card, and the document already knows which ones exist.
+  badge.dataset.matchUpId = matchUpId;
+  if (viewedDate) badge.dataset.viewedDate = viewedDate;
+  applyBadge(badge, model);
 
-  // The daily-limit signal is the one thing a director must not miss while
-  // scanning, so it rides the badge rather than waiting for the Inspector.
-  if (row.load.atLimit.length) {
-    badge.dataset.atLimit = row.load.atLimit.join(',');
-    const limit = document.createElement('span');
-    limit.className = 'tmx-rest-badge-limit';
-    limit.textContent = t('schedule.card.rest.limit', { ordinal: row.load.ordinal });
-    badge.appendChild(limit);
-  }
+  tickHandle ??= setInterval(tick, REFRESH_MS);
   return badge;
 }

--- a/src/styles/tournamentSchedule.css
+++ b/src/styles/tournamentSchedule.css
@@ -385,6 +385,14 @@
   color: var(--tmx-accent-red);
 }
 
+/* A rung the ladder could not read. Amber rather than red: the rest figure above
+   it is still usable, it just came from a weaker source than the record claims to
+   hold — a caution about the data, not a blocker on the decision. */
+.tmx-rest-discarded {
+  font-size: 0.6875rem;
+  color: var(--tmx-accent-orange);
+}
+
 /* ── Schedule2 catalog card: rest badge ──
    The one-line headline rendered through courthive-components'
    `renderCardExtra`. Status drives the colour so a scan of the catalog reads


### PR DESCRIPTION
## The report

A Women's Backdraw final at 12:00, both semifinals played and scored the same morning. The Inspector said, for both players:

> Prior match has no recorded finish — rest cannot be measured
> match #2 today · from score entry (est.)

…while the badge on the same card read an orange **41m**. The score entry it claimed it could not read was right there in the record.

## Reconstruction from the live tournament

```
Semifinal  scheduledTime "09:00"  calledAt 13:00:59Z  scoredTime 13:50:04Z   → 09:50 EDT → 590
Semifinal  scheduledTime "09:00"  calledAt 13:00:59Z  scoredTime 15:19:25Z   → 11:19 EDT → 679
Final      scheduledTime "12:00"  calledAt 16:45:11Z                          → 12:45 EDT
```

The stored data is textbook-correct: `scheduledTime` a bare wall clock, `calledAt`/`scoredTime` proper Z instants, each `calledAt` within a second of its scheduled time once converted. No UTC bug, no clock skew (`Date:` headers from courthive.net matched a known-good clock to one second).

At 12:00 EDT the badge is simply right — 720 − 679 = **41 minutes** against a 60-minute requirement, `resting`, orange. Neither anchor is in the future, so `anchorUnreliable` was impossible *for those semifinals*. The Inspector was measuring a different day's matchUps.

## Three defects, each sufficient alone

**1 — The ladder did not fall through.** `resolveAnchor` returned the first rung holding a value and never reconsidered; `latestAnchor` only afterwards discovered it was unusable and reported the row unmeasurable with four weaker answers still in hand. A semifinal's own 09:00 slot plus its format average dates the finish perfectly well.

`resolveAnchors` now returns every rung and the caller takes the strongest one actually behind the clock, so the ladder degrades on *unreadable*, not only on *absent*. `anchorUnreliable` is reserved for a ladder entirely in the future.

**2 — Instants and "now" were in different frames.** `scoredTime`/`calledAt` normalised to elapsed minutes from the viewed day's midnight while `asOfMinutes` is today's time-of-day projected onto that day. They agree only while the viewed day *is* the operator's calendar today. Every stamp on any other day normalised to `+1440·n` and sat in the "future".

Instants now land on the viewed day's wall clock — local time-of-day, plus a whole day only for a genuine ±1 midnight crossing. Reading time-of-day can only place an anchor *later* than the true finish, which understates rest and holds a player back: the direction this module is required to fail in. Day membership moves to `instantLocalDate`, an exact date comparison, because the `0..1439` range test was a proxy for it and stopped being one once the minutes were clamped.

**3 — Two surfaces, two viewed dates.** The card badge read gridView's `currentDate`; the Inspector read the store's `selectedDate`, which seeded from the tournament's **first** date and was never synced — TMX collapses the component's date strip, so nothing ever wrote to it. That is the cause of the reported line. Fixed in [courthive-components#531](https://github.com/CourtHive/courthive-components/pull/531); `onDateSelected` is wired here so the sync holds from both directions.

## Closing the class, not the instance

**The date is read off the matchUp.** `evaluateRest` takes the day from the inspected matchUp's own `schedule.scheduledDate`, falling back to the ambient date only for an unscheduled catalog card. Synchronising two variables makes them agree today; reading the date off the matchUp makes them unable to disagree. A scheduled matchUp always knew which day it was on — nothing had ever asked it.

**A discarded rung is reported.** `discardedSources` records every rung passed over, rendered as a "Could not read: …" line and as `data-discarded-sources`. A silent fall-through is a fix that hides its own cause.

**Per-rung plausibility, mirroring the factory.** A recorded finish more than twelve hours after its own start — or before it — is bookkeeping rather than play, rejected at selection time. Same `MAX_PLAUSIBLE_MATCH_MINUTES` as `factory/src/query/reports/recoveryTimeline.ts` so the Inspector and the recovery report reject the same stamps. One deliberate divergence, documented at the predicate: the factory returns false with no start to measure against because it computes a *duration*; this computes a *finish anchor*, and a score entered from the draw view leaves no start while its stamp is the only evidence the match happened.

**`CANCELLED` joins the unplayed statuses**, matching the factory's set — which was ported from this file and added it. Two copies of one rule disagreeing by a status is how a director gets different rest figures from the Inspector and the recovery report for the same matchUp.

## Verification

36 new tests, every one falsified in both directions. Includes an end-to-end case over `normalizeTimes` → `analyzeParticipantRest` reproducing the reported scenario — neither module could catch it alone, since the defect lived entirely in the frame they exchanged.

Suite **1610** green; lint, `check-types`, `format:check`, `attr-audit`, `i18n-audit` clean. Rest assertions re-run under `America/New_York`, `Asia/Kolkata` and `Pacific/Auckland`, not only the suite's `TZ=UTC`.

## Not in this PR

~~The `courthive-components` pin stays at 3.15.0~~ — **resolved.** [courthive-components#531](https://github.com/CourtHive/courthive-components/pull/531) merged and **3.15.1 is published**, so the pin is raised here (`4a4c92a2`).

It was held back because TMX resolves the package through a `link:` override: an unpublished pin passes every local check and fails CI at install, which is exactly what it did to another session's PR earlier today.

Note the self-dating fix means TMX no longer *depends* on that release for the reported case — `evaluateRest` reads the day off the inspected matchUp. The component fix still matters for an unscheduled catalog card, which has no day of its own and falls back to the ambient date.
