### PR TITLE
fix(schedule): finish the venue frame — five sites #1362 missed

### DIFF
--- a/src/components/modals/crowdTrackersModalLogic.ts
+++ b/src/components/modals/crowdTrackersModalLogic.ts
@@ -6,6 +6,7 @@
 
 import { classifyScorer, type ScorerClassification } from 'services/crowd/classifyScorer';
 import type { CrowdScoringSession } from 'services/crowd/scoreRelayClient';
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { t } from 'i18n';
 
 export interface SessionScorerInfo {
@@ -76,7 +77,10 @@ export function decidePrimaryButtonLabel(session: CrowdScoringSession): 'Promote
 
 export function buildSecondaryLine(
   session: CrowdScoringSession,
-  formatTime: (date: Date) => string = (d) => d.toLocaleTimeString(),
+  // `updatedAt` is an instant, and a crowd-scoring session is something
+  // happening AT the venue — so the default reads it on the venue's clock. Still
+  // injectable, which is how the tests pin the string without a zone.
+  formatTime: (date: Date) => string = (d) => d.toLocaleTimeString(undefined, { timeZone: venueTimeZone() }),
 ): string {
   return `${session.pointHistory.length} pts · v${session.version} · updated ${formatTime(new Date(session.updatedAt))}`;
 }

--- a/src/components/modals/printFactSheet.ts
+++ b/src/components/modals/printFactSheet.ts
@@ -3,6 +3,7 @@
  */
 import { generateFactSheet, listFactSheetTemplates } from 'pdf-factory';
 import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { tournamentEngine } from 'services/factory/engine';
 import { renderForm } from 'courthive-components';
 import { openModal } from './baseModal/baseModal';
@@ -39,7 +40,9 @@ export function printFactSheet(): void {
     const templateId = inputs.templateId?.value || 'national-federation';
     const doc = generateFactSheet(tournamentRecord, { templateId });
     const safeName = tournamentName.replaceAll(/[^a-zA-Z0-9-_ ]/g, '').replaceAll(/\s+/g, '-');
-    const date = new Date().toISOString().split('T')[0];
+    // `toISOString()` is the UTC day, so west of Greenwich an evening print
+    // stamps the filename with tomorrow. Same class of bug as #1352.
+    const date = venueCalendarDate();
     const filename = `fact-sheet-${safeName}-${date}.pdf`;
 
     if (action === 'open') {

--- a/src/components/modals/printPlayerList.ts
+++ b/src/components/modals/printPlayerList.ts
@@ -5,6 +5,7 @@ import { generatePlayerListPDF, generateSignInSheetPDF } from 'pdf-factory';
 import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
 import { participantRoles } from 'tods-competition-factory';
 import { tournamentEngine } from 'services/factory/engine';
+import { venueTimeZone } from 'functions/venueTimeFrame';
 import { renderForm } from 'courthive-components';
 import { openModal } from './baseModal/baseModal';
 import { t } from 'i18n';
@@ -79,7 +80,10 @@ export function printPlayerList({ eventId }: PrintPlayerListParams = {}): void {
       doc = generateSignInSheetPDF(players, {
         header: headerConfig,
         eventName: printOptions.eventName || undefined,
-        signInDate: new Date().toLocaleDateString(),
+        // The day the sheet is signed AT THE VENUE — a sheet printed late
+        // evening from a laptop west of the venue would otherwise be dated
+        // tomorrow, on the one document whose date is its whole point.
+        signInDate: new Date().toLocaleDateString(undefined, { timeZone: venueTimeZone() }),
       });
     } else {
       doc = generatePlayerListPDF(players, { header: headerConfig });

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Every export here returns an `HTMLSpanElement`, and TMX runs vitest without a
+ * DOM — so a value test cannot call one. What CAN be pinned, and is the thing
+ * that actually regressed, is which clock the module reads.
+ *
+ * `calledAt` is a full ISO **instant**. #1362 moved the venue frame across the
+ * schedule surface but missed `calledAtFormatter`, leaving the matchUps table
+ * disagreeing with itself: `matchUpStatusPredicates.isCalledForScheduledDay`
+ * bucketed a row as called-today on the VENUE's clock while the cell beside it
+ * printed the OPERATOR's. Two surfaces, one matchUp, two answers — precisely the
+ * mixed-convention page `Mentat/planning/DECISION_VENUE_TIME_FRAME.md` exists to
+ * prevent.
+ *
+ * Guarded at the source, the same way `signInPresence.test.ts` guards its own
+ * UTC-day bug and for the same reason: under `TZ=UTC` the browser-zone
+ * implementation and the venue-zone one produce identical output, so no
+ * assertion on a rendered value could tell them apart even with a DOM.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+/** Source with comments stripped — the guards must match code, not prose about code. */
+const code = readFileSync(new URL('./scheduleStatusFormatter.ts', import.meta.url), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/.*$/gm, '');
+
+describe('scheduleStatusFormatter reads the venue clock, never the browser`s', () => {
+  it('can see the code — otherwise every guard below passes on an empty string', () => {
+    expect(code).toContain('export function calledAtFormatter');
+    expect(code).toContain('export function scheduleTimeFormatter');
+  });
+
+  it('derives no clock or calendar value from browser-local accessors', () => {
+    for (const accessor of ['getHours()', 'getMinutes()', 'getFullYear()', 'getMonth()', 'getDate()']) {
+      expect(code).not.toContain(accessor);
+    }
+  });
+
+  it('never derives a calendar day from toISOString — that is UTC, not the venue', () => {
+    expect(code).not.toMatch(/toISOString\(\)\s*\.slice\(/);
+    expect(code).not.toMatch(/toISOString\(\)\s*\.split\(/);
+  });
+
+  it('routes through the venue frame', () => {
+    expect(code).toContain('venueTimeFrame');
+    // `calledAt` is an instant and must go through `venueClock`; `scheduledDate`
+    // / `scheduledTime` are bare venue wall clocks compared against "now", which
+    // is why the module needs both the day and the clock.
+    expect(code).toContain('venueClock');
+    expect(code).toContain('venueCalendarDate');
+  });
+});

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.ts
@@ -70,14 +70,20 @@ export function scheduleLockFormatter(cell: any): HTMLSpanElement | string {
   return el;
 }
 
-// `calledAt` is a full ISO timestamp (stamped when a matchUp is dropped on the
-// active strip), unlike scheduledTime's bare HH:MM — render it as local HH:MM.
+// `calledAt` is a full ISO **instant** (stamped when a matchUp is dropped on the
+// active strip), unlike scheduledTime's bare HH:MM — so it needs a zone, and the
+// zone is the venue's.
+//
+// This column is the one `matchUpStatusPredicates.isCalledForScheduledDay` names
+// when it says "the same convention the calledAt column uses". #1362 moved that
+// predicate and the Call Timing Variance report and missed the column itself,
+// which left the page disagreeing with itself in the sharpest possible way: the
+// row was bucketed as called-today on the venue's clock while the cell beside it
+// printed the operator's.
 export function calledAtFormatter(cell: any): HTMLSpanElement | string {
-  const value = cell.getValue();
-  if (!value) return '';
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return '';
+  const clock = venueClock(cell.getValue());
+  if (!clock) return '';
   const el = document.createElement('span');
-  el.textContent = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  el.textContent = clock;
   return el;
 }

--- a/src/pages/tournament/tabs/matchUpsTab/abandonMatchUpsAction.ts
+++ b/src/pages/tournament/tabs/matchUpsTab/abandonMatchUpsAction.ts
@@ -11,20 +11,26 @@ import { ABANDON_TOURNAMENT_MATCHUPS } from 'constants/mutationConstants';
 import { getRepublishRankingsOption } from 'pages/tournament/tabs/matchUpsTab/republishRankingsAction';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
 import { mutationRequest } from 'services/mutation/mutationRequest';
+import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
 import { RIGHT } from 'constants/tmxConstants';
-import dayjs from 'dayjs';
 
 // Calendar-day comparison via ISO `YYYY-MM-DD` string compare. Avoids the
 // `new Date("YYYY-MM-DD")` UTC-midnight off-by-one that renders the wrong day
-// west of UTC; `dayjs().format` yields the local calendar date. True when today
-// is on or after the tournament's last date.
+// west of UTC. True when today is on or after the tournament's last date.
+//
+// "Today" is the VENUE's day, not the device's. `endDate` is a venue calendar
+// day, so comparing it against the operator's would offer — or withhold — the
+// abandon action a day early or late for anyone running the event from another
+// zone. The previous `dayjs().format('YYYY-MM-DD')` fixed the UTC half of this
+// (#1352's bug class) and left the operator-vs-venue half, which is what
+// `venueCalendarDate()` closes.
 function onOrPastLastDate(): boolean {
   const { tournamentRecord } = tournamentEngine.getTournament() ?? {};
   const endDate = tournamentRecord?.endDate;
   if (!endDate) return false;
-  return dayjs().format('YYYY-MM-DD') >= String(endDate).slice(0, 10);
+  return venueCalendarDate() >= String(endDate).slice(0, 10);
 }
 
 // Modal body: a one-line explanation plus a checkbox that relaxes the default


### PR DESCRIPTION
#1362 claimed to move **every** instant→clock site in one pass, on the grounds that a half-migrated page is worse than a uniformly wrong one. It did not. Three successive sweeps of `origin/main`, each shaped differently, found five survivors.

That progression is the more useful finding, so it is recorded rather than tidied away:

| sweep | shape | missed because |
|---|---|---|
| 1 (in #1362) | `getHours` / `getMinutes` / `toLocale*` | treated a file as done after fixing the sites already found in it — `scheduleStatusFormatter` had three, two were fixed |
| 2 | added `toISOString` | never grepped `toISOString` the first time |
| 3 | every `new Date(<expr>)`, then `dayjs()` | no earlier grep matched `dayjs()`, which is how the fifth site reads the clock |

## The one that matters

**`calledAtFormatter`** rendered `calledAt` — a full ISO instant — with raw `getHours()`.

This is the column `matchUpStatusPredicates` names when it says *"the same convention the calledAt column uses"*. #1362 moved that predicate **and** the Call Timing Variance report, and left the column. So the matchUps table disagreed with itself in the sharpest way available: a row bucketed as called-today on the **venue's** clock, beside a cell printing the **operator's**.

That is the exact mixed-convention page `DECISION_VENUE_TIME_FRAME.md` exists to prevent — shipped by the change that exists to prevent it.

## The other four

- **`abandonMatchUpsAction.onOrPastLastDate`** compared `dayjs().format('YYYY-MM-DD')` — the device's day — against `tournamentRecord.endDate`, a venue day. Offers or withholds "abandon remaining matchUps" a day early or late from another zone. Its existing comment was *half* right and stays: `dayjs().format` genuinely does avoid the `new Date("YYYY-MM-DD")` UTC off-by-one (#1352's class). It fixed the UTC half and left the operator-vs-venue half; the comment now says which half is which, so it is not misread as evidence the question is settled. Drops the last `dayjs()` clock read in the tree.
- **`printPlayerList`** dated the sign-in sheet on the browser's calendar. Printed late evening west of the venue, it is dated *tomorrow* — on the one document whose date is its entire point.
- **`printFactSheet`** built its filename date from `toISOString()`, i.e. the UTC day.
- **`crowdTrackersModalLogic`**'s default `formatTime` read session `updatedAt` on the browser clock. A crowd-scoring session happens at the venue. Kept injectable and kept `toLocaleTimeString`'s format — only the zone moved.

## Deliberately still excluded

Looked at and ruled out, rather than skipped:

| site | why not |
|---|---|
| chat / local-draft timestamps | operator-session — "when did I see this", per the rule in `venueTimeFrame.ts` |
| `mapTournament` | external list data; no tournament record in hand to carry a zone |
| `editDisplaySettings` | fixture data for a settings preview |
| `scheduleDateSelectorLogic`, `renderOverview`, `scheduleResultsDrawer` | naive date-string labels — never instants |
| `gridView.formatHM`, `updatedAtFormatter` fallback | naive wall clocks / documented no-zone fallback |
| `.getTime()` comparisons (sorts, embargo-expiry, `updatedAt` freshness) | zone-independent by construction |

## Testing

`scheduleStatusFormatter` gets a **source guard**, not value tests. Every export returns an element and vitest has no DOM — and even with one the assertions would be vacuous under `TZ=UTC`, where the browser-zone and venue-zone implementations render identically. Same guard shape `signInPresence.test.ts` uses against its own UTC-day bug.

**Verified by reintroducing the regression**: restoring the raw accessors fails the accessor guard and nothing else.

## Verification

`check-types`, `lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci`, production build, **1660 tests** (150 files).