### PR TITLE
feat(schedule): the catalog rest badge ticks, so it stops contradicting the Inspector

### DIFF
--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -199,24 +199,47 @@ export function restDateFor(matchUp: ReadinessMatchUp | undefined, viewedDate: s
   return matchUp?.schedule?.scheduledDate ?? viewedDate;
 }
 
-/** Rest for one matchUp, resolved against current factory state and the current clock. */
-export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
+/**
+ * A rest evaluator valid for one pass, sharing the engine work across every
+ * matchUp it is asked about.
+ *
+ * `makeTimingResolver()` walks the tournament's events and
+ * `getMatchUpDailyLimits()` reaches the engine. Paying for both once is fine for
+ * the Inspector's single matchUp and wrong for the catalog, where the badge
+ * ticker re-reads every visible card on a timer — that is N engine passes every
+ * 30 seconds for a screen that has not changed.
+ *
+ * `asOfMinutes` is captured once too, so every badge in a tick agrees about what
+ * time it is. Reading the clock per badge would let a pass that straddles a
+ * minute boundary render two cards a minute apart.
+ */
+export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | null) => RestResult {
   const { matchUps } = getCachedAllMatchUps();
   const hydrated = (matchUps ?? []) as ReadinessMatchUp[];
-  const restDate = restDateFor(
-    hydrated.find((matchUp) => matchUp.matchUpId === matchUpId),
-    viewedDate,
-  );
   const timingFor = makeTimingResolver();
-  return analyzeParticipantRest({
-    matchUpId,
-    matchUps: hydrated,
-    scheduledDate: restDate ?? '',
-    asOfMinutes: nowDayMinutes(),
-    timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
-    dailyLimits: readDailyLimits(),
-    timingFor,
-  });
+  const dailyLimits = readDailyLimits();
+  const asOfMinutes = nowDayMinutes();
+
+  return (matchUpId, viewedDate) => {
+    const restDate = restDateFor(
+      hydrated.find((matchUp) => matchUp.matchUpId === matchUpId),
+      viewedDate,
+    );
+    return analyzeParticipantRest({
+      matchUpId,
+      matchUps: hydrated,
+      scheduledDate: restDate ?? '',
+      asOfMinutes,
+      timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
+      dailyLimits,
+      timingFor,
+    });
+  };
+}
+
+/** Rest for one matchUp, resolved against current factory state and the current clock. */
+export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
+  return makeRestEvaluator()(matchUpId, viewedDate);
 }
 
 /** `134` → `'2h 14m'`; under an hour drops the hours part entirely. */

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.test.ts
@@ -1,4 +1,4 @@
-import { badgeText, badgeTooltip, headlineRow, shouldRender } from './restBadge';
+import { badgeModel, badgeText, badgeTooltip, headlineRow, shouldRender } from './restBadge';
 import { describe, expect, it } from 'vitest';
 
 // constants and types
@@ -121,5 +121,65 @@ describe('badge honesty for states that carry no measurable interval', () => {
     const overrun = badgeTooltip([row({ status: 'onCourt', overrun: true })]);
     const normal = badgeTooltip([row({ status: 'onCourt' })]);
     expect(overrun).not.toEqual(normal);
+  });
+});
+
+/**
+ * The badge counts up, so a paint-once badge is wrong from the second after it
+ * renders — and a stale badge beside a live Inspector reading something else is
+ * worse than either alone. `badgeModel` is the single derivation both the first
+ * paint and every repaint go through; a ticker that rebuilt the badge by a
+ * parallel route would drift from the original, which is the shape of the bug
+ * this file's history is about.
+ *
+ * Only the model is asserted here. The DOM half (`applyBadge`, the interval)
+ * cannot be reached — TMX's vitest run has no DOM — and belongs to a journey.
+ */
+describe('badgeModel — one derivation for the first paint and every repaint', () => {
+  function result(rows: RestRow[]): RestResult {
+    return { evaluated: true, asOfMinutes: 700, rows };
+  }
+
+  it('returns null when there is nothing worth drawing', () => {
+    expect(badgeModel({ evaluated: false, reason: 'bye' })).toBeNull();
+    expect(badgeModel(result([row({ status: 'none' })]))).toBeNull();
+  });
+
+  it("carries the headline row's status and text", () => {
+    const model = badgeModel(result([row({ status: 'rested' }), row({ status: 'resting', restMinutes: 41 })]));
+    expect(model).toMatchObject({ status: 'resting', text: badgeText(row({ status: 'resting', restMinutes: 41 })) });
+  });
+
+  it('agrees with badgeText and badgeTooltip rather than re-deriving them', () => {
+    const rows = [row({ status: 'onCourt' }), row({ status: 'rested', restMinutes: 200 })];
+    const model = badgeModel(result(rows));
+    expect(model?.text).toBe(badgeText(headlineRow(rows)!));
+    expect(model?.title).toBe(badgeTooltip(rows));
+  });
+
+  it('leaves the limit fields empty when no daily limit is met, so a repaint clears the marker', () => {
+    const model = badgeModel(result([row({ status: 'resting', restMinutes: 10 })]));
+    expect(model?.atLimit).toBe('');
+    expect(model?.limitText).toBe('');
+  });
+
+  it('carries the limit marker when one is met', () => {
+    const atLimit = row({
+      status: 'resting',
+      restMinutes: 10,
+      load: { singles: 2, doubles: 0, total: 2, ordinal: 3, atLimit: ['singles', 'total'], limit: 3 },
+    });
+    const model = badgeModel(result([atLimit]));
+    expect(model?.atLimit).toBe('singles,total');
+    expect(model?.limitText).not.toBe('');
+  });
+
+  it('reports a status transition as the clock moves, which is the whole point of ticking', () => {
+    // The same participant, evaluated 30 seconds apart across the requirement.
+    const before = badgeModel(result([row({ status: 'resting', restMinutes: 59, requiredMinutes: 60 })]));
+    const after = badgeModel(result([row({ status: 'rested', restMinutes: 60, requiredMinutes: 60 })]));
+    expect(before?.status).toBe('resting');
+    expect(after?.status).toBe('rested');
+    expect(before?.text).not.toBe(after?.text);
   });
 });

--- a/src/pages/tournament/tabs/scheduleViews/restBadge.ts
+++ b/src/pages/tournament/tabs/scheduleViews/restBadge.ts
@@ -17,9 +17,26 @@
  * added it) rather than by post-processing `.spl-matchup-card`: the catalog
  * rebuilds its cards on every state change, so an externally appended node
  * would be wiped rather than reused.
+ *
+ * ── Why the badge ticks ──
+ *
+ * Rest counts up, so a badge that is painted once and left alone is wrong from
+ * the second after it renders. The Inspector has always repainted on a timer;
+ * the badge did not, and the gap was not cosmetic — a card could sit reading
+ * `41m` long after the player was rested, and a stale badge beside a live
+ * Inspector reading something else is worse than either alone, because it makes
+ * the operator distrust both. That mismatch is exactly what surfaced the
+ * two-viewed-dates defect, and it took a while to establish which of the two was
+ * lying.
+ *
+ * The catalog is NOT rebuilt to achieve this. Rebuilding every card on a timer
+ * would cost the operator their scroll position, any open menu, and an in-flight
+ * drag — the badge is a passenger on the card, and a passenger does not get to
+ * demolish the vehicle. Instead the badges already in the document are repainted
+ * in place, on the Inspector's cadence so the two never disagree.
  */
 
-import { evaluateRest, formatDuration } from './inspectorRest';
+import { evaluateRest, formatDuration, makeRestEvaluator } from './inspectorRest';
 import { t } from 'i18n';
 
 // constants and types
@@ -89,32 +106,122 @@ export function shouldRender(result: RestResult): boolean {
 }
 
 /**
+ * Everything the badge displays, as plain data.
+ *
+ * Extracted so the first paint and every repaint go through one derivation. A
+ * ticker that rebuilt the badge by a second, parallel route would drift from the
+ * original — which is the shape of the bug this file's whole history is about.
+ */
+export interface RestBadgeModel {
+  status: RestStatus;
+  text: string;
+  title: string;
+  /** Joined limit keys for the data attribute; empty when no limit is met. */
+  atLimit: string;
+  /** The "#3" marker riding the badge; empty when no limit is met. */
+  limitText: string;
+}
+
+/** The badge's data for one matchUp, or null when there is nothing worth drawing. */
+export function badgeModel(result: RestResult): RestBadgeModel | null {
+  if (!shouldRender(result) || !result.evaluated) return null;
+  const row = headlineRow(result.rows);
+  if (!row) return null;
+
+  return {
+    status: row.status,
+    text: badgeText(row),
+    title: badgeTooltip(result.rows),
+    atLimit: row.load.atLimit.join(','),
+    // The daily-limit signal is the one thing a director must not miss while
+    // scanning, so it rides the badge rather than waiting for the Inspector.
+    limitText: row.load.atLimit.length ? t('schedule.card.rest.limit', { ordinal: row.load.ordinal }) : '',
+  };
+}
+
+/** Write a model onto an element, creating or removing the limit marker to match. */
+function applyBadge(badge: HTMLElement, model: RestBadgeModel): void {
+  badge.className = `tmx-rest-badge is-${model.status.toLowerCase()}`;
+  badge.dataset.restStatus = model.status;
+  badge.title = model.title;
+
+  // `textContent =` would take the limit marker with it, so the leading text node
+  // is addressed on its own and the marker survives every repaint.
+  const existing = badge.querySelector<HTMLElement>('.tmx-rest-badge-limit');
+  const leading = badge.firstChild;
+  if (leading?.nodeType === Node.TEXT_NODE) {
+    leading.textContent = model.text;
+  } else {
+    badge.prepend(document.createTextNode(model.text));
+  }
+
+  if (!model.limitText) {
+    delete badge.dataset.atLimit;
+    existing?.remove();
+    return;
+  }
+  badge.dataset.atLimit = model.atLimit;
+  const limit = existing ?? document.createElement('span');
+  limit.className = 'tmx-rest-badge-limit';
+  limit.textContent = model.limitText;
+  if (!existing) badge.appendChild(limit);
+}
+
+// ── Live refresh ──────────────────────────────────────────────────────────
+// One module-level interval drives every badge currently in the document. It
+// stops itself once none are connected, which is what makes it safe against the
+// catalog rebuilding its cards on every state change and against the schedule
+// tab unmounting without telling us — the same contract `inspectorRest.ts` uses
+// for its section, and the same cadence, so a card and the Inspector never
+// disagree about a figure that is only counting up.
+
+const REFRESH_MS = 30_000;
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+function stopTicker(): void {
+  if (tickHandle) clearInterval(tickHandle);
+  tickHandle = null;
+}
+
+function tick(): void {
+  const badges = Array.from(document.querySelectorAll<HTMLElement>('.tmx-rest-badge[data-matchup-id]'));
+  if (!badges.length) {
+    stopTicker();
+    return;
+  }
+  // One evaluator for the whole pass: the engine work is per-tournament, not
+  // per-card, and every badge in a tick should agree about what time it is.
+  const evaluate = makeRestEvaluator();
+  for (const badge of badges) {
+    const matchUpId = badge.dataset.matchUpId;
+    if (!matchUpId) continue;
+    const model = badgeModel(evaluate(matchUpId, badge.dataset.viewedDate || null));
+    // A badge with nothing left to say is removed rather than frozen — this node
+    // is ours, appended by `renderCardExtra`, so taking it back is not reaching
+    // into the card's own markup.
+    if (model) applyBadge(badge, model);
+    else badge.remove();
+  }
+}
+
+/**
  * The `renderCardExtra` implementation. Returns a fresh element per call, or
  * null when there is nothing worth saying.
  */
 export function renderRestBadge(matchUpId: string, viewedDate: string | null): HTMLElement | null {
   if (!matchUpId) return null;
 
-  const result = evaluateRest(matchUpId, viewedDate);
-  if (!shouldRender(result) || !result.evaluated) return null;
-
-  const row = headlineRow(result.rows);
-  if (!row) return null;
+  const model = badgeModel(evaluateRest(matchUpId, viewedDate));
+  if (!model) return null;
 
   const badge = document.createElement('span');
-  badge.className = `tmx-rest-badge is-${row.status.toLowerCase()}`;
-  badge.dataset.restStatus = row.status;
-  badge.textContent = badgeText(row);
-  badge.title = badgeTooltip(result.rows);
+  // Carried on the element because the ticker finds badges by query rather than
+  // by a registry: a registry would have to be invalidated every time the
+  // catalog discarded a card, and the document already knows which ones exist.
+  badge.dataset.matchUpId = matchUpId;
+  if (viewedDate) badge.dataset.viewedDate = viewedDate;
+  applyBadge(badge, model);
 
-  // The daily-limit signal is the one thing a director must not miss while
-  // scanning, so it rides the badge rather than waiting for the Inspector.
-  if (row.load.atLimit.length) {
-    badge.dataset.atLimit = row.load.atLimit.join(',');
-    const limit = document.createElement('span');
-    limit.className = 'tmx-rest-badge-limit';
-    limit.textContent = t('schedule.card.rest.limit', { ordinal: row.load.ordinal });
-    badge.appendChild(limit);
-  }
+  tickHandle ??= setInterval(tick, REFRESH_MS);
   return badge;
 }


### PR DESCRIPTION
**Stacked on [#1356](https://github.com/CourtHive/TMX/pull/1356)** — base is `fix/rest-frame-and-viewed-date`, so review that one first; this diff is only the three files below.

## The problem

Rest counts up, so a badge painted once is wrong from the second after it renders. The Inspector has repainted on a 30s timer since it shipped; the badge never did. A card could sit reading `41m` long after the player was rested.

Worse than stale-on-its-own: a stale badge beside a live Inspector saying something else makes the operator distrust **both**. That mismatch is precisely what surfaced the two-viewed-dates defect in #1356 — and working out which of the two was lying took far longer than it should have, because either could have been.

## The catalog is not rebuilt to achieve this

Rebuilding every card on a timer would cost the operator their scroll position, any open menu, and an in-flight drag. The badge is a passenger on the card; a passenger does not demolish the vehicle.

Badges already in the document are repainted in place, on the Inspector's cadence so the two cannot disagree.

## What changed

- **`badgeModel`** is now the single derivation both the first paint and every repaint go through. A ticker that rebuilt the badge by a parallel route would drift from the original — which is the shape of the bug this file's history is about.
- **`applyBadge`** addresses the leading text node rather than assigning `textContent`, so the daily-limit marker survives a repaint. A badge with nothing left to say is removed rather than frozen; the node is ours, appended via `renderCardExtra`, so taking it back isn't reaching into the card's own markup.
- **Badges are found by query on `data-matchup-id`**, not a registry — a registry would need invalidating every time the catalog discarded a card, and the document already knows which ones exist. The interval stops itself once none are connected, the same contract `inspectorRest.ts` uses.
- **`makeRestEvaluator`** shares the per-pass engine work. `makeTimingResolver()` walks the tournament's events and `getMatchUpDailyLimits()` reaches the engine, so evaluating per card meant N engine passes every 30 seconds for a screen that had not changed. It also fixes `asOfMinutes` once per tick, so a pass straddling a minute boundary cannot render two cards a minute apart.

## Verification

Six tests on the model, falsified in both directions, including the `resting → rested` transition that is the entire point of ticking. Suite **1616** green; lint, check-types, format:check, `attr-audit --ci`, `i18n-audit --ci` all clean.

**Not covered by unit tests, deliberately:** `applyBadge` and the interval. TMX's vitest run has no DOM, so that half belongs to a journey — the same boundary #1346 drew for the Inspector actions popover.

## Note on how this was built

TMX's shared checkout was occupied by another session with uncommitted work on `fix/officials-time-on-court` (no in-flight claim filed). Rather than move HEAD under them, this was developed in a `git worktree` sibling of `factory/` so the `link:` overrides still resolve. Nothing in the main checkout was touched.