### PR TITLE
fix(officials): time on court was always blank — read the field the factory sets

### DIFF
--- a/e2e/journeys/106-officials-board.spec.ts
+++ b/e2e/journeys/106-officials-board.spec.ts
@@ -43,6 +43,13 @@ async function seedOfficials(page: Page): Promise<string> {
           },
         },
         {
+          participantId: 'official-worked',
+          participantName: 'Cy Worked',
+          participantType: 'INDIVIDUAL',
+          participantRole: 'OFFICIAL',
+          person: { standardFamilyName: 'Worked', standardGivenName: 'Cy' },
+        },
+        {
           participantId: 'official-absent',
           participantName: 'Bo Absent',
           participantType: 'INDIVIDUAL',
@@ -52,7 +59,28 @@ async function seedOfficials(page: Page): Promise<string> {
       ],
     });
     // Only ONE of them signs in — the control that makes waiting/available distinguishable.
-    engine.modifyParticipantsSignInStatus({ participantIds: ['official-signed-in'], signInState: 'SIGNED_IN' });
+    engine.modifyParticipantsSignInStatus({
+      participantIds: ['official-signed-in', 'official-worked'],
+      signInState: 'SIGNED_IN',
+    });
+
+    // Assign Ada a completed matchUp with measured play, scheduled TODAY, so the board has a
+    // non-empty "time on court" to render. This is the case a unit test cannot prove: the column read
+    // a field the factory never populates, so it was plausible in isolation and blank on screen.
+    const today = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const localToday = `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+    const { matchUps } = engine.allTournamentMatchUps();
+    const target = matchUps[0];
+    if (target) {
+      const ids = { drawId: target.drawId, matchUpId: target.matchUpId };
+      engine.addMatchUpScheduledDate({ ...ids, scheduledDate: localToday });
+      engine.addMatchUpStartTime({ ...ids, startTime: '10:00' });
+      engine.addMatchUpEndTime({ ...ids, endTime: '11:30' });
+      // Cy, not Ada: assigning Ada a matchUp would make her `assigned` and destroy the
+      // waiting-vs-available distinction the first test exists to prove.
+      engine.addMatchUpOfficial({ ...ids, participantId: 'official-worked' });
+    }
 
     await dev.save?.();
     return tournamentRecord.tournamentId;
@@ -86,6 +114,25 @@ test.describe('Journey 106 — officials board', () => {
     // D5: signed in today and unassigned = waiting; not signed in = available.
     await expect(signedInRow.locator('[data-official-state]')).toHaveAttribute('data-official-state', 'waiting');
     await expect(absentRow.locator('[data-official-state]')).toHaveAttribute('data-official-state', 'available');
+  });
+
+  test('time on court renders a measured duration, not a blank', async ({ page }) => {
+    // The shipped defect: the column read a top-level `matchUpDuration` that no TMX hydration sets,
+    // so it was always empty. 90 minutes of play must render as 1:30.
+    const tournamentId = await seedOfficials(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await page.locator(S.NAV_OFFICIALS).click();
+
+    const board = page.locator(S.TOURNAMENT_OFFICIALS);
+    const cyRow = board.locator('.tabulator-row').filter({ hasText: 'Cy Worked' }).first();
+    await expect(cyRow).toBeVisible({ timeout: 10_000 });
+    await expect(cyRow).toContainText('1:30');
+
+    // Control: an official with no matchUp shows no duration, so the assertion above is about the
+    // measured value rather than a string that appears on every row.
+    const adaRow = board.locator('.tabulator-row').filter({ hasText: 'Ada Signed' }).first();
+    await expect(adaRow).not.toContainText('1:30');
   });
 
   test('an un-consented mobile still renders on the board (D6 — mark, do not hide)', async ({ page }) => {

--- a/src/services/officiating/officialsBoard.test.ts
+++ b/src/services/officiating/officialsBoard.test.ts
@@ -5,7 +5,7 @@
  * sign-in must NOT make somebody read as present on Friday. Nothing signs anybody out at end of day,
  * so `participant.signedIn` — the latest value — would say it does.
  */
-import { buildOfficialsBoard, signedInOnDate, durationToMinutes, isOfficial } from './officialsBoard';
+import { buildOfficialsBoard, signedInOnDate, durationMinutes, isOfficial } from './officialsBoard';
 import { describe, expect, it } from 'vitest';
 
 const DAY = '2026-08-24';
@@ -34,13 +34,14 @@ const signIn = (date: string, itemValue = 'SIGNED_IN') => {
 const assignment = (over: any = {}) => ({
   matchUpId: over.matchUpId ?? 'm1',
   matchUpStatus: over.matchUpStatus ?? 'TO_BE_PLAYED',
-  matchUpDuration: over.matchUpDuration,
   winningSide: over.winningSide,
   schedule: {
     scheduledDate: over.scheduledDate ?? DAY,
     scheduledTime: over.scheduledTime,
     courtName: over.courtName,
     official: over.official,
+    // The factory publishes measured play as schedule.milliseconds, not a top-level field.
+    milliseconds: over.minutes === undefined ? undefined : over.minutes * 60_000,
   },
 });
 
@@ -69,16 +70,31 @@ describe('signedInOnDate', () => {
   });
 });
 
-describe('durationToMinutes', () => {
-  it('parses the factory HH:MM:SS field', () => {
-    expect(durationToMinutes('01:23:45')).toBe(83);
-    expect(durationToMinutes('00:00:30')).toBe(0);
+describe('durationMinutes', () => {
+  /**
+   * Reads `schedule.milliseconds`. The board originally read a top-level `matchUpDuration`, which is
+   * `undefined` on every hydration TMX uses — so the column was always blank. These pin the field, not
+   * just the arithmetic: an implementation that went back to `matchUpDuration` returns 0 here.
+   */
+  it('reads schedule.milliseconds', () => {
+    expect(durationMinutes({ schedule: { milliseconds: 5_400_000 } })).toBe(90);
   });
 
-  it('returns 0 for absent or malformed input rather than NaN', () => {
+  it('is 0 when only the top-level matchUpDuration is present', () => {
+    // The exact shipped bug: this shape is what the board was reading, and the factory never sets it.
+    expect(durationMinutes({ matchUpDuration: '01:30:00' })).toBe(0);
+  });
+
+  it('floors partial minutes rather than rounding up', () => {
+    expect(durationMinutes({ schedule: { milliseconds: 119_000 } })).toBe(1);
+  });
+
+  it('is 0 for absent, non-numeric or negative input rather than NaN', () => {
     // NaN would poison the summed column silently — worse than a visible zero.
-    expect(durationToMinutes(undefined)).toBe(0);
-    expect(durationToMinutes('not-a-duration')).toBe(0);
+    expect(durationMinutes(undefined)).toBe(0);
+    expect(durationMinutes({ schedule: {} })).toBe(0);
+    expect(durationMinutes({ schedule: { milliseconds: 'lots' } })).toBe(0);
+    expect(durationMinutes({ schedule: { milliseconds: -1 } })).toBe(0);
   });
 });
 
@@ -146,8 +162,8 @@ describe('buildOfficialsBoard', () => {
   it('sums time on court and counts matches for the date', () => {
     const rows = buildOfficialsBoard({
       matchUps: [
-        assignment({ matchUpId: 'm1', official: 'o1', matchUpStatus: 'COMPLETED', matchUpDuration: '01:30:00' }),
-        assignment({ matchUpId: 'm2', official: 'o1', matchUpStatus: 'COMPLETED', matchUpDuration: '00:45:00' }),
+        assignment({ matchUpId: 'm1', official: 'o1', matchUpStatus: 'COMPLETED', minutes: 90 }),
+        assignment({ matchUpId: 'm2', official: 'o1', matchUpStatus: 'COMPLETED', minutes: 45 }),
       ],
       participants: [official('o1', 'Ana', [signIn(DAY)])],
       date: DAY,
@@ -160,9 +176,7 @@ describe('buildOfficialsBoard', () => {
     // matchUpDuration adds a live-elapsed term for anything started and not ended, so a forgotten
     // STOP would otherwise inflate "time on court today" indefinitely.
     const rows = buildOfficialsBoard({
-      matchUps: [
-        assignment({ matchUpId: 'm1', official: 'o1', matchUpStatus: 'IN_PROGRESS', matchUpDuration: '97:00:00' }),
-      ],
+      matchUps: [assignment({ matchUpId: 'm1', official: 'o1', matchUpStatus: 'IN_PROGRESS', minutes: 97 * 60 })],
       participants: [official('o1', 'Ana', [signIn(DAY)])],
       date: DAY,
     });

--- a/src/services/officiating/officialsBoard.ts
+++ b/src/services/officiating/officialsBoard.ts
@@ -78,19 +78,24 @@ export interface OfficialRow {
 }
 
 /**
- * `"HH:MM:SS"` to whole minutes.
+ * Minutes of play the factory has already measured for this matchUp.
  *
- * The factory attaches `matchUpDuration` as a formatted string during hydration
- * (`getMatchUpScheduleDetails`); the underlying function is **not** exported, so parsing the field is
- * the supported route and reimplementing the START/STOP/RESUME/END ladder here would be a second
- * source of truth for a number the factory already computes.
+ * **Reads `schedule.milliseconds`, not `matchUpDuration`.** The board originally read a top-level
+ * `matchUpDuration`, which is `undefined` on every hydration TMX uses — verified against
+ * `allTournamentMatchUps({ inContext, nextMatchUps })`, `competitionScheduleMatchUps` and
+ * `getMatchUpScheduleDetails` — so the column was always blank. The figure is published as
+ * `schedule.milliseconds` (with a formatted `schedule.time` alongside).
+ *
+ * Consuming the integer is also the right call: parsing `"HH:MM:SS"` re-derived a number the factory
+ * had already computed, and would silently yield 0 if that format ever changed.
+ *
+ * ⚠️ **Includes a live-elapsed term for a running matchUp**, so it grows between reads and an
+ * unclosed timer would grow without bound — hence the cap at the call site.
  */
-export function durationToMinutes(duration?: string): number {
-  if (!duration) return 0;
-  const parts = String(duration).split(':').map(Number);
-  if (parts.length < 2 || parts.some((part) => !Number.isFinite(part))) return 0;
-  const [hours, minutes] = parts;
-  return hours * 60 + minutes;
+export function durationMinutes(matchUp: any): number {
+  const milliseconds = matchUp?.schedule?.milliseconds;
+  if (typeof milliseconds !== 'number' || !Number.isFinite(milliseconds) || milliseconds <= 0) return 0;
+  return Math.floor(milliseconds / 60_000);
 }
 
 function isLive(matchUp: any): boolean {
@@ -144,7 +149,7 @@ export function buildOfficialsBoard({ matchUps, participants, date }: BoardArgs)
       participantRole: participant?.participantRole,
       matchesToday: assigned.length,
       minutesOnCourtToday: assigned.reduce(
-        (total, matchUp) => total + Math.min(durationToMinutes(matchUp?.matchUpDuration), MAX_PLAUSIBLE_MATCH_MINUTES),
+        (total, matchUp) => total + Math.min(durationMinutes(matchUp), MAX_PLAUSIBLE_MATCH_MINUTES),
         0,
       ),
     };


### PR DESCRIPTION
Third defect in the officials board, found while checking CA's scenario of a matchUp interrupted and completed on a different day.

## The bug

The board read a **top-level `matchUpDuration`**. No TMX hydration populates it — verified against all three candidates:

| probe | `matchUpDuration` |
|---|---|
| `allTournamentMatchUps({ inContext, nextMatchUps })` — what the board uses | `undefined` |
| `competitionScheduleMatchUps` | `undefined` |
| `getMatchUpScheduleDetails` | `undefined` |

So **"Time on court today" was empty for every official, always.**

`getMatchUpScheduleDetails` publishes the measured figure as **`schedule.milliseconds`** (with a formatted `schedule.time` alongside). Reading the integer also removes a parse of `"HH:MM:SS"` that re-derived a number the factory had already computed and would have silently yielded zero on any format change.

I verified earlier that `matchUpDuration` was a *field* rather than an exported function — and then assumed the field was populated. It isn't.

## What the tests pin

The unit tests pin the **field**, not the arithmetic — an implementation that goes back to `matchUpDuration` returns zero and **four go red**:

```ts
it('is 0 when only the top-level matchUpDuration is present', ...)
```

**Journey 106 gains the assertion the unit tests structurally cannot make** — that the column actually renders `1:30`. "Plausible in isolation, blank on screen" is exactly how this shipped, so the unit layer alone would not have caught it. Falsified at both levels: restoring the bug turns 4 unit tests **and** the journey red.

Two things about the journey seed, both deliberate:

- The duration case uses a **third official** (Cy). Assigning Ada a matchUp would make her `assigned` and destroy the waiting-vs-available distinction the first test exists to prove.
- It asserts an official with **no** matchUp shows **no** duration — a control, so the `1:30` assertion is about a measured value rather than a string that happens to appear on every row.

## Related, and not in this PR

CA's interruption scenario turned out to be a deeper model gap: the record **refuses** a next-day `RESUME` (`ERR_INVALID_RESUME_TIME`), because bare `HH:MM` items are anchored to one reference day. Measured with a same-day control. Filed against the Temporal migration (post-Oct) in `SCHEDULE_ENDDATE_AND_TIMEZONE_AWARENESS.md` → **A-next**, with the officiating consequence noted: the official can change across an interruption, and a last-write-wins scalar attributes the whole duration to whoever holds the field at report time.

## Verification

lint 0 · check-types 0 · format:check 0 · attr-audit 0 · i18n-audit 0 · **147 files / 1591 tests** · journeys 105 + 106 green.

Count reconciles: main is 1589; +4 new duration tests, −2 replaced.