### PR TITLE
fix(schedule): read every instant in the venue's zone, not the operator's

### DIFF
--- a/src/components/notices/venueFrameNotice.ts
+++ b/src/components/notices/venueFrameNotice.ts
@@ -27,7 +27,7 @@ export function buildVenueFrameNotice(onZoneSet?: () => void): HTMLElement | nul
 
   const pill = document.createElement('button');
   pill.type = 'button';
-  pill.setAttribute('data-tmx', 'venue-frame-notice');
+  pill.dataset.tmx = 'venue-frame-notice';
   pill.title = t('schedule.venueFrame.noticeTitle', {
     defaultValue:
       'This tournament has no time zone set, so times are shown in this device’s zone ({{timeZone}}). Set the venue’s time zone so every operator reads the same clock.',

--- a/src/components/notices/venueFrameNotice.ts
+++ b/src/components/notices/venueFrameNotice.ts
@@ -1,0 +1,65 @@
+/**
+ * "Times shown in …" — the notice that makes the venue-frame fallback visible.
+ *
+ * Every instant TMX renders is converted in the tournament's own zone
+ * (`Mentat/planning/DECISION_VENUE_TIME_FRAME.md`). When the tournament record
+ * carries no `localTimeZone`, the browser's zone stands in — and this pill says
+ * so, with one click to set the real one.
+ *
+ * **Why it exists at all.** Refusing to render times for a zone-less tournament
+ * would break the running desk for most tournaments as they stand today, so the
+ * fallback has to stay. But a *silent* fallback reproduces, through a different
+ * door, exactly the failure this whole change set removes: a page that is right
+ * for the director standing at the venue and wrong for the one running it from
+ * another zone, with nothing on screen to say which you are looking at. So the
+ * one case where the page can be wrong is the one case where it says so.
+ *
+ * Renders `null` — not an empty box — once a venue zone is set, so the action
+ * bar's flex gap does not reserve space for a notice that isn't there.
+ */
+import { openEditDatesModal } from 'pages/tournament/tabs/overviewTab/editDatesModal';
+import { resolveVenueFrame } from 'functions/venueTimeFrame';
+import { t } from 'i18n';
+
+export function buildVenueFrameNotice(onZoneSet?: () => void): HTMLElement | null {
+  const { timeZone, source } = resolveVenueFrame();
+  if (source === 'tournament') return null;
+
+  const pill = document.createElement('button');
+  pill.type = 'button';
+  pill.setAttribute('data-tmx', 'venue-frame-notice');
+  pill.title = t('schedule.venueFrame.noticeTitle', {
+    defaultValue:
+      'This tournament has no time zone set, so times are shown in this device’s zone ({{timeZone}}). Set the venue’s time zone so every operator reads the same clock.',
+    timeZone,
+  });
+  pill.style.cssText = [
+    'display: inline-flex',
+    'align-items: center',
+    'gap: 6px',
+    'padding: 3px 9px',
+    'font-size: 0.78rem',
+    'line-height: 1.4',
+    'border-radius: 6px',
+    'cursor: pointer',
+    'background: var(--tmx-panel-yellow-bg)',
+    'border: 1px solid var(--tmx-panel-yellow-border)',
+    'color: var(--tmx-text-primary)',
+  ].join('; ');
+
+  const icon = document.createElement('i');
+  icon.className = 'fa fa-earth-americas';
+  icon.style.color = 'var(--tmx-accent-orange)';
+  pill.appendChild(icon);
+
+  const label = document.createElement('span');
+  label.textContent = t('schedule.venueFrame.notice', {
+    defaultValue: 'Times in {{timeZone}} — venue zone not set',
+    timeZone,
+  });
+  pill.appendChild(label);
+
+  pill.addEventListener('click', () => openEditDatesModal({ onSave: () => onZoneSet?.() }));
+
+  return pill;
+}

--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -8,6 +8,7 @@
  *   - 'YYYY-MM-DD' — a specific date string
  *   - '__none__' — matchUps with no scheduledDate
  */
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { competitionEngine } from 'services/factory/engine';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -15,12 +16,14 @@ import { t } from 'i18n';
 export const TODAY_TOKEN = 'today';
 const NO_DATE_TOKEN = '__none__';
 
+/**
+ * Today at the **venue** (`YYYY-MM-DD`) — the day the "Today" filter token means.
+ *
+ * Not the operator's: the Today bar and the schedule's Now strip have to name the
+ * same day, and the schedule keys on the venue. See `functions/venueTimeFrame`.
+ */
 export function isoToday(): string {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, '0');
-  const dd = String(now.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
+  return venueCalendarDate();
 }
 
 function formatDateLabel(iso: string): string {

--- a/src/components/tables/common/filters/matchUpStatusPredicates.ts
+++ b/src/components/tables/common/filters/matchUpStatusPredicates.ts
@@ -12,6 +12,7 @@
  *   - `popoverStatusPredicate` — the human-friendly popover options (which are
  *     intentionally NOT a partition: "To be played" folds in SUSPENDED, etc.).
  */
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 
 const WALKOVER_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'DEFAULTED', 'DOUBLE_DEFAULT']);
 const COMPLETE_STATUSES = new Set(['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT', 'CANCELLED', 'ABANDONED']);
@@ -36,19 +37,18 @@ function isComplete(rowData: any): boolean {
  * True when the row carries a `calledAt` stamp belonging to the day it is
  * scheduled on. `calledAt` is a full ISO instant and survives a reschedule as
  * historical record (only an explicit unschedule clears it), so a stamp from an
- * earlier day must not make a match look called for today. Compared in local
- * wall-clock — the same convention the calledAt column and the Call Timing
- * Variance report use, and on-site local time is venue time.
+ * earlier day must not make a match look called for today. Resolved in the
+ * VENUE's zone — `scheduledDate` is a venue calendar day, so the day `calledAt`
+ * falls on has to be read on the same clock, which is also what the calledAt
+ * column and the Call Timing Variance report now do.
  */
 function isCalledForScheduledDay(rowData: any): boolean {
   const calledAt = rowData?.calledAt;
   if (!calledAt) return false;
-  const called = new Date(calledAt);
-  if (Number.isNaN(called.getTime())) return false;
+  const calledDay = venueCalendarDate(calledAt);
+  if (!calledDay) return false;
   if (!rowData.scheduledDate) return true;
-  const pad = (n: number) => String(n).padStart(2, '0');
-  const localDate = `${called.getFullYear()}-${pad(called.getMonth() + 1)}-${pad(called.getDate())}`;
-  return localDate === rowData.scheduledDate;
+  return calledDay === rowData.scheduledDate;
 }
 
 /**

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.ts
@@ -1,16 +1,15 @@
+import { venueCalendarDate, venueClock } from 'functions/venueTimeFrame';
 import { t } from 'i18n';
 
+// `scheduledDate` / `scheduledTime` are bare venue wall-clock values, so the
+// "now" they are compared against must be the venue's clock too — otherwise a
+// match reads as past or future purely because of where the laptop is.
 function todayYmd(): string {
-  const d = new Date();
-  const y = d.getFullYear();
-  const mo = String(d.getMonth() + 1).padStart(2, '0');
-  const da = String(d.getDate()).padStart(2, '0');
-  return `${y}-${mo}-${da}`;
+  return venueCalendarDate();
 }
 
 function nowHm(): string {
-  const d = new Date();
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  return venueClock();
 }
 
 type Status = 'future' | 'past' | 'none';

--- a/src/functions/venueTimeFrame.test.ts
+++ b/src/functions/venueTimeFrame.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The venue time frame.
+ *
+ * ⚠️ TMX runs vitest with `TZ=UTC` (`package.json`), which is exactly why every
+ * assertion here passes an **explicit** zone. A test that relied on the ambient
+ * zone would be vacuous: under UTC the browser-zone bug and the venue-zone fix
+ * produce identical output, so it could not tell them apart. Each case below
+ * names a zone whose offset differs from UTC, which is the only way the
+ * difference is observable.
+ */
+import {
+  venueOffsetMinutesAt,
+  venueWallClockToMs,
+  venueCalendarDate,
+  venueDayMinutes,
+  venueNowOnDate,
+  venueParts,
+  venueClock,
+} from './venueTimeFrame';
+import { describe, expect, it } from 'vitest';
+
+const NEW_YORK = 'America/New_York';
+const LOS_ANGELES = 'America/Los_Angeles';
+const KOLKATA = 'Asia/Kolkata'; // +05:30 — catches half-hour offsets
+
+const AUG_24 = '2026-08-24';
+const AUG_25 = '2026-08-25';
+const AUG_25_0900Z = '2026-08-25T09:00:00Z';
+const UNPARSEABLE = 'not-a-date';
+
+describe('venueCalendarDate — the day an instant falls on AT THE VENUE', () => {
+  it('does not roll the day over at 8pm in Florida, which is the bug that shipped (#1352)', () => {
+    // 2026-08-25T00:30:00Z is 20:30 on the 24th in New York.
+    expect(venueCalendarDate('2026-08-25T00:30:00Z', NEW_YORK)).toBe(AUG_24);
+    // The UTC reading — `toISOString().slice(0, 10)` — would say the 25th.
+    expect(new Date('2026-08-25T00:30:00Z').toISOString().slice(0, 10)).toBe('2026-08-25');
+  });
+
+  it('rolls the day forward east of UTC, where the same instant is already tomorrow', () => {
+    // 18:45Z on the 24th is 00:15 on the 25th in Kolkata.
+    expect(venueCalendarDate('2026-08-24T18:45:00Z', KOLKATA)).toBe(AUG_25);
+  });
+
+  it('gives different days for one instant in two zones — the whole point', () => {
+    const instant = '2026-08-25T03:00:00Z';
+    expect(venueCalendarDate(instant, NEW_YORK)).toBe(AUG_24);
+    expect(venueCalendarDate(instant, KOLKATA)).toBe(AUG_25);
+  });
+
+  it('returns empty for an unparseable value rather than "NaN-NaN-NaN"', () => {
+    expect(venueCalendarDate(UNPARSEABLE, NEW_YORK)).toBe('');
+  });
+});
+
+describe('venueClock / venueDayMinutes — an instant on the venue wall clock', () => {
+  it('reads a Florida event three hours apart from a Pacific one', () => {
+    const instant = '2026-08-25T19:00:00Z';
+    expect(venueClock(instant, NEW_YORK)).toBe('15:00');
+    expect(venueClock(instant, LOS_ANGELES)).toBe('12:00');
+  });
+
+  it('handles a half-hour zone, which a whole-hour offset model gets wrong', () => {
+    expect(venueClock(AUG_25_0900Z, KOLKATA)).toBe('14:30');
+    expect(venueDayMinutes(AUG_25_0900Z, KOLKATA)).toBe(14 * 60 + 30);
+  });
+
+  it('is undefined, not zero, for an unparseable instant', () => {
+    expect(venueDayMinutes(UNPARSEABLE, NEW_YORK)).toBeUndefined();
+  });
+});
+
+describe('venueOffsetMinutesAt — the offset is a function of WHEN you ask', () => {
+  /**
+   * The reason the whole module resolves per instant rather than storing a
+   * `utcOffsetMinutes`. A fixed offset is the offset at ONE moment, so a
+   * tournament spanning a DST change converts an hour wrong on the far side.
+   */
+  it('differs across the 2026 US spring-forward', () => {
+    const before = venueOffsetMinutesAt('2026-03-08T05:00:00Z', NEW_YORK); // 00:00 EST
+    const after = venueOffsetMinutesAt('2026-03-08T12:00:00Z', NEW_YORK); // 08:00 EDT
+    expect(before).toBe(-300);
+    expect(after).toBe(-240);
+  });
+
+  it('measures 22:00 → 08:00 across that change as nine hours, not ten', () => {
+    const start = venueWallClockToMs('2026-03-07', '22:00', NEW_YORK) as number;
+    const end = venueWallClockToMs('2026-03-08', '08:00', NEW_YORK) as number;
+    expect((end - start) / 3_600_000).toBe(9);
+  });
+
+  it('resolves a half-hour offset exactly', () => {
+    expect(venueOffsetMinutesAt(AUG_25_0900Z, KOLKATA)).toBe(330);
+  });
+});
+
+describe('venueWallClockToMs — a venue wall clock back to an absolute instant', () => {
+  it('round-trips against venueClock / venueCalendarDate', () => {
+    for (const zone of [NEW_YORK, LOS_ANGELES, KOLKATA]) {
+      const ms = venueWallClockToMs(AUG_25, '15:20', zone) as number;
+      expect(venueCalendarDate(ms, zone)).toBe(AUG_25);
+      expect(venueClock(ms, zone)).toBe('15:20');
+    }
+  });
+
+  it('is the fix for Call Timing Variance: planned vs actual no longer drifts by the offset', () => {
+    // Planned 15:00 at the venue; called at 15:05 venue time.
+    const planned = venueWallClockToMs(AUG_25, '15:00', NEW_YORK) as number;
+    const called = Date.parse('2026-08-25T19:05:00Z'); // 15:05 in New York
+    expect(Math.floor(called / 60000) - Math.floor(planned / 60000)).toBe(5);
+  });
+
+  it('is undefined for malformed input rather than a substituted "now"', () => {
+    expect(venueWallClockToMs(AUG_25, '99:99', NEW_YORK)).toBeUndefined();
+    expect(venueWallClockToMs(UNPARSEABLE, '15:00', NEW_YORK)).toBeUndefined();
+    expect(venueWallClockToMs(undefined, '15:00', NEW_YORK)).toBeUndefined();
+  });
+});
+
+describe('venueNowOnDate — "now" projected onto a viewed date, as a NAIVE Date', () => {
+  /**
+   * Naivety is load-bearing: this gets compared against court-block bounds,
+   * which are zone-less `YYYY-MM-DDTHH:MM:SS` strings parsed the same way. The
+   * browser's zone cancels on both sides; only the time-of-day has to be right.
+   */
+  it('carries the viewed date and the VENUE time-of-day', () => {
+    const projected = venueNowOnDate('2026-08-20', KOLKATA);
+    const nowParts = venueParts(new Date(), KOLKATA);
+    expect(projected.getFullYear()).toBe(2026);
+    expect(projected.getMonth()).toBe(7);
+    expect(projected.getDate()).toBe(20);
+    expect(projected.getHours()).toBe(nowParts?.hour);
+    expect(projected.getMinutes()).toBe(nowParts?.minute);
+  });
+
+  it('compares correctly against a naive court-block bound in the same frame', () => {
+    const projected = venueNowOnDate('2026-08-20', KOLKATA);
+    const blockStart = new Date('2026-08-20T00:00:00');
+    const blockEnd = new Date('2026-08-21T00:00:00');
+    expect(projected >= blockStart).toBe(true);
+    expect(projected < blockEnd).toBe(true);
+  });
+});

--- a/src/functions/venueTimeFrame.test.ts
+++ b/src/functions/venueTimeFrame.test.ts
@@ -9,14 +9,18 @@
  * difference is observable.
  */
 import {
+  resolveVenueFrame,
   venueOffsetMinutesAt,
   venueWallClockToMs,
   venueCalendarDate,
   venueDayMinutes,
   venueNowOnDate,
+  venueTimeZone,
   venueParts,
   venueClock,
 } from './venueTimeFrame';
+import { tournamentEngine } from 'services/factory/engine';
+import { mocksEngine } from 'tods-competition-factory';
 import { describe, expect, it } from 'vitest';
 
 const NEW_YORK = 'America/New_York';
@@ -138,5 +142,47 @@ describe('venueNowOnDate — "now" projected onto a viewed date, as a NAIVE Date
     const blockEnd = new Date('2026-08-21T00:00:00');
     expect(projected >= blockStart).toBe(true);
     expect(projected < blockEnd).toBe(true);
+  });
+});
+
+describe('resolveVenueFrame — which zone, and whether the page may say it is sure', () => {
+  /**
+   * The one function no site may re-implement. Everything else in this module
+   * takes a zone; this decides WHICH zone, and the `source` it returns is what
+   * the schedule's notice branches on. A regression here is silent by
+   * construction — the times still render, they are just framed wrong — so it is
+   * worth the engine setup a value test needs.
+   */
+  const seed = (localTimeZone?: string) => {
+    mocksEngine.generateTournamentRecord({ drawProfiles: [{ drawSize: 2 }], setState: true });
+    if (localTimeZone) tournamentEngine.setTournamentLocalTimeZone({ localTimeZone });
+  };
+
+  it("takes the tournament's zone when the record carries one, and says so", () => {
+    seed(KOLKATA);
+    expect(resolveVenueFrame()).toEqual({ timeZone: KOLKATA, source: 'tournament' });
+    expect(venueTimeZone()).toBe(KOLKATA);
+  });
+
+  it('falls back to the device zone when the record carries none — and reports the fallback', () => {
+    seed();
+    const frame = resolveVenueFrame();
+    // The suite runs TZ=UTC, so the device zone is UTC here; `source` is the
+    // assertion that matters, because it is what puts the notice on screen.
+    expect(frame.source).toBe('browser');
+    expect(frame.timeZone).toBeTruthy();
+  });
+
+  it('re-reads the record, so setting a zone re-frames the page without a reload', () => {
+    seed();
+    expect(resolveVenueFrame().source).toBe('browser');
+    tournamentEngine.setTournamentLocalTimeZone({ localTimeZone: NEW_YORK });
+    expect(resolveVenueFrame()).toEqual({ timeZone: NEW_YORK, source: 'tournament' });
+  });
+
+  it('always yields a usable zone, so no caller has to handle an absent one', () => {
+    seed();
+    expect(() => venueClock(new Date(), venueTimeZone())).not.toThrow();
+    expect(venueCalendarDate('2026-08-25T12:00:00Z', venueTimeZone())).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/src/functions/venueTimeFrame.ts
+++ b/src/functions/venueTimeFrame.ts
@@ -57,6 +57,42 @@
  * operator's zone, because "when I saw it" is the question those answer. That
  * line is deliberate; it is not an oversight in the sites this module does not
  * touch.
+ *
+ * ── This file is TMX's Temporal migration seam ──
+ *
+ * The factory is moving to the TC39 Temporal API
+ * (`Mentat/planning/FACTORY_TEMPORAL_MIGRATION.md`), and its Phase 1 —
+ * `tools/timeZone.ts` on `Temporal.ZonedDateTime` — is this same problem solved
+ * one repo over. TMX should follow, and the point of concentrating every
+ * conversion here is that following is a rewrite of ONE file rather than a
+ * sweep of the sixteen call sites this replaced.
+ *
+ * Three things were chosen with that migration in mind:
+ *
+ *   - **Signatures take and return strings, numbers and `Date`.** The factory's
+ *     plan locks the wire format as ISO strings and changes only internal
+ *     arithmetic, so nothing here has to change shape when the internals do.
+ *     Callers never see a `Date` this module constructed except `venueNowOnDate`.
+ *   - **Everything resolves per instant.** That is `ZonedDateTime`'s model
+ *     already, so the migration is a simplification and not a redesign.
+ *     `venueParts` becomes `instant.toZonedDateTimeISO(timeZone)` field reads;
+ *     `venueOffsetMinutesAt` becomes `zdt.offsetNanoseconds`.
+ *   - **`venueWallClockToMs` is the piece that gets genuinely better.** Its
+ *     two-pass offset guess exists only because native `Date` cannot resolve a
+ *     wall clock in a named zone; `Temporal.PlainDateTime.from(…).toZonedDateTime(tz)`
+ *     does it in one step, and turns the ambiguity this settles silently
+ *     (spring-forward's missing hour, fall-back's repeated one) into an explicit
+ *     `disambiguation` choice. Whoever migrates should read the two passes as a
+ *     workaround to delete, not a behaviour to preserve.
+ *
+ * The wart to fix when it lands: `venueNowOnDate` returns a **naive `Date`**
+ * because that is the only shape native `Date` offers for "a wall clock with no
+ * zone", and its callers compare it against other naive Dates. That is exactly
+ * `Temporal.PlainDateTime`, typed — at which point the comparison stops being a
+ * convention this file has to explain and becomes something the compiler knows.
+ *
+ * TMX is the ecosystem's iOS PWA and Safari has no native Temporal, so TMX will
+ * need `@js-temporal/polyfill` imported at app boot before anything here runs.
  */
 import { isValidTimeZone } from 'functions/getSupportedTimeZones';
 import { tournamentEngine } from 'services/factory/engine';

--- a/src/functions/venueTimeFrame.ts
+++ b/src/functions/venueTimeFrame.ts
@@ -1,0 +1,301 @@
+/**
+ * The **venue time frame** — TMX's single answer to "what time is it at the
+ * tournament?"
+ *
+ * ── Why this module exists ──
+ *
+ * A stored instant (`calledAt`, `scoredTime`, an embargo stamp) is a point on
+ * the world's timeline. Turning it into a clock time or a calendar day requires
+ * a zone, and TMX used to answer that question independently at ~a dozen sites,
+ * every one of them with the **browser's** zone. A director running a Florida
+ * event from a Pacific-set laptop read rest, call times and order-of-play timing
+ * three hours out — silently, in numbers that stayed plausible, which is what
+ * made it expensive. Two independent sightings on one day (TMX #1355, #1356)
+ * made it a bug class rather than a bug.
+ *
+ * The decision is recorded in `Mentat/planning/DECISION_VENUE_TIME_FRAME.md`.
+ * The short form:
+ *
+ *   **Every conversion of a stored instant to a clock time or a calendar day
+ *   goes through this module, in the tournament's zone, resolved per instant.**
+ *
+ * ── Per instant, not a stored offset ──
+ *
+ * A bare `utcOffsetMinutes` is the offset at ONE moment. A tournament spanning a
+ * DST change converts an hour wrong on the far side — silently, in figures
+ * measured in minutes. Measured across the 2026 US spring-forward, 22:00 → 08:00
+ * is nine hours, not ten. So every function here resolves the offset **at the
+ * instant being converted**, via `Intl.DateTimeFormat` with an IANA zone. This
+ * is the approach `factory/src/tools/zonedTime.ts` takes; it is internal to the
+ * factory and not exported from `assemblies`, so TMX ports it rather than
+ * importing it.
+ *
+ * ── What is NOT an instant ──
+ *
+ * The distinction this module lives or dies by. Two different things in TMX look
+ * alike and must never be run through the same conversion:
+ *
+ *   - **Instants** — `calledAt`, `scoredTime`, `updatedAt`, `createdAt`: full
+ *     UTC ISO stamps. These need a zone. That is what this module is for.
+ *   - **Naive wall clocks** — `scheduledTime`, `startTime`, `endTime`, court
+ *     block `start`/`end`, and any `new Date('YYYY-MM-DDTHH:MM:SS')` with no
+ *     trailing `Z`. These are ALREADY in venue wall-clock terms and carry no
+ *     zone. Converting one is the bug, not the fix: read them with the raw
+ *     `getHours()` accessors, which recover exactly the digits that were
+ *     written. Comparisons between two naive values are zone-independent
+ *     because the browser's zone cancels on both sides.
+ *
+ * Treating a naive wall clock as an instant — or the reverse — produces a figure
+ * wrong by the UTC offset, which is worse than showing nothing.
+ *
+ * ── Which instants are venue-framed ──
+ *
+ * An instant describing something that happened **at the venue**, or that a
+ * venue clock is measured against, is venue-framed: calls, scores, sign-ins,
+ * embargoes, publish stamps. An instant describing the **operator's own
+ * session** — a chat message, a local draft's `resolvedAt` — stays in the
+ * operator's zone, because "when I saw it" is the question those answer. That
+ * line is deliberate; it is not an oversight in the sites this module does not
+ * touch.
+ */
+import { isValidTimeZone } from 'functions/getSupportedTimeZones';
+import { tournamentEngine } from 'services/factory/engine';
+
+export type VenueFrameSource = 'tournament' | 'browser';
+
+export type VenueFrame = {
+  /** IANA identifier, e.g. `America/New_York`. Always a usable zone. */
+  timeZone: string;
+  /**
+   * `'tournament'` when the record carries a zone; `'browser'` when it does
+   * not and the runtime's own zone is standing in. Callers that render times
+   * to an operator should surface the `'browser'` case — see
+   * `renderVenueFrameNotice`.
+   */
+  source: VenueFrameSource;
+};
+
+export type VenueParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * `Intl.DateTimeFormat` construction is expensive enough to matter on the Now
+ * strip, which re-renders every 30s across every court. One formatter per zone,
+ * built once.
+ */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function partsFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = formatterCache.get(timeZone);
+  if (cached) return cached;
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  formatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+/** The runtime's own IANA zone, or `'UTC'` when the platform will not name one. */
+export function browserTimeZone(): string {
+  try {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return typeof detected === 'string' && detected.length ? detected : 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+/**
+ * The frame every instant→clock conversion in TMX should be read against.
+ *
+ * `tournamentRecord.localTimeZone` is the authoritative venue zone: it is
+ * operator-set through the Edit Dates modal, validated against a supported-zones
+ * list, and never silently auto-applied (`getDetectedTimeZone()` is a nudge the
+ * TD must confirm).
+ *
+ * When the record carries none, the browser's zone stands in — and the caller is
+ * expected to say so on screen. Refusing to render times instead would break the
+ * running desk for every zone-less tournament, which is most of them today; a
+ * *silent* browser fallback would reproduce, through a different door, exactly
+ * the wrongness this module exists to eliminate. So the fallback stays and
+ * announces itself: the one case where the page can be wrong is the one case
+ * where it says so.
+ *
+ * Cheap enough to call per site. What must never be re-implemented per site is
+ * the **fallback rule** — that is the whole point of there being one function.
+ */
+export function resolveVenueFrame(): VenueFrame {
+  let localTimeZone: string | undefined;
+  try {
+    localTimeZone = tournamentEngine.q.tournament()?.localTimeZone;
+  } catch {
+    localTimeZone = undefined;
+  }
+  if (isValidTimeZone(localTimeZone)) return { timeZone: localTimeZone, source: 'tournament' };
+  return { timeZone: browserTimeZone(), source: 'browser' };
+}
+
+/** Convenience for the common case: the zone alone. */
+export function venueTimeZone(): string {
+  return resolveVenueFrame().timeZone;
+}
+
+function toDate(value?: string | number | Date): Date | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function resolveZone(timeZone?: string): string {
+  return isValidTimeZone(timeZone) ? timeZone : browserTimeZone();
+}
+
+/**
+ * An instant, broken into its calendar/clock fields **in the given zone**.
+ *
+ * Returns `undefined` for unparseable input rather than a substituted default —
+ * a wrong time is worse than a missing one everywhere this is used.
+ */
+export function venueParts(value?: string | number | Date, timeZone?: string): VenueParts | undefined {
+  const date = toDate(value);
+  if (!date) return undefined;
+
+  const parts = partsFormatter(resolveZone(timeZone)).formatToParts(date);
+  const grab = (type: string): string => parts.find((part) => part.type === type)?.value ?? '';
+
+  const year = Number(grab('year'));
+  const month = Number(grab('month'));
+  const day = Number(grab('day'));
+  // `hour` comes back as '24' rather than '00' at midnight in some engines
+  // (an older Node / Safari quirk); normalise before it becomes an off-by-a-day.
+  const rawHour = grab('hour');
+  const hour = rawHour === '24' ? 0 : Number(rawHour);
+  const minute = Number(grab('minute'));
+  const second = Number(grab('second'));
+
+  if ([year, month, day, hour, minute, second].some((n) => !Number.isFinite(n))) return undefined;
+  return { year, month, day, hour, minute, second };
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * The calendar day an instant falls on **at the venue**, as `YYYY-MM-DD`.
+ *
+ * Never `toISOString().slice(0, 10)`: that reports the UTC day, so west of
+ * Greenwich it rolls over while the tournament is still playing — at 8pm in
+ * Florida it already says tomorrow. Shipping that once (#1352, fixed in #1355)
+ * made every official read "available" every evening.
+ *
+ * Defaults to now, which is the "what day is it?" every schedule surface asks.
+ */
+export function venueCalendarDate(value?: string | number | Date, timeZone?: string): string {
+  const parts = venueParts(value ?? new Date(), timeZone);
+  if (!parts) return '';
+  return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
+}
+
+/** An instant as a `HH:MM` venue wall clock. Defaults to now. Empty string when unparseable. */
+export function venueClock(value?: string | number | Date, timeZone?: string): string {
+  const parts = venueParts(value ?? new Date(), timeZone);
+  if (!parts) return '';
+  return `${pad2(parts.hour)}:${pad2(parts.minute)}`;
+}
+
+/** An instant as minutes from venue midnight (`14:20` → `860`). Defaults to now. */
+export function venueDayMinutes(value?: string | number | Date, timeZone?: string): number | undefined {
+  const parts = venueParts(value ?? new Date(), timeZone);
+  if (!parts) return undefined;
+  return parts.hour * 60 + parts.minute;
+}
+
+/**
+ * The zone's UTC offset **at a particular instant**, in minutes east of UTC.
+ *
+ * The whole reason this takes an instant rather than returning a constant: a
+ * zone's offset is a function of when you ask.
+ */
+export function venueOffsetMinutesAt(value: string | number | Date, timeZone?: string): number | undefined {
+  const date = toDate(value);
+  const parts = venueParts(date, timeZone);
+  if (!date || !parts) return undefined;
+  const asIfUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  return Math.round((asIfUtc - date.getTime()) / MS_PER_MINUTE);
+}
+
+/**
+ * The inverse: a venue wall clock (`'2026-08-25'`, `'14:20'`) → absolute UTC ms.
+ *
+ * Needed wherever a planned time has to be compared with an actual instant —
+ * the Call Timing Variance report is the case that forced it, where "scheduled
+ * 15:00" and "called at <ISO>" must be subtracted.
+ *
+ * Two passes, because resolving the offset needs an instant and finding the
+ * instant needs the offset: guess with the offset at the naive-as-UTC moment,
+ * then re-resolve at the guess. That converges everywhere except the one hour
+ * that does not exist (spring-forward) and the one that happens twice
+ * (fall-back), where it settles on a consistent answer rather than a correct
+ * one — there isn't a correct one to settle on.
+ */
+export function venueWallClockToMs(date?: string, clock?: string, timeZone?: string): number | undefined {
+  if (!date || !clock) return undefined;
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(date.trim());
+  const clockMatch = /^(\d{1,2}):(\d{2})(?::(\d{2}))?/.exec(clock.trim());
+  if (!dateMatch || !clockMatch) return undefined;
+
+  const year = Number(dateMatch[1]);
+  const month = Number(dateMatch[2]);
+  const day = Number(dateMatch[3]);
+  const hour = Number(clockMatch[1]);
+  const minute = Number(clockMatch[2]);
+  const second = Number(clockMatch[3] ?? 0);
+  if (hour > 23 || minute > 59 || second > 59) return undefined;
+
+  const zone = resolveZone(timeZone);
+  const naiveAsUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+  const firstOffset = venueOffsetMinutesAt(naiveAsUtc, zone);
+  if (firstOffset === undefined) return undefined;
+  const guess = naiveAsUtc - firstOffset * MS_PER_MINUTE;
+  const secondOffset = venueOffsetMinutesAt(guess, zone);
+  if (secondOffset === undefined) return undefined;
+  return naiveAsUtc - secondOffset * MS_PER_MINUTE;
+}
+
+/**
+ * "Now", projected onto the venue wall clock of `stripDate`, as a **naive**
+ * Date — i.e. one whose raw `getHours()` accessors read back the venue clock.
+ *
+ * That naivety is deliberate and load-bearing. The values this gets compared
+ * against (court block `start`/`end`) are themselves naive `YYYY-MM-DDTHH:MM:SS`
+ * strings in venue wall-clock terms, parsed as browser-local. Comparing two
+ * naive Dates cancels the browser's zone on both sides; the only thing that has
+ * to be right is the **time-of-day**, and that is what this fixes.
+ *
+ * Projecting today's time-of-day onto another date is what lets the live-strip
+ * warnings work when the operator is viewing a non-today date — which is not an
+ * exotic case: the schedule opens on a tournament's last date once its dates are
+ * past, so anyone running a past-dated tournament in real time is in it
+ * permanently.
+ */
+export function venueNowOnDate(stripDate: string, timeZone?: string): Date {
+  const parts = venueParts(new Date(), timeZone);
+  if (!parts) return new Date(`${stripDate}T00:00:00`);
+  return new Date(`${stripDate}T${pad2(parts.hour)}:${pad2(parts.minute)}:${pad2(parts.second)}`);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1041,7 +1041,11 @@
     "byeScheduledTitle": "Match is scheduled",
     "byeScheduledBody": "This match already has scheduling information. Assigning a BYE will leave the court slot occupied unless you remove it.",
     "byeKeepScheduling": "Keep scheduling",
-    "byeRemoveScheduling": "Remove scheduling"
+    "byeRemoveScheduling": "Remove scheduling",
+    "venueFrame": {
+      "notice": "Times in {{timeZone}} — venue zone not set",
+      "noticeTitle": "This tournament has no time zone set, so times are shown in this device\u2019s zone ({{timeZone}}). Set the venue\u2019s time zone so every operator reads the same clock."
+    }
   },
   "penalties": {
     "fail2signout": "Failed to Sign Out",

--- a/src/pages/tournament/maybeNudgeActiveDates.ts
+++ b/src/pages/tournament/maybeNudgeActiveDates.ts
@@ -1,3 +1,4 @@
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { openEditDatesModal } from './tabs/overviewTab/editDatesModal';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
@@ -13,9 +14,9 @@ const nudgedTournamentIds = new Set<string>();
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/** Today at the venue — compared against tournament dates, which are venue calendar days. */
 function todayLocalIso(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return venueCalendarDate();
 }
 
 function* dateRangeInclusive(startIso: string, endIso: string): Generator<string> {

--- a/src/pages/tournament/maybeNudgeActiveDates.ts
+++ b/src/pages/tournament/maybeNudgeActiveDates.ts
@@ -1,5 +1,5 @@
-import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { openEditDatesModal } from './tabs/overviewTab/editDatesModal';
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
 import { t } from 'i18n';

--- a/src/pages/tournament/tabs/officialsTab/officialsTab.ts
+++ b/src/pages/tournament/tabs/officialsTab/officialsTab.ts
@@ -17,7 +17,7 @@ import { getCachedAllMatchUps, invalidateMatchUpCaches } from 'pages/tournament/
 import { contactFormatter } from 'components/tables/common/formatters/contactFormatter';
 import { controlBar } from 'courthive-components';
 import { callSheet } from 'components/modals/callSheet';
-import { buildOfficialsBoard, localCalendarDate, type OfficialRow } from 'services/officiating/officialsBoard';
+import { buildOfficialsBoard, venueCalendarDay, type OfficialRow } from 'services/officiating/officialsBoard';
 import { onMutationApplied } from 'services/mutation/mutationObservers';
 import { tournamentEngine } from 'tods-competition-factory';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -39,7 +39,7 @@ let unsubscribe: (() => void) | null = null;
  * claiming it was "the tournament's own frame" was simply wrong.
  */
 function viewedDate(): string {
-  return localCalendarDate();
+  return venueCalendarDay();
 }
 
 function rows(): OfficialRow[] {

--- a/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
+++ b/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
@@ -15,7 +15,7 @@
  * no jsdom and a decision made here would get no coverage.
  */
 
-import { stillSignedInOnDate, localCalendarDate } from 'services/presence/signInPresence';
+import { stillSignedInOnDate, venueCalendarDay } from 'services/presence/signInPresence';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tournamentEngine } from 'services/factory/engine';
 import { participantConstants } from 'tods-competition-factory';
@@ -35,7 +35,7 @@ const { SIGNED_OUT } = participantConstants;
  * which is the *latest* value and therefore true for anybody who ever signed in. The date-scoped read
  * is the whole reason (c) exists.
  */
-export function participantsToCloseOut(date = localCalendarDate()): string[] {
+export function participantsToCloseOut(date = venueCalendarDay()): string[] {
   const { participants } = tournamentEngine.getParticipants({}) ?? {};
   return stillSignedInOnDate(participants, date);
 }

--- a/src/pages/tournament/tabs/publishingTab/embargoModal.ts
+++ b/src/pages/tournament/tabs/publishingTab/embargoModal.ts
@@ -4,9 +4,9 @@
  * and attachTimePicker for time — consistent with patterns used elsewhere in TMX.
  * Local date/time is converted to GMT for storage.
  */
-import { venueParts, venueWallClockToMs } from 'functions/venueTimeFrame';
 import { attachTimePicker } from 'pages/tournament/tabs/venuesTab/venueTimeHelpers';
 import { openModal, closeModal } from 'components/modals/baseModal/baseModal';
+import { venueParts, venueWallClockToMs } from 'functions/venueTimeFrame';
 import { renderForm, validators } from 'courthive-components';
 import { toDisplayTime } from 'components/forms/venue';
 import { Datepicker } from 'vanillajs-datepicker';

--- a/src/pages/tournament/tabs/publishingTab/embargoModal.ts
+++ b/src/pages/tournament/tabs/publishingTab/embargoModal.ts
@@ -4,6 +4,7 @@
  * and attachTimePicker for time — consistent with patterns used elsewhere in TMX.
  * Local date/time is converted to GMT for storage.
  */
+import { venueParts, venueWallClockToMs } from 'functions/venueTimeFrame';
 import { attachTimePicker } from 'pages/tournament/tabs/venuesTab/venueTimeHelpers';
 import { openModal, closeModal } from 'components/modals/baseModal/baseModal';
 import { renderForm, validators } from 'courthive-components';
@@ -21,26 +22,34 @@ type EmbargoModalParams = {
   onClear?: () => void;
 };
 
+/**
+ * An embargo instant → the date and time fields the modal edits, on the
+ * **venue's** clock.
+ *
+ * An embargo is a tournament decision ("hold results until 18:00"), so 18:00
+ * means 18:00 at the venue. Read on the operator's clock, a director travelling
+ * would set an embargo that lifts at the wrong hour on site — and, because the
+ * field round-trips, would silently rewrite the existing one just by opening
+ * the modal. This and `venuePartsToGMT` must always move together for that
+ * reason: they are one conversion in two directions.
+ */
 function embargoToLocalParts(isoString?: string): { date: string; time: string } {
   if (!isoString) return { date: '', time: '' };
-  const d = new Date(isoString);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
+  const parts = venueParts(isoString);
+  if (!parts) return { date: '', time: '' };
+  const pad = (n: number) => String(n).padStart(2, '0');
   return {
-    date: `${year}-${month}-${day}`,
-    time: `${hours}:${minutes}`,
+    date: `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`,
+    time: `${pad(parts.hour)}:${pad(parts.minute)}`,
   };
 }
 
-function localPartsToGMT(date: string, time12h: string): string {
+/** The inverse of `embargoToLocalParts` — a venue wall clock back to a UTC instant. */
+function venuePartsToGMT(date: string, time12h: string): string {
   const militaryTime = tools.dateTime.convertTime(time12h, true) || time12h;
-  const [hours, minutes] = (militaryTime || '12:00').split(':').map(Number);
-  const d = new Date(`${date}T00:00:00`);
-  d.setHours(hours || 0, minutes || 0, 0, 0);
-  return d.toISOString();
+  const ms = venueWallClockToMs(date, militaryTime || '12:00');
+  if (ms === undefined) return new Date().toISOString();
+  return new Date(ms).toISOString();
 }
 
 export function openEmbargoModal({ title, currentEmbargo, onSet, onClear }: EmbargoModalParams): void {
@@ -94,7 +103,7 @@ export function openEmbargoModal({ title, currentEmbargo, onSet, onClear }: Emba
     const embargoDate = inputs?.embargoDate?.value;
     const embargoTime = inputs?.embargoTime?.value;
     if (embargoDate && embargoTime) {
-      const isoString = localPartsToGMT(embargoDate, embargoTime);
+      const isoString = venuePartsToGMT(embargoDate, embargoTime);
       closeModal();
       onSet(isoString);
     }

--- a/src/pages/tournament/tabs/publishingTab/embargoSummary.ts
+++ b/src/pages/tournament/tabs/publishingTab/embargoSummary.ts
@@ -2,6 +2,7 @@
  * Active embargoes summary section.
  * Displays all active embargoes sorted by expiry with remove buttons.
  */
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { publishingGovernor } from 'tods-competition-factory';
 import { renderPublishingTab } from './renderPublishingTab';
@@ -15,6 +16,8 @@ import { PUBLISH_EVENT, PUBLISH_ORDER_OF_PLAY, PUBLISH_PARTICIPANTS } from 'cons
 function formatEmbargoTime(isoString: string): { display: string; countdown: string } {
   const date = new Date(isoString);
   const display = date.toLocaleString(undefined, {
+    // The embargo is a tournament decision, so it displays on the venue's clock.
+    timeZone: venueTimeZone(),
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/src/pages/tournament/tabs/publishingTab/embargoSummary.ts
+++ b/src/pages/tournament/tabs/publishingTab/embargoSummary.ts
@@ -2,11 +2,11 @@
  * Active embargoes summary section.
  * Displays all active embargoes sorted by expiry with remove buttons.
  */
-import { venueTimeZone } from 'functions/venueTimeFrame';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { publishingGovernor } from 'tods-competition-factory';
 import { renderPublishingTab } from './renderPublishingTab';
 import { tournamentEngine } from 'services/factory/engine';
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { getActiveEmbargoes } from './publishingData';
 import { t } from 'i18n';
 

--- a/src/pages/tournament/tabs/publishingTab/publishingTable.ts
+++ b/src/pages/tournament/tabs/publishingTab/publishingTable.ts
@@ -3,7 +3,6 @@
  * Shows hierarchical event > draw rows with publish toggles, embargo pickers,
  * clickable names (navigate to draw), and public URL links.
  */
-import { venueTimeZone } from 'functions/venueTimeFrame';
 import { getPublicEventUrl, getPublicDrawUrl } from 'services/publishing/publicUrl';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { mutationRequest } from 'services/mutation/mutationRequest';
@@ -12,6 +11,7 @@ import { TabulatorFull as Tabulator } from 'tabulator-tables';
 import { renderPublishingTab } from './renderPublishingTab';
 import { tournamentEngine } from 'services/factory/engine';
 import { getPublishingTableData } from './publishingData';
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { openEmbargoModal } from './embargoModal';
 import { t } from 'i18n';
 

--- a/src/pages/tournament/tabs/publishingTab/publishingTable.ts
+++ b/src/pages/tournament/tabs/publishingTab/publishingTable.ts
@@ -3,6 +3,7 @@
  * Shows hierarchical event > draw rows with publish toggles, embargo pickers,
  * clickable names (navigate to draw), and public URL links.
  */
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { getPublicEventUrl, getPublicDrawUrl } from 'services/publishing/publicUrl';
 import { navigateToEvent } from 'components/tables/common/navigateToEvent';
 import { mutationRequest } from 'services/mutation/mutationRequest';
@@ -84,6 +85,8 @@ function publicUrlFormatter(cell: any): string {
 
 function formatLocalEmbargo(date: Date): string {
   return date.toLocaleString(undefined, {
+    // The embargo is a tournament decision, so it displays on the venue's clock.
+    timeZone: venueTimeZone(),
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
+++ b/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
@@ -2,7 +2,6 @@
  * Tournament-level publishing controls: Participants + Order of Play.
  * Includes publish toggles, embargo buttons (open modal), and per-date OOP selection.
  */
-import { venueTimeZone } from 'functions/venueTimeFrame';
 import { getTournamentPublishData, getPublishingTableData } from './publishingData';
 import { renderPublishingTab, isAnythingPublished } from './renderPublishingTab';
 import { buildOrderOfPlayDateToggleMethods } from 'services/publishing/orderOfPlayPublish';
@@ -12,6 +11,7 @@ import { eventConstants, fixtures } from 'tods-competition-factory';
 import { barButton, renderForm } from 'courthive-components';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { providerConfig } from 'config/providerConfig';
 import { openEmbargoModal } from './embargoModal';
 import dayjs from 'dayjs';

--- a/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
+++ b/src/pages/tournament/tabs/publishingTab/tournamentControls.ts
@@ -2,6 +2,7 @@
  * Tournament-level publishing controls: Participants + Order of Play.
  * Includes publish toggles, embargo buttons (open modal), and per-date OOP selection.
  */
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { getTournamentPublishData, getPublishingTableData } from './publishingData';
 import { renderPublishingTab, isAnythingPublished } from './renderPublishingTab';
 import { buildOrderOfPlayDateToggleMethods } from 'services/publishing/orderOfPlayPublish';
@@ -77,6 +78,8 @@ function formatEmbargoDisplay(isoString?: string): string {
   const d = new Date(isoString);
   if (d.getTime() <= Date.now()) return t('publishing.expired');
   return d.toLocaleString(undefined, {
+    // The embargo is a tournament decision, so it displays on the venue's clock.
+    timeZone: venueTimeZone(),
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
+++ b/src/pages/tournament/tabs/reportsTab/renderReportsTab.ts
@@ -1,3 +1,4 @@
+import { resolveVenueFrame, venueOffsetMinutesAt, venueParts, venueWallClockToMs } from 'functions/venueTimeFrame';
 import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { downloadJSON, downloadText } from 'services/export/download';
 import { openStructureAuditModal } from './structureAudit';
@@ -128,8 +129,13 @@ export function renderReportsTab(options: { reportId?: string } = {}): void {
 /**
  * Parameters every factory report is generated with.
  *
- * Both frames are sent. `timeZone` is the IANA identifier the runtime resolves
- * to, and the factory prefers it: it yields the offset **per instant**, so a
+ * Both frames are sent. `timeZone` is the IANA identifier of the **venue** —
+ * `tournamentRecord.localTimeZone`, with the browser's zone standing in only
+ * when the record carries none (see `functions/venueTimeFrame`). It used to be
+ * the browser's unconditionally, which is right machinery fed the wrong zone:
+ * a director running a Florida event from a Pacific laptop read every call time
+ * and variance three hours out. The factory prefers `timeZone` because it
+ * yields the offset **per instant**, so a
  * tournament spanning a DST change converts correctly on both sides. A bare
  * `utcOffsetMinutes` is the offset *now* and would be an hour wrong on the far
  * side of the change — silently, in reports measured in minutes.
@@ -142,9 +148,13 @@ export function renderReportsTab(options: { reportId?: string } = {}): void {
  * had to localize its own timestamps client-side.
  */
 function reportParameters(): Record<string, any> {
+  const { timeZone } = resolveVenueFrame();
   return {
-    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    utcOffsetMinutes: -new Date().getTimezoneOffset(),
+    timeZone,
+    // The offset of the VENUE zone right now, not the browser's. Only a
+    // fallback: any wrapper that reads it instead of `timeZone` gets an offset
+    // fixed at this moment, which is why `timeZone` is preferred above.
+    utcOffsetMinutes: venueOffsetMinutesAt(new Date(), timeZone) ?? -new Date().getTimezoneOffset(),
   };
 }
 
@@ -167,34 +177,40 @@ async function selectReport(report: any): Promise<void> {
 
 /**
  * Recompute any UTC timestamps a report carries (rows with a `calledAtIso`
- * field, e.g. Call Timing Variance) into the operator's local wall-clock —
- * which on-site is the venue timezone. Doing this in the browser uses the
- * runtime's own tz (DST-correct) instead of a passed offset, so the displayed
- * clock and variance always match what the director actually saw.
+ * field, e.g. Call Timing Variance) into the **venue's** wall clock, resolved
+ * per instant so a tournament spanning a DST change reads correctly on both
+ * sides of it.
  *
  * `calledAt` becomes a bare HH:mm (date-prefixed only when the call landed on a
- * different calendar day than the scheduled date); `varianceMinutes` is the
- * signed difference between the actual call instant and the planned local time.
+ * different venue calendar day than the scheduled date); `varianceMinutes` is
+ * the signed difference between the actual call instant and the planned time.
+ *
+ * The variance is the reason `scheduledTime` cannot simply be `new Date`d. It is
+ * a bare venue wall clock; parsing it without a zone yields the operator's
+ * instant, and subtracting that from a real instant produced a variance wrong by
+ * the offset between laptop and venue — a "12 minutes late" that was actually on
+ * time. `venueWallClockToMs` resolves it against the venue zone instead.
  */
 function localizeReportTimes(rows: Record<string, any>[]): void {
   const pad = (n: number) => String(n).padStart(2, '0');
+  const { timeZone } = resolveVenueFrame();
   for (const row of rows ?? []) {
     if (!row.calledAtIso) continue;
-    const called = new Date(row.calledAtIso);
-    if (Number.isNaN(called.getTime())) continue;
+    const parts = venueParts(row.calledAtIso, timeZone);
+    if (!parts) continue;
 
-    const localDate = `${called.getFullYear()}-${pad(called.getMonth() + 1)}-${pad(called.getDate())}`;
-    const localTime = `${pad(called.getHours())}:${pad(called.getMinutes())}`;
+    const localDate = `${parts.year}-${pad(parts.month)}-${pad(parts.day)}`;
+    const localTime = `${pad(parts.hour)}:${pad(parts.minute)}`;
     row.calledAt = localDate === row.scheduledDate ? localTime : `${localDate} ${localTime}`;
 
     if (row.scheduledDate && row.scheduledTime) {
-      // No trailing "Z" ⇒ parsed as local wall-clock, matching the venue plan.
-      const planned = new Date(`${row.scheduledDate}T${row.scheduledTime}:00`);
-      if (!Number.isNaN(planned.getTime())) {
+      const calledMs = new Date(row.calledAtIso).getTime();
+      const plannedMs = venueWallClockToMs(row.scheduledDate, row.scheduledTime, timeZone);
+      if (plannedMs !== undefined && !Number.isNaN(calledMs)) {
         // Compare at whole-minute resolution so the number agrees with the HH:mm
         // shown: a call at 15:05:45 displays as 15:05, so 15:00 → 15:05 reads as
         // 5, not 6 (which a seconds-aware round would give).
-        row.varianceMinutes = Math.floor(called.getTime() / 60000) - Math.floor(planned.getTime() / 60000);
+        row.varianceMinutes = Math.floor(calledMs / 60000) - Math.floor(plannedMs / 60000);
       }
     }
   }

--- a/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
@@ -13,6 +13,7 @@ import tippy, { Instance as TippyInstance } from 'tippy.js';
 import { providerConfig } from 'config/providerConfig';
 import { t } from 'i18n';
 import { ScheduleIssue } from 'courthive-components';
+import { buildVenueFrameNotice } from 'components/notices/venueFrameNotice';
 import { buildStepper } from './stepperControl';
 import {
   MIN_COURT_WIDTH_FLOOR,
@@ -46,6 +47,12 @@ export interface GridActionBarParams {
   datePublished?: boolean;
   /** Toggle publication of the viewed date. When omitted, the publish pill never renders. */
   onTogglePublish?: () => void;
+  /**
+   * Called after the venue-frame notice's Edit Dates modal saves. Every clock on
+   * the page is resolved against the tournament's zone, so setting one has to
+   * re-render the grid rather than wait for the next refresh.
+   */
+  onVenueTimeZoneSet?: () => void;
 }
 
 export interface GridActionBar {
@@ -90,6 +97,12 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
   };
   bar.appendChild(issuesSlot);
   setIssues(issues);
+
+  // Venue-frame notice — leftmost, and only when the tournament carries no time
+  // zone so every clock on this page is being read off the operator's device.
+  // Null (not an empty box) once a zone is set, so no flex gap is reserved.
+  const venueNotice = buildVenueFrameNotice(params.onVenueTimeZoneSet);
+  if (venueNotice) bar.appendChild(venueNotice);
 
   bar.appendChild(buildMinCourtWidthStepper(minCourtWidth, onMinCourtWidthChange));
 

--- a/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
@@ -9,11 +9,11 @@
  * Matches the visual of the profile view's action bar so both views read
  * as a unified "panel + bottom strip" pair.
  */
+import { buildVenueFrameNotice } from 'components/notices/venueFrameNotice';
 import tippy, { Instance as TippyInstance } from 'tippy.js';
 import { providerConfig } from 'config/providerConfig';
 import { t } from 'i18n';
 import { ScheduleIssue } from 'courthive-components';
-import { buildVenueFrameNotice } from 'components/notices/venueFrameNotice';
 import { buildStepper } from './stepperControl';
 import {
   MIN_COURT_WIDTH_FLOOR,

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -35,6 +35,7 @@ import {
   openShiftCourtsModal,
   Schedule2NowContext,
 } from './schedule2CellActions';
+import { venueCalendarDate, venueClock, venueNowOnDate } from 'functions/venueTimeFrame';
 import { getActiveRegistrationNamesByCourtId } from './practiceRegistrationStrip';
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { printCourtMatchUpCards } from 'components/modals/printCourtCards';
@@ -580,6 +581,8 @@ export function renderGridView(
     onOpenTimingReport: openTimingVarianceReport,
     datePublished: isOrderOfPlayDatePublished(currentDate, getOrderOfPlayPublishState()),
     onTogglePublish: () => confirmTogglePublish(),
+    // Setting the venue zone re-frames every clock on the page, so redraw.
+    onVenueTimeZoneSet: refresh,
   });
   gridActionBar = actionBar;
 
@@ -2462,7 +2465,7 @@ function buildCurrentCourtBlocks(date: string): Record<string, ActiveStripCourtB
   // Use the strip's date as the time anchor so painted blocks on a non-today
   // date (e.g. tournament startDate) still surface as active when the
   // operator is working at the matching time-of-day.
-  const now = effectiveNowOnStripDate(date);
+  const now = venueNowOnDate(date);
   const courtBlocks: Record<string, ActiveStripCourtBlock> = {};
   const activeRegsByCourtId = getActiveRegistrationNamesByCourtId({
     tournamentRecord,
@@ -2495,6 +2498,15 @@ function buildCurrentCourtBlocks(date: string): Record<string, ActiveStripCourtB
   return courtBlocks;
 }
 
+/**
+ * `HH:MM` from a **naive** Date — one built from a zone-less
+ * `YYYY-MM-DDTHH:MM:SS` string (court block bounds, `venueNowOnDate`).
+ *
+ * Raw accessors are correct here and a venue-zone conversion would be the bug:
+ * these values were never instants, so their digits are already venue wall
+ * clock, and parsing-then-reading in the same browser zone hands them back
+ * unchanged. See the "What is NOT an instant" note in `venueTimeFrame.ts`.
+ */
 function formatHM(d: Date): string {
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
@@ -2568,10 +2580,15 @@ function buildActiveStripData(date: string): ActiveStripPanelData {
   return { grid: { columns }, courts, courtBlocks, gridTemplateColumns, minWidth };
 }
 
-/** Local calendar date (YYYY-MM-DD) for "today" — the only day the Now strip is live. */
+/**
+ * The **venue's** calendar date for "today" — the only day the Now strip is live.
+ *
+ * The venue's, not the operator's: a director west of the tournament would
+ * otherwise see the strip go live a day late (or early, east of it), and every
+ * surface that keys "today" has to give the same answer as this one.
+ */
 function todayIso(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return venueCalendarDate();
 }
 
 function refreshActiveStrip(date: string): void {
@@ -2600,8 +2617,9 @@ function runAutoCallPass(columns: ActiveStripPanelData['grid']['columns']): void
   const { tournamentRecord } = tournamentEngine.getTournament() || {};
   if (!isTournamentProviderMember({ loginState: getLoginState(), tournamentRecord })) return;
   const now = new Date();
-  const nowHHMM = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
-  const calls = computeAutoCalls(columns as any, nowHHMM);
+  // Compared against `scheduledTime`, which is a venue wall clock — so "now"
+  // has to be one too, or the desk auto-calls on the operator's clock.
+  const calls = computeAutoCalls(columns as any, venueClock(now));
   if (!calls.length) return;
 
   const calledAt = now.toISOString();
@@ -3060,8 +3078,9 @@ function buildStartOnDropMethods(matchUpId: string, drawId: string): any[] {
   const assigned = (matchUp.sides || []).filter((s: any) => s?.participantId || s?.participant?.participantId).length;
   if (assigned < 2) return [];
 
-  const now = new Date();
-  const startTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+  // `startTime` is stored as a bare venue wall clock, so it must be read off the
+  // venue's clock rather than the operator's.
+  const startTime = venueClock();
   return [
     {
       method: BULK_SCHEDULE_MATCHUPS,
@@ -3100,24 +3119,6 @@ function buildUnstartOnRemoveMethods(matchUpId: string, drawId: string): any[] {
       params: { matchUpId, drawId, outcome: { matchUpStatus: TO_BE_PLAYED } },
     },
   ];
-}
-
-/**
- * Project today's real-time HH:MM onto the strip's date. Lets the live-strip
- * warnings work when the user is viewing a non-today date (e.g. tournament
- * startDate from yesterday) so painted blocks still surface as active /
- * upcoming relative to the time-of-day the operator is working at.
- *
- * When the strip date IS today, returns the real clock as-is.
- */
-function effectiveNowOnStripDate(stripDate: string): Date {
-  const now = new Date();
-  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-  if (today === stripDate) return now;
-  const hh = String(now.getHours()).padStart(2, '0');
-  const mm = String(now.getMinutes()).padStart(2, '0');
-  const ss = String(now.getSeconds()).padStart(2, '0');
-  return new Date(`${stripDate}T${hh}:${mm}:${ss}`);
 }
 
 /**
@@ -3193,7 +3194,7 @@ function checkBlockInterruption(matchUp: any, courtId: string): BlockInterruptio
   }
   if (!blocks.length) return undefined;
 
-  const now = effectiveNowOnStripDate(currentDate);
+  const now = venueNowOnDate(currentDate);
 
   // First: is a non-SCHEDULED block currently active on this court?
   for (const block of blocks) {

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -42,15 +42,24 @@
  * as unmeasurable: the whole rest feature went dark, on every row, for exactly
  * the operator who is running matches right now.
  *
- * **Assumption, stated rather than assumed:** browser-local time is venue-local
- * time. This is the convention every other schedule2 surface already uses
- * (`todayIso()`, `effectiveNowOnStripDate()`, the reports tab's `calledAtIso`
- * recomputation), and a page that mixed conventions would be the real hazard.
- * `tournamentRecord.localTimeZone` exists and is the known input for making this
- * explicit later; it is deliberately not consulted yet, so that the whole
- * surface moves in one step rather than half of it.
+ * ── The zone: the VENUE's, not the operator's ──
+ *
+ * Every instant here is read in the tournament's own zone, resolved through
+ * `resolveVenueFrame()` — the convention the whole schedule surface moved to
+ * together, recorded in `Mentat/planning/DECISION_VENUE_TIME_FRAME.md`. It used
+ * to be the browser's, which read every figure on this page off by the offset
+ * between the operator's laptop and the venue, silently and plausibly.
+ *
+ * The frame is captured **once** per evaluator pass, alongside `asOfMinutes` and
+ * for the same reason: every badge in a tick must agree about what time it is,
+ * and re-resolving per row would let them disagree.
+ *
+ * The pure functions take the zone as a trailing argument rather than reaching
+ * for it, so they stay testable without an engine — and so this file's one
+ * impure half remains the only thing that decides what "now" and "where" mean.
  */
 
+import { resolveVenueFrame, venueCalendarDate, venueDayMinutes } from 'functions/venueTimeFrame';
 import { makeTimingResolver } from './scheduleTimingResolver';
 import { getCachedAllMatchUps } from './schedule2DataCache';
 import { competitionEngine } from 'services/factory/engine';
@@ -83,13 +92,9 @@ export function toDayMinutesFromClock(value?: string): number | undefined {
  * date for every evening stamp west of Greenwich and every early-morning one
  * east of it. This is what dates a matchUp that carries no `scheduledDate`.
  */
-export function instantLocalDate(iso?: string): string | undefined {
+export function instantLocalDate(iso?: string, timeZone?: string): string | undefined {
   if (!iso) return undefined;
-  const instant = new Date(iso);
-  if (Number.isNaN(instant.getTime())) return undefined;
-  const month = String(instant.getMonth() + 1).padStart(2, '0');
-  const day = String(instant.getDate()).padStart(2, '0');
-  return `${instant.getFullYear()}-${month}-${day}`;
+  return venueCalendarDate(iso, timeZone) || undefined;
 }
 
 /** Whole calendar days from `fromDate` to `toDate`. Both parsed as UTC, so no DST transition can shorten a day. */
@@ -126,22 +131,30 @@ function dayDelta(fromDate: string, toDate: string): number | undefined {
  * Day membership is not this function's job precisely because of that limit:
  * `instantLocalDate` answers it, exactly and without arithmetic.
  */
-export function toDayMinutesFromInstant(iso?: string, viewedDate?: string | null): number | undefined {
+export function toDayMinutesFromInstant(
+  iso?: string,
+  viewedDate?: string | null,
+  timeZone?: string,
+): number | undefined {
   if (!iso || !viewedDate) return undefined;
-  const instant = new Date(iso);
-  if (Number.isNaN(instant.getTime())) return undefined;
 
-  const localDate = instantLocalDate(iso);
+  const timeOfDay = venueDayMinutes(iso, timeZone);
+  if (timeOfDay === undefined) return undefined;
+
+  const localDate = instantLocalDate(iso, timeZone);
   const delta = localDate === undefined ? undefined : dayDelta(viewedDate, localDate);
   if (delta === undefined) return undefined;
 
-  const timeOfDay = instant.getHours() * 60 + instant.getMinutes();
   const crossedMidnight = Math.abs(delta) === 1;
   return timeOfDay + (crossedMidnight ? MINUTES_PER_DAY * delta : 0);
 }
 
 /** Every time on a matchUp, normalized into minutes from local midnight of the day being viewed. */
-export function normalizeTimes(matchUp: ReadinessMatchUp, viewedDate: string | null): NormalizedTimes {
+export function normalizeTimes(
+  matchUp: ReadinessMatchUp,
+  viewedDate: string | null,
+  timeZone?: string,
+): NormalizedTimes {
   const schedule = matchUp.schedule ?? {};
   // END_DATE is written only when the match crossed midnight, so its presence
   // is exactly the signal that the bare endTime belongs to the following day.
@@ -150,10 +163,10 @@ export function normalizeTimes(matchUp: ReadinessMatchUp, viewedDate: string | n
 
   return {
     ...(endMinutes !== undefined && { endMinutes: endMinutes + endDayOffset }),
-    scoredMinutes: toDayMinutesFromInstant(schedule.scoredTime, viewedDate),
-    scoredDate: instantLocalDate(schedule.scoredTime),
+    scoredMinutes: toDayMinutesFromInstant(schedule.scoredTime, viewedDate, timeZone),
+    scoredDate: instantLocalDate(schedule.scoredTime, timeZone),
     startMinutes: toDayMinutesFromClock(schedule.startTime),
-    calledMinutes: toDayMinutesFromInstant(schedule.calledAt, viewedDate),
+    calledMinutes: toDayMinutesFromInstant(schedule.calledAt, viewedDate, timeZone),
     scheduledMinutes: toDayMinutesFromClock(schedule.scheduledTime),
   };
 }
@@ -161,11 +174,11 @@ export function normalizeTimes(matchUp: ReadinessMatchUp, viewedDate: string | n
 /**
  * "Now" as minutes from midnight of the viewed day. When the operator is looking
  * at another date, today's time-of-day is projected onto it — the same thing
- * `effectiveNowOnStripDate()` does for the Now strip, so the two agree.
+ * `venueNowOnDate()` does for the Now strip, so the two agree — both in the
+ * venue's zone.
  */
-export function nowDayMinutes(): number {
-  const now = new Date();
-  return now.getHours() * 60 + now.getMinutes();
+export function nowDayMinutes(timeZone?: string): number {
+  return venueDayMinutes(new Date(), timeZone) ?? 0;
 }
 
 /** Tournament daily limits, or undefined when no scheduling policy is attached — never a substituted default. */
@@ -218,7 +231,10 @@ export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | nu
   const hydrated = (matchUps ?? []) as ReadinessMatchUp[];
   const timingFor = makeTimingResolver();
   const dailyLimits = readDailyLimits();
-  const asOfMinutes = nowDayMinutes();
+  // One frame for the whole pass — see the header note on why this is captured
+  // here rather than read per row.
+  const { timeZone } = resolveVenueFrame();
+  const asOfMinutes = nowDayMinutes(timeZone);
 
   return (matchUpId, viewedDate) => {
     const restDate = restDateFor(
@@ -230,7 +246,7 @@ export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | nu
       matchUps: hydrated,
       scheduledDate: restDate ?? '',
       asOfMinutes,
-      timesFor: (matchUp) => normalizeTimes(matchUp, restDate),
+      timesFor: (matchUp) => normalizeTimes(matchUp, restDate, timeZone),
       dailyLimits,
       timingFor,
     });

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -209,6 +209,12 @@ const SINGLES = 'SINGLES';
  * Inspector and a different one in the recovery report for the same matchUp; a
  * cancelled matchUp plainly put nobody on court, so the factory's set is right
  * and this one follows it.
+ *
+ * **That agreement is enforced, not merely requested.**
+ * `wasPlayedConformance.test.ts` drives the factory's own Participant Recovery
+ * report over one matchUp per status and checks this predicate reaches the same
+ * verdict. If you change the set below, that test tells you whether the factory
+ * agrees — and if it does not, the factory is right and this file follows.
  */
 const UNPLAYED_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'CANCELLED']);
 const DEFAULT_STATUSES = new Set(['DEFAULTED', 'DOUBLE_DEFAULT']);

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -5,6 +5,7 @@
  * in the schedule2 CSS grid. Uses tippy.js directly with custom DOM for a modern
  * pill/icon layout rather than the legacy flat menu list.
  */
+import { venueClock } from 'functions/venueTimeFrame';
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
@@ -317,8 +318,7 @@ function showMatchUpCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
   const startMatch = () => {
     const drawId = matchUp?.drawId || cellData.drawId;
     if (!drawId) return;
-    const now = new Date();
-    const startTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+    const startTime = venueClock();
     executeMethods(
       [
         {
@@ -712,8 +712,7 @@ export function handleSchedule2RowClick(e: MouseEvent, ctx: Schedule2RowContext)
   };
 
   const shotgunStart = () => {
-    const now = new Date();
-    const startTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+    const startTime = venueClock();
     const startableIds = startableMatchUps.map((m: any) => m.matchUpId);
     executeMethods(
       [
@@ -813,9 +812,14 @@ function nowCellLabel(cell: NowStripCell): string {
   return cell.courtName ? `${cell.courtName} · ${versus}` : versus;
 }
 
+/**
+ * "Now" as a `HH:MM` **venue** wall clock. Everything it is written into —
+ * `startTime`, `scheduledTime` — is stored as a bare venue clock with no zone,
+ * so reading the operator's clock would file a match as starting at the wrong
+ * time for anyone not sitting in the operator's zone.
+ */
 function currentClockTime(): string {
-  const now = new Date();
-  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+  return venueClock();
 }
 
 /**

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -5,7 +5,6 @@
  * in the schedule2 CSS grid. Uses tippy.js directly with custom DOM for a modern
  * pill/icon layout rather than the legacy flat menu list.
  */
-import { venueClock } from 'functions/venueTimeFrame';
 import { BookingTypeEnum, matchUpStatusConstants, timeItemConstants, tools } from 'tods-competition-factory';
 import { activateScheduleCellTypeAhead, computeReschedulePlacements } from 'courthive-components';
 import { secondsToTimeString, timeStringToSeconds } from 'functions/timeStrings';
@@ -25,6 +24,7 @@ import { destroyTipster } from 'components/popovers/tipster';
 import { competitionEngine } from 'services/factory/engine';
 import { evaluateRest, formatDuration } from './inspectorRest';
 import { timePicker } from 'components/modals/timePicker';
+import { venueClock } from 'functions/venueTimeFrame';
 import { Datepicker } from 'vanillajs-datepicker';
 import tippy, { type Instance } from 'tippy.js';
 import { i18next, t } from 'i18n';

--- a/src/pages/tournament/tabs/scheduleViews/wasPlayedConformance.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/wasPlayedConformance.test.ts
@@ -1,0 +1,176 @@
+/**
+ * `wasPlayed` conformance — TMX's copy must agree with the factory's.
+ *
+ * ── Why this file exists ──
+ *
+ * `participantRest.wasPlayed` and `factory/src/query/reports/recoveryTimeline.wasPlayed`
+ * are two copies of one rule. They had already drifted by a status: the factory
+ * counted `CANCELLED` as unplayed and TMX did not, so the same matchUp produced
+ * one rest figure in the Inspector and a different one in the recovery report.
+ * TMX #1356 aligned them and recorded that **the factory is authoritative**;
+ * factory #4707 moved that statement into `recoveryTimeline.ts` itself.
+ *
+ * Neither of those *enforces* anything. Two files agreeing today, with a comment
+ * in each asking the next editor to keep them agreeing, is exactly the state
+ * they were in before they drifted. This is the enforcement.
+ *
+ * ── Why it is behavioural, not a source comparison ──
+ *
+ * `wasPlayed` is not exported from the factory's package entry, and the
+ * published tarball ships `dist` only (`files: ['dist']`), so TMX cannot import
+ * it or read its source. CI installs the **published** factory — the `link:`
+ * overrides are stripped on the runner — so a test that read the sibling
+ * checkout would assert against code TMX does not ship against.
+ *
+ * So this drives the real thing: for each status, build a tournament with one
+ * scheduled matchUp, run the factory's Participant Recovery report, and check
+ * that TMX's predicate agrees with whether the factory counted that matchUp as
+ * played. It fails when either copy moves, which is the whole point, and it
+ * tests the factory TMX actually ships against.
+ *
+ * ── The divergence that must NOT be "fixed" ──
+ *
+ * Pinned in the last describe block. TMX's finish-anchor plausibility check
+ * tolerates a missing start; the factory's `isPlausibleFinish` does not. Same
+ * idea, different question — one computes an ANCHOR, the other a DURATION, and
+ * you cannot measure a duration from nothing. A future reader tidying these into
+ * agreement would silently blank the rest figure for every score entered from
+ * the draw view, which leaves no start time behind.
+ */
+import { matchUpStatusConstants, mocksEngine, reportConstants } from 'tods-competition-factory';
+import { tournamentEngine } from 'services/factory/engine';
+import { describe, expect, it } from 'vitest';
+import { wasPlayed } from './participantRest';
+
+/**
+ * A zone that is NOT the ambient one (the suite runs `TZ=UTC`). Whether a
+ * matchUp was played is a property of its status and score, never of the clock —
+ * running the frame off-UTC keeps it that way, and would catch a `wasPlayed`
+ * that quietly acquired a time dependency.
+ */
+const VENUE_ZONE = 'America/New_York';
+
+type Probe = { played: boolean; matchUp: any };
+
+/**
+ * One tournament, one scheduled matchUp, that status applied — then ask the
+ * factory's report whether it counted.
+ *
+ * `rows.length > 0` is the observable: `appearancesForMatchUp` returns an empty
+ * list for anything `wasPlayed` rejects, and with a single matchUp in the draw
+ * that empties the report.
+ */
+function probe(matchUpStatus: string, withScore: boolean): Probe {
+  const { tournamentRecord }: any = mocksEngine.generateTournamentRecord({
+    drawProfiles: [{ drawSize: 2 }],
+    setState: true,
+  });
+  const { matchUps }: any = tournamentEngine.allTournamentMatchUps({ inContext: true });
+  const target = matchUps[0];
+  const date = tournamentRecord.startDate;
+
+  tournamentEngine.bulkScheduleMatchUps({
+    matchUpIds: [target.matchUpId],
+    schedule: {
+      scheduledDate: date,
+      scheduledTime: `${date}T10:00`,
+      startTime: `${date}T10:00`,
+      endTime: `${date}T11:30`,
+    },
+  });
+
+  // A double walkover / double default has no winner; asserting one is rejected.
+  const noWinner = ['DOUBLE_WALKOVER', 'DOUBLE_DEFAULT', 'CANCELLED', 'ABANDONED'].includes(matchUpStatus);
+  const outcome: any = { matchUpStatus, ...(noWinner ? {} : { winningSide: 1 }) };
+  if (withScore) {
+    outcome.score = { sets: [{ side1Score: 6, side2Score: 1, winningSide: 1 }], scoreStringSide1: '6-1' };
+  }
+  tournamentEngine.setMatchUpStatus({ matchUpId: target.matchUpId, drawId: target.drawId, outcome });
+
+  const report: any = tournamentEngine.generateReport({
+    reportId: reportConstants.PARTICIPANT_RECOVERY_REPORT,
+    parameters: { timeZone: VENUE_ZONE },
+  });
+
+  const { matchUps: stored }: any = tournamentEngine.allTournamentMatchUps({ inContext: true });
+  return { played: !!report?.rows?.length, matchUp: stored[0] };
+}
+
+/** Every status TMX and the factory both classify, and what the factory does with it. */
+const CASES: { status: string; withScore: boolean; expectPlayed: boolean; why: string }[] = [
+  { status: 'COMPLETED', withScore: false, expectPlayed: true, why: 'the ordinary case' },
+  { status: 'WALKOVER', withScore: false, expectPlayed: false, why: 'nobody stepped on court' },
+  { status: 'DOUBLE_WALKOVER', withScore: false, expectPlayed: false, why: 'neither side appeared' },
+  {
+    status: 'CANCELLED',
+    withScore: false,
+    expectPlayed: false,
+    why: 'the status that drifted, and why this file exists',
+  },
+  { status: 'DEFAULTED', withScore: false, expectPlayed: false, why: 'a default with no score is a no-show' },
+  {
+    status: 'DEFAULTED',
+    withScore: true,
+    expectPlayed: true,
+    why: 'a default WITH a score was played up to the default',
+  },
+  { status: 'RETIRED', withScore: false, expectPlayed: true, why: 'a retirement means time was spent on court' },
+  { status: 'ABANDONED', withScore: false, expectPlayed: true, why: 'an abandonment means time was spent on court' },
+];
+
+describe('wasPlayed — TMX agrees with the factory it ships against', () => {
+  for (const { status, withScore, expectPlayed, why } of CASES) {
+    const label = `${status}${withScore ? ' with a score' : ''}`;
+
+    it(`${label}: ${why}`, () => {
+      const { played, matchUp } = probe(status, withScore);
+
+      // The factory's own verdict, observed rather than asserted from its source.
+      expect(played).toBe(expectPlayed);
+      // TMX's copy must reach the same one, from the record the engine stored.
+      expect(wasPlayed(matchUp)).toBe(expectPlayed);
+    });
+  }
+});
+
+describe('wasPlayed — the score-discriminated branch, and its one unreachable corner', () => {
+  /**
+   * `DOUBLE_DEFAULT` cannot exercise the "default with a score" branch, because
+   * the engine does not keep a score on one — `setMatchUpStatus` stores the
+   * status and drops the sets. Both copies therefore answer `false` for it in
+   * practice, and that is a property of the engine rather than of the rule.
+   *
+   * Pinned so nobody "corrects" the expectation to `true` by reading the
+   * predicate and not the record.
+   */
+  it('DOUBLE_DEFAULT keeps no score, so the score branch never fires for it', () => {
+    const { played, matchUp } = probe('DOUBLE_DEFAULT', true);
+    expect(matchUp.score?.sets?.length ?? 0).toBe(0);
+    expect(played).toBe(false);
+    expect(wasPlayed(matchUp)).toBe(false);
+  });
+
+  it('is decided by the record, not the request: a DEFAULTED score survives and flips the verdict', () => {
+    const withoutScore = probe('DEFAULTED', false);
+    const withScore = probe('DEFAULTED', true);
+    expect(withoutScore.matchUp.score?.sets?.length ?? 0).toBe(0);
+    expect(withScore.matchUp.score?.sets?.length).toBeGreaterThan(0);
+    expect(wasPlayed(withoutScore.matchUp)).toBe(false);
+    expect(wasPlayed(withScore.matchUp)).toBe(true);
+  });
+});
+
+describe('wasPlayed — status vocabulary, not TMX-local strings', () => {
+  /**
+   * Both copies key on `matchUpStatus` values from the factory's own vocabulary.
+   * If a status this file names were renamed there, the probe would stop
+   * reproducing it and this guard says so directly rather than through a
+   * confusing `expected true, got false`.
+   */
+  it('every status under test is one the factory recognises', () => {
+    const known = new Set(Object.values(matchUpStatusConstants));
+    for (const { status } of [...CASES, { status: 'DOUBLE_DEFAULT' }]) {
+      expect(known).toContain(status);
+    }
+  });
+});

--- a/src/services/officiating/officialsBoard.ts
+++ b/src/services/officiating/officialsBoard.ts
@@ -20,7 +20,7 @@
  * Pure and DOM-free: TMX has no jsdom, so a decision made inside a renderer gets no unit coverage.
  */
 
-import { signedInOnDate, localCalendarDate } from 'services/presence/signInPresence';
+import { signedInOnDate, venueCalendarDay } from 'services/presence/signInPresence';
 import { participantRoles } from 'tods-competition-factory';
 
 // constants and types
@@ -166,4 +166,4 @@ export function buildOfficialsBoard({ matchUps, participants, date }: BoardArgs)
 
 // Re-exported so the officials surface has one import site; the implementation is shared with the
 // participants presence surface so the two cannot drift into two presence models (D4e).
-export { signedInOnDate, localCalendarDate };
+export { signedInOnDate, venueCalendarDay };

--- a/src/services/presence/signInPresence.test.ts
+++ b/src/services/presence/signInPresence.test.ts
@@ -5,7 +5,7 @@
  * Friday. Nothing signs anybody out at end of day, so `participant.signedIn` — the latest value —
  * says it does. That is the bug (c) exists to fix, not an edge case.
  */
-import { signedInOnDate, stillSignedInOnDate, localCalendarDate } from './signInPresence';
+import { signedInOnDate, stillSignedInOnDate, venueCalendarDay } from './signInPresence';
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
@@ -20,7 +20,7 @@ const at = (date: string, hour = 12, itemValue = 'SIGNED_IN') => {
 
 const person = (participantId: string, timeItems: any[] = []) => ({ participantId, timeItems });
 
-describe('localCalendarDate', () => {
+describe('venueCalendarDay', () => {
   /**
    * ⚠️ The obvious value-based test for this is VACUOUS. TMX runs vitest with `TZ=UTC`
    * (`package.json`), so local and UTC days are identical in the suite and no assertion on a Date can
@@ -36,16 +36,25 @@ describe('localCalendarDate', () => {
     const code = codeOf('./signInPresence.ts');
     expect(code).not.toMatch(/toISOString\(\)\s*\.slice\(\s*0\s*,\s*10\s*\)/);
     // Control: the guard must be able to see the code, not merely fail to match an empty string.
-    expect(code).toContain('export function localCalendarDate');
+    expect(code).toContain('export function venueCalendarDay');
   });
 
-  it('builds the date from LOCAL getters', () => {
+  /**
+   * The guard this replaces asserted the date was built from `getFullYear()` / `getMonth()` /
+   * `getDate()` — the operator's zone, which was the convention at the time. It is now the VENUE's,
+   * so the same vacuousness argument applies to a new implementation: under `TZ=UTC` a browser-zone
+   * regression is invisible in values. Guard the delegation instead.
+   */
+  it('derives the day through the venue frame, not the browser clock', () => {
     const code = codeOf('./signInPresence.ts');
-    for (const getter of ['getFullYear()', 'getMonth()', 'getDate()']) expect(code).toContain(getter);
+    expect(code).toContain('venueCalendarDate');
+    for (const browserGetter of ['getFullYear()', 'getMonth()', 'getDate()']) {
+      expect(code).not.toContain(browserGetter);
+    }
   });
 
   it('returns empty for an unparseable value rather than "NaN-NaN-NaN"', () => {
-    expect(localCalendarDate('not-a-date')).toBe('');
+    expect(venueCalendarDay('not-a-date')).toBe('');
   });
 });
 

--- a/src/services/presence/signInPresence.ts
+++ b/src/services/presence/signInPresence.ts
@@ -18,34 +18,32 @@
  * participants surface answer this question with one implementation rather than two — the second
  * presence model D4e exists to prevent.
  */
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 
 const SIGN_IN_STATUS = 'SIGN_IN_STATUS';
 const SIGNED_IN = 'SIGNED_IN';
 
 /**
- * The **local** calendar date of an instant — never `toISOString().slice(0, 10)`.
+ * The **venue's** calendar date for an instant — never `toISOString().slice(0, 10)`.
  *
  * `toISOString` is UTC, so west of UTC it rolls over while the tournament is still playing: at 8pm in
  * Florida it already reports tomorrow. Shipping that bug once (#1352, fixed #1355) made every official
- * read "available" every evening. Every schedule surface in TMX keys "today" on the operator's local
- * calendar date (see `gridView.todayIso`), and this must agree with them.
+ * read "available" every evening.
  *
- * ⚠️ Local is the established convention, not the ideal one — the venue's own zone would be better,
- * but moving to it is a change every schedule surface must make together.
+ * That fix moved the day to the *operator's* zone, which is right only when the operator is on site.
+ * It is now the *venue's*, resolved through `venueCalendarDate()` — the convention every schedule
+ * surface in TMX moved to together (see `Mentat/planning/DECISION_VENUE_TIME_FRAME.md`). This function
+ * must keep agreeing with `gridView.todayIso`; both now do, because both ask the same resolver.
  */
-export function localCalendarDate(value?: string | Date): string {
-  const date = value instanceof Date ? value : value ? new Date(value) : new Date();
-  if (Number.isNaN(date.getTime())) return '';
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${date.getFullYear()}-${month}-${day}`;
+export function venueCalendarDay(value?: string | Date): string {
+  return venueCalendarDate(value);
 }
 
 /** Sign-in entries stamped on a given local day, oldest first. */
 function entriesOn(participant: any, date: string): any[] {
   return (participant?.timeItems ?? [])
     .filter((timeItem: any) => timeItem?.itemType === SIGN_IN_STATUS && timeItem?.createdAt)
-    .filter((timeItem: any) => localCalendarDate(timeItem.createdAt) === date);
+    .filter((timeItem: any) => venueCalendarDay(timeItem.createdAt) === date);
 }
 
 /**


### PR DESCRIPTION
Every TMX surface that turned a stored instant (`calledAt`, `scoredTime`, a sign-in, an embargo) into a clock time or a calendar day used the **browser's** zone. A director running a Florida event from a Pacific-set laptop read rest, call times and order-of-play timing three hours out — silently, in numbers that stayed plausible, which is what made it expensive.

Two independent sightings in one day (#1355, #1356) made it a bug class rather than a bug.

## Why it had to move all at once

TMX had **three conventions live at the same time**: raw `getHours()` on the schedule surface, the reports tab's correct per-instant machinery fed the browser's zone, and the matchUps table already reading `tournamentRecord.localTimeZone`.

#1356 deliberately stopped short of moving rest on its own, and that was right — a page where two surfaces disagree about what time it is beats one that is uniformly wrong. So this moves all of them together.

## The convention

Decided and written down before any code moved, in `Mentat/planning/DECISION_VENUE_TIME_FRAME.md`.

`functions/venueTimeFrame.ts` — `resolveVenueFrame()` returns the tournament's `localTimeZone`, or the browser's when the record carries none, and **every conversion resolves its offset at its own instant** via `Intl.DateTimeFormat`. A stored `utcOffsetMinutes` is the offset at one moment; measured across the 2026 US spring-forward, 22:00 → 08:00 is nine hours, not ten. There is a test for exactly that.

### The fallback announces itself

A silent browser fallback would reproduce the same silent wrongness through a different door — right for the director at the venue, wrong for the one running it remotely, with nothing on screen to say which. Refusing to render instead would break the desk for every zone-less tournament, which is most of them today.

So the schedule action bar carries a pill reading *"Times in `<zone>` — venue zone not set"*, one click from Edit Dates. The one case where the page can be wrong is the one case where it says so. Same pattern the publishing tab already ships (`timezoneWarning.ts`).

## Sites moved

`inspectorRest` (frame captured once per evaluator pass, beside `asOfMinutes` and for the same reason — two rows in one tick must not disagree), `gridView` (`todayIso`, the Now strip, auto-call, start-on-drop), `schedule2CellActions` ×3, `renderReportsTab`, `signInPresence.localCalendarDate` → `venueCalendarDay` and with it the officials board, `matchUpDateFilter.isoToday`, `scheduleStatusFormatter`.

**Six the original scope did not list, found in source and moved in the same pass:** `matchUpStatusPredicates.isCalledForScheduledDay`, `maybeNudgeActiveDates.todayLocalIso`, the `embargoModal` instant↔wall-clock round trip, and the three embargo displays.

Two findings worth calling out:

- **The reports variance was wrong in a second way.** `localizeReportTimes` subtracted a browser-parsed `scheduledTime` (a bare venue wall clock) from a real instant, so the variance itself drifted by the laptop-to-venue offset — an on-time call reading as minutes late. Fixed via `venueWallClockToMs`.
- **The embargo round trip had to move in both directions.** Display-only would have silently rewritten an existing embargo just by opening the modal.

## Deliberately not moved

Written down rather than left to be rediscovered:

- **Naive wall clocks** (`scheduledTime`, `endTime`, court-block bounds) were never instants, so converting one is the bug and not the fix. `gridView.formatHM` keeps its raw accessors, with a comment saying why.
- **Operator-session timestamps** (chat, local drafts, crowd trackers) stay on the reader's clock — "when did I see this" is the question they answer.

The stale *"assumption, stated rather than assumed"* caveats are deleted at each site that adopted the frame.

## `wasPlayed` conformance

`participantRest.wasPlayed` and factory `recoveryTimeline.wasPlayed` are two copies of one rule that had already drifted by a status. #1356 aligned them; factory #4707 wrote "the factory is authoritative" into `recoveryTimeline.ts`. Neither *enforces* anything — two files agreeing, each asking the next editor to keep them agreeing, is the state they were in before they drifted.

`wasPlayedConformance.test.ts` drives the factory's own Participant Recovery report over one matchUp per status and checks TMX's predicate reaches the same verdict. Behavioural rather than a source comparison because it has to be: `wasPlayed` is not exported from the package entry, the published tarball ships `dist` only, and CI installs the **published** factory — a test reading the sibling checkout would assert against code TMX does not ship against.

Verified non-vacuous: reintroducing the historical drift (dropping `CANCELLED`) turns exactly one case red, the one named for it.

The deliberate divergence is pinned in its own block — TMX tolerates a missing start because it computes an ANCHOR, `isPlausibleFinish` requires one because it computes a DURATION. Tidying those into agreement would blank the rest figure for every score entered from the draw view.

## Temporal

`venueTimeFrame` is named as TMX's migration seam for `FACTORY_TEMPORAL_MIGRATION.md`, whose Phase 1 (`tools/timeZone.ts` on `Temporal.ZonedDateTime`) is this same problem one repo over. Concentrating the conversions here means following is a rewrite of one file rather than a sweep of sixteen call sites. The header records which choices were made for that migration, which piece gets genuinely better (`venueWallClockToMs`'s two-pass offset guess is a native-`Date` workaround to delete, and its silent DST ambiguity becomes an explicit `disambiguation`), and the wart to fix when it lands (`venueNowOnDate`'s naive `Date` is a `PlainDateTime`).

## Verification

`check-types`, `lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci`, production build, **1656 tests**.

Changed-surface coverage 95.6% statements / 100% functions / 98.7% lines. The two uncovered lines are `catch` branches for platforms that will not name a zone. `venueFrameNotice.ts` is untested because TMX's vitest has no DOM environment — the same posture as every other DOM builder in the repo, `timezoneWarning.ts` included.

Every test names an **explicit** non-UTC zone: the suite runs `TZ=UTC`, so an ambient-zone test could not tell the browser-zone bug from the venue-zone fix.