### PR TITLE
feat(presence): close the day, so "signed in" stops meaning "signed in once"

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2354,7 +2354,11 @@
         "preferNickname": "Prefer nickname in draws",
         "nameTooShort": "Please enter a name of at least 3 characters"
       },
-      "selected": "selected"
+      "selected": "selected",
+      "closeTheDay": "Close the day",
+      "closeTheDayNobody": "Nobody is currently signed in",
+      "closeTheDayConfirm_one": "Sign out {{count}} person who is still signed in today?",
+      "closeTheDayConfirm_other": "Sign out {{count}} people who are still signed in today?"
     }
   },
   "overlays": {

--- a/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
+++ b/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
@@ -1,0 +1,63 @@
+/**
+ * End of day: sign out everyone still marked present.
+ *
+ * The write half of phase (c) — D4b, *"close the day, and read as-of"*. The read half already exists
+ * (`services/presence/signInPresence`); without this action it answers honestly about a history whose
+ * end nobody records, so a Thursday volunteer still reads present on Sunday.
+ *
+ * **Deliberately NOT built by loosening `signOutUnapproved`.** That action is COMPETITOR-scoped and
+ * its header explains why: *"signed in with no events"* is the **definition** of an official, a coach
+ * or a volunteer, so without the role filter it signed out the entire personnel roster in one click.
+ * This action is role-agnostic on purpose — the day ending applies to everybody — which is the exact
+ * behaviour that made the other one dangerous. Two intents, two actions, two labels.
+ *
+ * The decision of *who* is closed out lives in `stillSignedInOnDate`, a pure function, because TMX has
+ * no jsdom and a decision made here would get no coverage.
+ */
+
+import { stillSignedInOnDate, localCalendarDate } from 'services/presence/signInPresence';
+import { mutationRequest } from 'services/mutation/mutationRequest';
+import { tournamentEngine } from 'services/factory/engine';
+import { participantConstants } from 'tods-competition-factory';
+import { confirmModal } from 'components/modals/baseModal/baseModal';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { t } from 'i18n';
+
+// constants and types
+import { MODIFY_SIGN_IN_STATUS } from 'constants/mutationConstants';
+
+const { SIGNED_OUT } = participantConstants;
+
+/**
+ * Everyone whose day is still open, for the local calendar date.
+ *
+ * `withSignInStatus` is **not** used, and that is the point: it populates `participant.signedIn`,
+ * which is the *latest* value and therefore true for anybody who ever signed in. The date-scoped read
+ * is the whole reason (c) exists.
+ */
+export function participantsToCloseOut(date = localCalendarDate()): string[] {
+  const { participants } = tournamentEngine.getParticipants({}) ?? {};
+  return stillSignedInOnDate(participants, date);
+}
+
+export function closeTheDay(replaceTableData: () => void): void {
+  const participantIds = participantsToCloseOut();
+
+  if (!participantIds.length) {
+    // Says "nobody is signed in", never silently succeeds — an action that appears to do something
+    // and does nothing teaches operators to press it twice.
+    tmxToast({ message: t('pages.participants.closeTheDayNobody'), intent: 'is-info' });
+    return;
+  }
+
+  confirmModal({
+    query: t('pages.participants.closeTheDayConfirm', { count: participantIds.length }),
+    okAction: () =>
+      mutationRequest({
+        methods: [{ method: MODIFY_SIGN_IN_STATUS, params: { signInState: SIGNED_OUT, participantIds } }],
+        callback: (result: any) => {
+          if (result.success) replaceTableData();
+        },
+      }),
+  });
+}

--- a/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
+++ b/src/pages/tournament/tabs/participantTab/renderIndividuals.ts
@@ -22,6 +22,7 @@ import { signInParticipants } from './controlBar/signInParticipants';
 import { printPlayerList } from 'components/modals/printPlayerList';
 import { callSheet } from 'components/modals/callSheet';
 import { signOutUnapproved } from './controlBar/signOutUnapproved';
+import { closeTheDay } from './controlBar/closeTheDay';
 import { getLoginState } from 'services/authentication/loginState';
 import { editRegistrationLink as sheetsLink } from './sheetsLink';
 import { addParticipantsToEvent } from './addParticipantsToEvent';
@@ -152,6 +153,15 @@ export function renderIndividuals({ view }: { view: string }): void {
     {
       onClick: () => signOutUnapproved(replaceTableData),
       label: t('pages.participants.signOutUnapproved'),
+      hide: !hasParticipants,
+      close: true,
+    },
+    {
+      // Sits beside signOutUnapproved deliberately, with a distinct label: that one is
+      // COMPETITOR-scoped entry management, this one is role-agnostic and means the day is over.
+      // Conflating them is what would sign the whole personnel roster out by accident.
+      onClick: () => closeTheDay(replaceTableData),
+      label: t('pages.participants.closeTheDay'),
       hide: !hasParticipants,
       close: true,
     },

--- a/src/services/officiating/officialsBoard.test.ts
+++ b/src/services/officiating/officialsBoard.test.ts
@@ -5,15 +5,8 @@
  * sign-in must NOT make somebody read as present on Friday. Nothing signs anybody out at end of day,
  * so `participant.signedIn` — the latest value — would say it does.
  */
-import {
-  buildOfficialsBoard,
-  signedInOnDate,
-  durationToMinutes,
-  isOfficial,
-  localCalendarDate,
-} from './officialsBoard';
+import { buildOfficialsBoard, signedInOnDate, durationToMinutes, isOfficial } from './officialsBoard';
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
 
 const DAY = '2026-08-24';
 const PRIOR = '2026-08-23';
@@ -73,41 +66,6 @@ describe('signedInOnDate', () => {
   it('is false with no timeItems at all', () => {
     expect(signedInOnDate(official('o1', 'Ana'), DAY)).toBe(false);
     expect(signedInOnDate(undefined, DAY)).toBe(false);
-  });
-});
-
-describe('localCalendarDate', () => {
-  /**
-   * ⚠️ **The obvious unit test for this is VACUOUS and was removed.**
-   *
-   * TMX runs vitest with `TZ=UTC` (`package.json`: `TZ=UTC vitest`), so local and UTC days are
-   * identical in the suite and no assertion on a Date value can tell the correct implementation from
-   * the shipped bug. Verified rather than assumed: restoring `toISOString().slice(0, 10)` left an
-   * earlier version of this block fully green.
-   *
-   * So the invariant is guarded at the SOURCE instead, which is falsifiable — reintroducing the bug
-   * turns the guard red.
-   */
-  /** Comments are stripped first: this file's own docstring quotes the banned pattern as prose. */
-  const codeOf = (file: string) =>
-    readFileSync(new URL(file, import.meta.url), 'utf8')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*$/gm, '');
-
-  it('never derives a calendar date from toISOString — that is UTC, and the board is local', () => {
-    const code = codeOf('./officialsBoard.ts');
-    expect(code).not.toMatch(/toISOString\(\)\s*\.slice\(\s*0\s*,\s*10\s*\)/);
-    // Control: the guard must be able to see the code at all, not merely fail to match an empty string.
-    expect(code).toContain('export function localCalendarDate');
-  });
-
-  it('builds the date from LOCAL getters', () => {
-    const code = codeOf('./officialsBoard.ts');
-    for (const getter of ['getFullYear()', 'getMonth()', 'getDate()']) expect(code).toContain(getter);
-  });
-
-  it('returns empty for an unparseable value rather than "NaN-NaN-NaN"', () => {
-    expect(localCalendarDate('not-a-date')).toBe('');
   });
 });
 

--- a/src/services/officiating/officialsBoard.ts
+++ b/src/services/officiating/officialsBoard.ts
@@ -20,13 +20,12 @@
  * Pure and DOM-free: TMX has no jsdom, so a decision made inside a renderer gets no unit coverage.
  */
 
+import { signedInOnDate, localCalendarDate } from 'services/presence/signInPresence';
 import { participantRoles } from 'tods-competition-factory';
 
 // constants and types
 const { OFFICIAL } = participantRoles;
 
-const SIGN_IN_STATUS = 'SIGN_IN_STATUS';
-const SIGNED_IN = 'SIGNED_IN';
 const IN_PROGRESS = 'IN_PROGRESS';
 const SUSPENDED = 'SUSPENDED';
 
@@ -53,27 +52,6 @@ const COMPLETED_STATUSES = new Set([
  */
 const MAX_PLAUSIBLE_MATCH_MINUTES = 12 * 60;
 
-/**
- * The **local** calendar date of an instant — never `toISOString().slice(0, 10)`.
- *
- * `toISOString` is UTC, so west of UTC it rolls over while the tournament is still playing: at 8pm in
- * Florida it already reports tomorrow. Every schedule surface in TMX keys "today" on the operator's
- * local calendar date (see `gridView.todayIso`), and this must agree with them or the officials board
- * and the Now strip disagree about what day it is.
- *
- * ⚠️ **Local is the established convention, not the ideal one.** The venue's own zone would be better
- * — a director running a Florida tournament from a Pacific laptop still reads the wrong day — but
- * moving to venue time is a change every schedule surface must make together. Fixing it here alone
- * would introduce a *fourth* notion of time.
- */
-export function localCalendarDate(value?: string | Date): string {
-  const date = value instanceof Date ? value : value ? new Date(value) : new Date();
-  if (Number.isNaN(date.getTime())) return '';
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${date.getFullYear()}-${month}-${day}`;
-}
-
 export type OfficialState = 'onCourt' | 'assigned' | 'waiting' | 'available';
 
 export interface OfficialRow {
@@ -97,33 +75,6 @@ export interface OfficialRow {
    */
   contacts?: any[];
   participantRole?: string;
-}
-
-/**
- * Was this person signed in **on this date**?
- *
- * **Deliberately not `participant.signedIn`.** That field is derived by `getParticipantMap` via
- * `getTimeItem`, which returns the *latest* `SIGN_IN_STATUS` by `createdAt` — and since nothing signs
- * anybody out at end of day, a Thursday sign-in still reads SIGNED_IN on Sunday. Reading the history
- * and filtering by date is what makes `waiting` mean what it says.
- *
- * **A date with no entry returns false, and that is the point.** It renders `available` — "not known
- * to be here" — never `waiting`. Presenting an inferred presence as a recorded one is precisely the
- * trap the presence plan keeps naming.
- */
-export function signedInOnDate(participant: any, date: string): boolean {
-  const entries = (participant?.timeItems ?? [])
-    .filter((timeItem: any) => timeItem?.itemType === SIGN_IN_STATUS && timeItem?.createdAt)
-    // `createdAt` is a UTC instant; `date` is a local calendar date. Slicing the ISO string would
-    // compare a UTC day against a local one and disagree for every evening sign-in west of UTC.
-    .filter((timeItem: any) => localCalendarDate(timeItem.createdAt) === date);
-
-  if (!entries.length) return false;
-
-  const latest = entries.reduce((acc: any, timeItem: any) =>
-    String(timeItem.createdAt) > String(acc.createdAt) ? timeItem : acc,
-  );
-  return latest?.itemValue === SIGNED_IN;
 }
 
 /**
@@ -207,3 +158,7 @@ export function buildOfficialsBoard({ matchUps, participants, date }: BoardArgs)
       a.participantName.localeCompare(b.participantName, undefined, { numeric: true }),
   );
 }
+
+// Re-exported so the officials surface has one import site; the implementation is shared with the
+// participants presence surface so the two cannot drift into two presence models (D4e).
+export { signedInOnDate, localCalendarDate };

--- a/src/services/presence/signInPresence.test.ts
+++ b/src/services/presence/signInPresence.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Presence as-of a date, and the set the end-of-day action closes out.
+ *
+ * The case that drives the whole of (c): a Thursday sign-in must NOT make somebody read as present on
+ * Friday. Nothing signs anybody out at end of day, so `participant.signedIn` — the latest value —
+ * says it does. That is the bug (c) exists to fix, not an edge case.
+ */
+import { signedInOnDate, stillSignedInOnDate, localCalendarDate } from './signInPresence';
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const DAY = '2026-08-24';
+const PRIOR = '2026-08-23';
+
+/** Built as a LOCAL midday instant so the fixture means "that local day" in whatever zone runs it. */
+const at = (date: string, hour = 12, itemValue = 'SIGNED_IN') => {
+  const [y, m, d] = date.split('-').map(Number);
+  return { itemType: 'SIGN_IN_STATUS', createdAt: new Date(y, m - 1, d, hour).toISOString(), itemValue };
+};
+
+const person = (participantId: string, timeItems: any[] = []) => ({ participantId, timeItems });
+
+describe('localCalendarDate', () => {
+  /**
+   * ⚠️ The obvious value-based test for this is VACUOUS. TMX runs vitest with `TZ=UTC`
+   * (`package.json`), so local and UTC days are identical in the suite and no assertion on a Date can
+   * tell the correct implementation from the `toISOString().slice(0, 10)` bug that shipped in #1352.
+   * Confirmed by restoring the bug and watching such a test stay green. Guarded at the source instead.
+   */
+  const codeOf = (file: string) =>
+    readFileSync(new URL(file, import.meta.url), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+  it('never derives a calendar date from toISOString — that is UTC, the surfaces are local', () => {
+    const code = codeOf('./signInPresence.ts');
+    expect(code).not.toMatch(/toISOString\(\)\s*\.slice\(\s*0\s*,\s*10\s*\)/);
+    // Control: the guard must be able to see the code, not merely fail to match an empty string.
+    expect(code).toContain('export function localCalendarDate');
+  });
+
+  it('builds the date from LOCAL getters', () => {
+    const code = codeOf('./signInPresence.ts');
+    for (const getter of ['getFullYear()', 'getMonth()', 'getDate()']) expect(code).toContain(getter);
+  });
+
+  it('returns empty for an unparseable value rather than "NaN-NaN-NaN"', () => {
+    expect(localCalendarDate('not-a-date')).toBe('');
+  });
+});
+
+describe('signedInOnDate', () => {
+  it('is true for a sign-in stamped that day', () => {
+    expect(signedInOnDate(person('p1', [at(DAY)]), DAY)).toBe(true);
+  });
+
+  it("does NOT carry a previous day's sign-in forward", () => {
+    // The entire reason (c) exists: with nothing signing anybody out, the latest value stays
+    // SIGNED_IN all week, so `participant.signedIn` would answer true here.
+    expect(signedInOnDate(person('p1', [at(PRIOR)]), DAY)).toBe(false);
+  });
+
+  it('honours a sign-out later the same day', () => {
+    // Somebody who signed in at 9 and out at 5 was not present at 6.
+    expect(signedInOnDate(person('p1', [at(DAY, 9), at(DAY, 17, 'SIGNED_OUT')]), DAY)).toBe(false);
+  });
+
+  it('honours signing back IN after signing out', () => {
+    expect(signedInOnDate(person('p1', [at(DAY, 9), at(DAY, 12, 'SIGNED_OUT'), at(DAY, 14)]), DAY)).toBe(true);
+  });
+
+  it('is false with no timeItems at all', () => {
+    expect(signedInOnDate(person('p1'), DAY)).toBe(false);
+    expect(signedInOnDate(undefined, DAY)).toBe(false);
+  });
+});
+
+describe('stillSignedInOnDate', () => {
+  it('returns exactly the people whose day is still open', () => {
+    const participants = [
+      person('open', [at(DAY, 9)]),
+      person('closed', [at(DAY, 9), at(DAY, 17, 'SIGNED_OUT')]),
+      person('yesterday', [at(PRIOR, 9)]),
+      person('never'),
+    ];
+    expect(stillSignedInOnDate(participants, DAY)).toEqual(['open']);
+  });
+
+  it('is role-agnostic — closing the day is not signOutUnapproved', () => {
+    // signOutUnapproved is COMPETITOR-scoped because "signed in with no events" is the definition of
+    // an official or a volunteer. Closing the day is the opposite intent and must include them.
+    const participants = [
+      { ...person('official', [at(DAY, 9)]), participantRole: 'OFFICIAL' },
+      { ...person('volunteer', [at(DAY, 9)]), participantRole: 'VOLUNTEER' },
+      { ...person('competitor', [at(DAY, 9)]), participantRole: 'COMPETITOR' },
+    ];
+    expect(stillSignedInOnDate(participants, DAY).sort()).toEqual(['competitor', 'official', 'volunteer']);
+  });
+
+  it('is empty rather than undefined for no input', () => {
+    expect(stillSignedInOnDate(undefined, DAY)).toEqual([]);
+    expect(stillSignedInOnDate([], DAY)).toEqual([]);
+  });
+});

--- a/src/services/presence/signInPresence.ts
+++ b/src/services/presence/signInPresence.ts
@@ -1,0 +1,83 @@
+/**
+ * Was this person here **on a given day**?
+ *
+ * Phase (c) of TMX_PRESENCE_AND_CHECK_IN, decision **D4b — "close the day, and read as-of"**.
+ *
+ * **Why this cannot be `participant.signedIn`.** That field is derived by the factory's
+ * `getParticipantMap` through `getTimeItem`, which returns the **latest** `SIGN_IN_STATUS` by
+ * `createdAt`. Since nothing signs anybody out at the end of a day, a volunteer who signed in on
+ * Thursday still reads `SIGNED_IN` on Sunday. The history is faithful; it is a history of a thing
+ * whose end nobody records. Reading the history and filtering by date is what makes "here today"
+ * mean what it says — and the companion half is the end-of-day action that writes the sign-out.
+ *
+ * **A day with no entry is `false`, and that is deliberate.** It renders as "not signed in today",
+ * never as present. An inferred presence shown as a recorded one is the trap this whole surface keeps
+ * naming.
+ *
+ * Extracted from `services/officiating/officialsBoard` (#1352) so the officials board and the
+ * participants surface answer this question with one implementation rather than two — the second
+ * presence model D4e exists to prevent.
+ */
+
+const SIGN_IN_STATUS = 'SIGN_IN_STATUS';
+const SIGNED_IN = 'SIGNED_IN';
+
+/**
+ * The **local** calendar date of an instant — never `toISOString().slice(0, 10)`.
+ *
+ * `toISOString` is UTC, so west of UTC it rolls over while the tournament is still playing: at 8pm in
+ * Florida it already reports tomorrow. Shipping that bug once (#1352, fixed #1355) made every official
+ * read "available" every evening. Every schedule surface in TMX keys "today" on the operator's local
+ * calendar date (see `gridView.todayIso`), and this must agree with them.
+ *
+ * ⚠️ Local is the established convention, not the ideal one — the venue's own zone would be better,
+ * but moving to it is a change every schedule surface must make together.
+ */
+export function localCalendarDate(value?: string | Date): string {
+  const date = value instanceof Date ? value : value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) return '';
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+/** Sign-in entries stamped on a given local day, oldest first. */
+function entriesOn(participant: any, date: string): any[] {
+  return (participant?.timeItems ?? [])
+    .filter((timeItem: any) => timeItem?.itemType === SIGN_IN_STATUS && timeItem?.createdAt)
+    .filter((timeItem: any) => localCalendarDate(timeItem.createdAt) === date);
+}
+
+/**
+ * Whether this person's **last recorded action on that day** was signing in.
+ *
+ * Deliberately not "did they sign in at any point": somebody who signed in at 9am and out at 5pm was
+ * not present at 6pm, and the end-of-day action depends on that distinction being honoured.
+ */
+export function signedInOnDate(participant: any, date: string): boolean {
+  const entries = entriesOn(participant, date);
+  if (!entries.length) return false;
+
+  const latest = entries.reduce((acc: any, timeItem: any) =>
+    String(timeItem.createdAt) > String(acc.createdAt) ? timeItem : acc,
+  );
+  return latest?.itemValue === SIGNED_IN;
+}
+
+/**
+ * Everyone still signed in on this date — the set the end-of-day action closes out.
+ *
+ * **Role-agnostic on purpose, and this is the load-bearing difference from `signOutUnapproved`.**
+ * That action is COMPETITOR-scoped precisely because "signed in with no events" is the *definition*
+ * of an official, a coach or a volunteer, so without its filter it would sign out the whole personnel
+ * roster. Closing the day is the opposite intent: everybody who is still marked present should stop
+ * being marked present, because the day is over. The two must never be merged.
+ *
+ * Pure, so the decision of *who* gets signed out is testable without a DOM.
+ */
+export function stillSignedInOnDate(participants: any[] | undefined, date: string): string[] {
+  return (participants ?? [])
+    .filter((participant: any) => signedInOnDate(participant, date))
+    .map((participant: any) => participant?.participantId)
+    .filter(Boolean);
+}


### PR DESCRIPTION
**Phase (c)** of [`TMX_PRESENCE_AND_CHECK_IN.md`](https://github.com/CourtHive/Mentat/blob/main/planning/TMX_PRESENCE_AND_CHECK_IN.md) — decision **D4b**, *"close the day, and read as-of"*. This closes the presence workstream.

## It was smaller than scoped, because two thirds already existed

| piece | state |
|---|---|
| Timestamped history | ✅ `SIGN_IN_STATUS` timeItems have always appended with `createdAt` |
| Read as-of a date | ✅ shipped with the officials board (#1352), corrected across timezones (#1355) |
| **Close the day** | ❌ **the only real build** |

The plan called (c) *"the only item with no existing model"*. The model was there; what was missing is the thing that makes it mean anything — **nobody ever signed anybody out**, so the latest `SIGN_IN_STATUS` for a Thursday volunteer still read `SIGNED_IN` on Sunday. Faithful history of a thing whose end nobody records.

## One presence model, not two

The as-of read moves to `services/presence/signInPresence.ts`, so the officials board and the participants surface answer *"is this person here today?"* with one implementation. **Two answers to that question is the second presence model D4e exists to prevent** — the whole reason D5 and (c) were scoped together.

## The end-of-day action is deliberately NOT a loosened `signOutUnapproved`

That action is `COMPETITOR`-scoped, and its own header explains why: *"signed in with no events"* is the **definition** of an official, a coach or a volunteer, so without the role filter it signed out the entire personnel roster in one click.

Closing the day is **role-agnostic by intent** — the day ends for everybody — which is exactly the behaviour that made the other one dangerous. So: separate action, separate label, sat beside it in the menu so the difference is visible rather than inferred.

Signing out nobody **says so** rather than silently succeeding. An action that appears to work and does nothing teaches operators to press it twice.

## Verification

| gate | result |
|---|---|
| `lint` / `check-types` / `format:check` | 0 |
| `attr-audit --ci` / `i18n-audit --ci` | 0 |
| `test --run` | **147 files / 1589 tests** |
| journeys 104 + 106 | 5 passed |

Count reconciles exactly: main is 1581; **+11 new**, **−3 moved** with the code they guard (the `toISOString` source guard had to follow `localCalendarDate` out of `officialsBoard.ts`, or it would have kept checking a file that no longer contained the thing it guards).

Falsified three ways, each the specific mistake it guards against — carrying a previous day's sign-in forward, ignoring a later sign-out, and scoping the close to competitors. All three turn the suite red with the collected count unchanged.

## Note on `participant.signedIn`

`closeTheDay` deliberately does **not** pass `withSignInStatus: true`. That flag populates `participant.signedIn`, which is the *latest* value and therefore true for anyone who ever signed in — the exact bug (c) exists to fix. The date-scoped read is the point.