### PR TITLE
fix(deps): update tods-competition-factory to 6.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.31.0",
+    "tods-competition-factory": "6.32.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Ecosystem fan-out of tods-competition-factory **6.32.0**.

`TMX` protects `main`, so this arrives as a PR rather than the direct push the
other consumers take. Generated by `Mentat/scripts/bump-factory-consumers.sh`, which
type-checked every consumer before committing.

Manifest (and lockfile, where the specifier is not a `link:` override) only.