### PR TITLE
fix(deps): update tods-competition-factory to 6.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.30.0",
+    "tods-competition-factory": "6.31.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
## Why

factory **6.31.0** was published and pinned by **nobody** — measured across every `package.json` on 2026-08-24, all nine consumers were still on 6.30.0.

TMX is the consumer this matters most for. 6.31.0 is where `src/query/reports/recoveryTimeline.ts` lives, and [#1356](https://github.com/CourtHive/TMX/pull/1356) deliberately mirrors that module's plausibility gate (`MAX_PLAUSIBLE_MATCH_MINUTES`) and its `wasPlayed` status set, so the Inspector's rest figure and the recovery report cannot disagree about the same matchUp. On 6.30.0, TMX mirrors a factory it cannot actually reach.

6.31.0 also carries the `getMatchUpFormatTiming` category fix ([#4686](https://github.com/CourtHive/competition-factory/pull/4686)), which is what `scheduleTimingResolver.ts` currently works around.

## Why it was invisible

TMX resolves `tods-competition-factory` through a `link:../factory` override, so a local install never asks npm and the stale pin costs nothing locally. The pin is what CI and the release build install.

## Verification

`lint`, `check-types`, `format:check`, `attr-audit --ci`, `i18n-audit --ci` and the full suite (**1589** tests) all clean against 6.31.0.

## Sequencing

Held back from the first fan-out pass because this checkout was on `feat/presence-close-the-day`; taken once #1357 landed and the claim was released. `courthive-ams` is the last one outstanding and is still held by a live session — handoff note left in `Mentat/in-flight/`.