### PR TITLE
test(e2e): match the journey label to its renumbered filename

### DIFF
--- a/e2e/journeys/110-schedule-time-entry.spec.ts
+++ b/e2e/journeys/110-schedule-time-entry.spec.ts
@@ -5,7 +5,7 @@ import { TournamentPage } from '../pages/TournamentPage';
 import { S } from '../helpers/selectors';
 
 /**
- * Journey 108 — schedule time entry cannot silently send an impossible end time.
+ * Journey 110 — schedule time entry cannot silently send an impossible end time.
  *
  * Reproduces the production defect behind two `ERR_INVALID_END_TIME` rejections on 2026-08-23
  * (CFS audit_log, tournament 189ab4d5). TMX's picker is a 12-hour clock which, seeded empty, opened
@@ -122,7 +122,7 @@ async function dialMinutes(page: Page, minutes: string) {
   await expect(field).toHaveValue(minutes);
 }
 
-test.describe('Journey 108 — schedule time entry', () => {
+test.describe('Journey 110 — schedule time entry', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForAppReady(page);


### PR DESCRIPTION
Follow-up to #1365.

The 108 → 110 rename committed without its content edit: `git add` was handed a stale pre-rename pathspec alongside the new one, which aborts the whole invocation, and the call had stderr redirected to `/dev/null` so nothing surfaced. `git mv` had already staged the rename, so the commit looked right and CI passed — leaving the file named `110-schedule-time-entry.spec.ts` while its docblock and `describe` still read "Journey 108", colliding again with #1363's `108-venue-frame-notice`.

Comment/label only; no test logic changes. Verified: lint, format:check, check-types clean.