### PR TITLE
fix(settings): open the language picker on the language actually in use

### DIFF
--- a/e2e/journeys/111-settings-language-preselect.spec.ts
+++ b/e2e/journeys/111-settings-language-preselect.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+
+/**
+ * Journey 111 — Settings must open on the language the interface is actually rendering.
+ *
+ * Reported symptom: opening Settings for the first time showed Arabic, and changing ANY other
+ * setting switched the whole interface to Arabic with no explanation.
+ *
+ * `resolveBootLanguage` passes `navigator.language` to `changeLanguage`, so `i18next.language` is
+ * region-tagged (`en-US`). Translations still resolve through `fallbackLng: 'en'` — the UI reads
+ * English and nothing looks wrong — but no manifest code equals `en-US`, so no option was marked
+ * selected and a `<select>` with nothing selected displays its first option. The manifest is
+ * alphabetical, so that was `ar`. `persistAll` then read the control's value on any save and wrote
+ * it as an EXPLICIT language choice before reloading.
+ *
+ * Playwright's default context locale is `en-US`, which is exactly the reproducing condition.
+ */
+
+const LANGUAGE_SELECT = '#language select, select#language';
+
+/**
+ * The live CFS manifest, served in its real alphabetical order. Stubbed because the preview server
+ * has no CFS behind it: without this the picker renders a SINGLE option (`en`, the bundled locale
+ * i18next already holds), and a one-option select reads `en` whether or not the matching rule is
+ * correct — the assertions below would pass against the very bug they exist to catch.
+ */
+const MANIFEST = {
+  locales: [
+    { code: 'ar', nativeLabel: 'العربية' },
+    { code: 'cs', nativeLabel: 'Čeština' },
+    { code: 'de', nativeLabel: 'Deutsch' },
+    { code: 'en', nativeLabel: 'English' },
+    { code: 'es', nativeLabel: 'Español' },
+    { code: 'fr', nativeLabel: 'Français' },
+    { code: 'hr', nativeLabel: 'Hrvatski' },
+    { code: 'pt-BR', nativeLabel: 'Português (Brasil)' },
+    { code: 'zh-CN', nativeLabel: '简体中文' },
+  ],
+};
+
+async function seedAndOpenSettings(page: Page): Promise<void> {
+  await page.route('**/i18n/manifest*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MANIFEST) }),
+  );
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page);
+  await page.evaluate(() => localStorage.clear());
+
+  // Direct IDB write (journey 81's pattern) so the /settings goto isn't overridden by dev.load.
+  const tournamentId = await page.evaluate(async () => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      drawProfiles: [{ eventName: 'Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      participantsProfile: { scaledParticipantsCount: 8 },
+      tournamentName: 'E2E Settings Language',
+      nonRandom: 1,
+      setState: true,
+    });
+    await dev.tmx2db.addTournament(tournamentRecord);
+    return tournamentRecord.tournamentId as string;
+  });
+
+  await page.goto(`/#/tournament/${tournamentId}/settings`);
+  await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
+}
+
+test.describe('Journey 111 — settings language preselect', () => {
+  test('opens on English rather than the first option in the list', async ({ page }) => {
+    await seedAndOpenSettings(page);
+
+    // The reproducing condition, asserted rather than assumed: the app is running a region-tagged
+    // language that appears nowhere in the locale manifest.
+    const active = await page.evaluate(
+      () => (globalThis as any).dev?.i18next?.language ?? document.documentElement.lang,
+    );
+    expect(active).toMatch(/^en/);
+
+    const select = page.locator(LANGUAGE_SELECT).first();
+    await expect(select).toBeVisible({ timeout: 10_000 });
+
+    // Control: the picker must actually be offering the full list, with Arabic first. Without this
+    // the value assertion below is vacuous — a single-option select reads 'en' regardless.
+    const options = await select.locator('option').evaluateAll((els) => els.map((el: any) => el.value));
+    expect(options.length).toBeGreaterThan(1);
+    expect(options[0]).toBe('ar');
+
+    // The regression: this read 'ar', because nothing was selected and Arabic sorts first.
+    await expect(select).toHaveValue('en');
+  });
+
+  test('changing an unrelated setting does not switch the interface language', async ({ page }) => {
+    await seedAndOpenSettings(page);
+
+    expect(await page.evaluate(() => document.documentElement.lang)).toMatch(/^en/);
+    expect(await page.evaluate(() => document.documentElement.dir)).toBe('ltr');
+
+    // Toggle something with nothing to do with language. Before the fix this persisted the language
+    // the control happened to be showing — Arabic — as an explicit choice, and reloaded into it.
+    // `saveLocal` is deliberately chosen: it persists through the same `persistAll` path but is not
+    // one of the settings that legitimately triggers a reload, so any reload here is the bug.
+    // The input itself is visually hidden by `is-checkradio`, so drive its label as a user would.
+    const toggle = page.locator('#tournamentSettings label[for="saveLocal"]').first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await toggle.click();
+    await page.waitForTimeout(1200); // a reload, if one is coming, happens well inside this
+
+    await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
+
+    // RTL is the loudest tell: Arabic would flip the document direction.
+    expect(await page.evaluate(() => document.documentElement.dir)).toBe('ltr');
+    expect(await page.evaluate(() => document.documentElement.lang)).toMatch(/^en/);
+    await expect(page.locator(LANGUAGE_SELECT).first()).toHaveValue('en');
+
+    // And nothing was recorded as a deliberate language choice.
+    const stored = await page.evaluate(() => {
+      const raw = localStorage.getItem('tmx.settings') ?? localStorage.getItem('settings') ?? '{}';
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return {};
+      }
+    });
+    expect(stored.language ?? 'en').not.toBe('ar');
+  });
+});

--- a/src/pages/tournament/tabs/settingsTab/languageOptions.test.ts
+++ b/src/pages/tournament/tabs/settingsTab/languageOptions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLanguageOptions, resolveCurrentLanguageCode } from './languageOptions';
+
+/** The live CFS manifest, in the order it is served (alphabetical — which is why `ar` is first). */
+const MANIFEST = [
+  { code: 'ar', nativeLabel: 'العربية' },
+  { code: 'cs', nativeLabel: 'Čeština' },
+  { code: 'de', nativeLabel: 'Deutsch' },
+  { code: 'en', nativeLabel: 'English' },
+  { code: 'es', nativeLabel: 'Español' },
+  { code: 'fr', nativeLabel: 'Français' },
+  { code: 'hr', nativeLabel: 'Hrvatski' },
+  { code: 'pt-BR', nativeLabel: 'Português (Brasil)' },
+  { code: 'zh-CN', nativeLabel: '简体中文' },
+];
+
+const BUNDLED = new Set(['en']);
+
+const selectedValue = (options: Array<{ value: string; selected: boolean }>) =>
+  options.find((option) => option.selected)?.value;
+
+/**
+ * Reported by CA: Settings opened showing Arabic, and changing any unrelated setting switched the
+ * whole interface to it.
+ *
+ * `resolveBootLanguage` passes `navigator.language` to `changeLanguage`, so `i18next.language` is
+ * region-tagged (`en-US`). Translations still resolve through `fallbackLng: 'en'`, so the UI reads
+ * English and nothing looks wrong — but no manifest code equals `en-US`, so nothing was marked
+ * selected and the `<select>` fell through to its first option.
+ */
+describe('buildLanguageOptions', () => {
+  it('selects English when the browser reports a region-tagged en-US', () => {
+    const options = buildLanguageOptions(MANIFEST, BUNDLED, 'en-US');
+    expect(selectedValue(options)).toBe('en');
+    // the regression: nothing selected, so the control displayed options[0]
+    expect(options[0].value).toBe('ar');
+    expect(options[0].selected).toBe(false);
+  });
+
+  it('marks exactly one option selected', () => {
+    for (const current of ['en-US', 'en', 'fr-FR', 'pt-BR', 'cs', undefined]) {
+      const options = buildLanguageOptions(MANIFEST, BUNDLED, current);
+      expect(options.filter((option) => option.selected)).toHaveLength(1);
+    }
+  });
+
+  it('keeps a genuinely region-specific locale rather than collapsing it to its base', () => {
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'pt-BR'))).toBe('pt-BR');
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'zh-CN'))).toBe('zh-CN');
+  });
+
+  it('falls back to the base language for any other region tag', () => {
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'fr-CA'))).toBe('fr');
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'de-AT'))).toBe('de');
+    // a Brazilian build of Portuguese asked for generically still lands somewhere sensible
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'pt'))).toBe('pt-BR');
+  });
+
+  it('falls back to English for a language that is not offered at all', () => {
+    expect(selectedValue(buildLanguageOptions(MANIFEST, BUNDLED, 'ja-JP'))).toBe('en');
+  });
+
+  it('prefers the native label so a speaker can recognise their own language', () => {
+    const options = buildLanguageOptions(MANIFEST, BUNDLED, 'en');
+    expect(options.find((option) => option.value === 'cs')?.label).toBe('Čeština');
+  });
+
+  it('still offers locales i18next holds when the manifest is unreachable', () => {
+    const options = buildLanguageOptions(undefined, new Set(['en', 'cs']), 'en-US');
+    expect(options.map((option) => option.value).sort((a, b) => a.localeCompare(b, 'en'))).toEqual(['cs', 'en']);
+    expect(selectedValue(options)).toBe('en');
+  });
+
+  it('returns nothing to select when there is nothing to offer', () => {
+    expect(buildLanguageOptions(undefined, new Set(), 'en-US')).toEqual([]);
+  });
+});
+
+describe('resolveCurrentLanguageCode', () => {
+  const AVAILABLE = MANIFEST.map((entry) => entry.code);
+
+  it('prefers an exact match over the base language', () => {
+    expect(resolveCurrentLanguageCode(AVAILABLE, 'pt-BR')).toBe('pt-BR');
+  });
+
+  it('tolerates the underscore form some platforms emit', () => {
+    expect(resolveCurrentLanguageCode(AVAILABLE, 'en_GB')).toBe('en');
+  });
+
+  it('is case-insensitive on the base language', () => {
+    expect(resolveCurrentLanguageCode(AVAILABLE, 'FR-fr')).toBe('fr');
+  });
+
+  it('answers undefined when nothing fits and English is not on offer', () => {
+    expect(resolveCurrentLanguageCode(['ar', 'cs'], 'ja-JP')).toBeUndefined();
+    expect(resolveCurrentLanguageCode([], 'en')).toBeUndefined();
+  });
+
+  it('handles a missing current language by falling back to English', () => {
+    expect(resolveCurrentLanguageCode(AVAILABLE, undefined)).toBe('en');
+  });
+});

--- a/src/pages/tournament/tabs/settingsTab/languageOptions.ts
+++ b/src/pages/tournament/tabs/settingsTab/languageOptions.ts
@@ -1,0 +1,99 @@
+/**
+ * Options for the Settings language picker.
+ *
+ * Extracted from `settingsGrid` so the matching rule is testable without a DOM. The rule is the
+ * whole point of this module: `i18next.language` is whatever was passed to `changeLanguage`, and
+ * `resolveBootLanguage` passes `navigator.language` — which is region-tagged on most browsers
+ * (`en-US`, not `en`). Translations still resolve through `fallbackLng`, so the UI reads correctly
+ * and nothing appears wrong, but an exact-equality match against the locale manifest finds nothing.
+ *
+ * A `<select>` with no selected option displays its first one. The manifest is alphabetical, so that
+ * was `ar` — and because `persistAll` reads the control's value on every save, changing an unrelated
+ * setting persisted Arabic as an explicit user choice and reloaded the app into it.
+ */
+
+/** Hardcoded display label for the bundled / always-present `en` locale. */
+const FALLBACK_LANGUAGES: Record<string, string> = {
+  en: 'English',
+};
+
+const DEFAULT_LANGUAGE = 'en';
+
+export interface LanguageOption {
+  value: string;
+  label: string;
+  selected: boolean;
+}
+
+export interface ManifestLocale {
+  code: string;
+  label?: string;
+  nativeLabel?: string;
+}
+
+/** `'en-US'` → `'en'`; `'en'` → `'en'`. Also tolerates the underscore form some platforms emit. */
+function baseLanguage(code: string): string {
+  return code.split(/[-_]/)[0].toLowerCase();
+}
+
+/**
+ * The available code that best represents `current`, or undefined when nothing fits.
+ *
+ * Exact match wins so a genuinely region-specific locale (`pt-BR`, `zh-CN`) keeps its identity.
+ * Otherwise the base language matches, which is what rescues `en-US` → `en`. `en` is the last
+ * resort because it is the bundled locale and what `fallbackLng` would have rendered anyway —
+ * returning nothing here is what let the control fall through to its first option.
+ */
+export function resolveCurrentLanguageCode(available: string[], current?: string): string | undefined {
+  if (!available.length) return undefined;
+
+  if (current) {
+    const exact = available.find((code) => code === current);
+    if (exact) return exact;
+
+    const base = baseLanguage(current);
+    const byBase = available.find((code) => baseLanguage(code) === base);
+    if (byBase) return byBase;
+  }
+
+  return available.find((code) => code === DEFAULT_LANGUAGE);
+}
+
+/**
+ * Build the option list for the language control. Prefers the manifest's native labels (e.g.
+ * "Čeština") — the most self-evident way to recognise your own language in a settings list.
+ *
+ * Exactly one option is selected whenever the resolver can place the current language, so the
+ * control always opens on what the interface is actually rendering.
+ */
+export function buildLanguageOptions(
+  manifestLocales: ManifestLocale[] | undefined,
+  knownInI18next: Set<string>,
+  currentLanguage: string | undefined,
+): LanguageOption[] {
+  const seen = new Set<string>();
+  const out: Array<Omit<LanguageOption, 'selected'>> = [];
+
+  // Manifest is the primary source.
+  for (const entry of manifestLocales ?? []) {
+    if (seen.has(entry.code)) continue;
+    seen.add(entry.code);
+    out.push({ value: entry.code, label: entry.nativeLabel || entry.label || entry.code });
+  }
+
+  // Backstop: any locale i18next has loaded that wasn't in the manifest (e.g. CFS unreachable, but a
+  // prior session fetched the file and it's still in memory). Include them so the user can keep
+  // using them.
+  for (const code of knownInI18next) {
+    if (seen.has(code)) continue;
+    seen.add(code);
+    out.push({ value: code, label: FALLBACK_LANGUAGES[code] || code });
+  }
+
+  const resolved = resolveCurrentLanguageCode(
+    out.map((option) => option.value),
+    currentLanguage,
+  );
+
+  return out.map((option) => ({ ...option, selected: option.value === resolved }));
+}

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -4,6 +4,7 @@ import { getCachedFontCatalog, ensurePdfFontReady, PROVIDER_DEFAULT_FONT } from 
 import { connectSocket, connected, disconnectSocket } from 'services/messaging/socketIo';
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
 import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
+import { buildLanguageOptions, resolveCurrentLanguageCode } from './languageOptions';
 import { ensureLocaleCurrent, fetchManifest } from 'i18n/runtime-loader';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { getLoginState } from 'services/authentication/loginState';
@@ -48,60 +49,8 @@ const { SINGLES } = factoryConstants.eventConstants;
 
 const RATINGS_PANEL_BLUE = 'settings-panel panel-blue';
 
-// Hardcoded display labels for the bundled / always-present `en` locale.
-// Used as the last-resort fallback when the CFS manifest is unreachable
-// AND no other locales are loaded in i18next yet.
-const FALLBACK_LANGUAGES: Record<string, string> = {
-  en: 'English',
-};
-
-interface LanguageOption {
-  value: string;
-  label: string;
-  selected: boolean;
-}
-
-/** Build the radio-button options list for the language panel. Prefers the
- *  manifest's native labels (e.g. "Čeština" for cs). Falls back to whatever
- *  i18next already has loaded, then to the bundled-en label. */
-function buildLanguageOptions(
-  manifestLocales: Array<{ code: string; label?: string; nativeLabel?: string }> | undefined,
-  knownInI18next: Set<string>,
-  currentLanguage: string,
-): LanguageOption[] {
-  const seen = new Set<string>();
-  const out: LanguageOption[] = [];
-
-  // Manifest is the primary source. Use nativeLabel so the option reads in
-  // the speaker's own script (e.g. "Čeština", "العربية") — that's the most
-  // self-evident way to recognise your own language in a settings list.
-  for (const entry of manifestLocales ?? []) {
-    if (seen.has(entry.code)) continue;
-    seen.add(entry.code);
-    out.push({
-      value: entry.code,
-      label: entry.nativeLabel || entry.label || entry.code,
-      selected: currentLanguage === entry.code,
-    });
-  }
-
-  // Backstop: any locale i18next has loaded that wasn't in the manifest
-  // (e.g. CFS unreachable, but a prior session fetched the file and it's
-  // still in memory). Include them so the user can keep using them.
-  for (const code of knownInI18next) {
-    if (seen.has(code)) continue;
-    seen.add(code);
-    out.push({
-      value: code,
-      label: FALLBACK_LANGUAGES[code] || code,
-      selected: currentLanguage === code,
-    });
-  }
-
-  return out;
-}
-
 async function persistAll(
+  availableLanguages: string[],
   languageInputs: any,
   ratingInputs: any,
   scoringInputs: any,
@@ -135,15 +84,21 @@ async function persistAll(
   });
 
   const language = languageInputs.language.value;
-  const languageChanged = language !== i18next.language;
+  // Compare against the code the control was OPENED on, not `i18next.language` — those differ
+  // whenever the active language is region-tagged (`en-US` resolving to the `en` option), and
+  // comparing raw would report a change on every save and reload the app each time.
+  const languageChanged = language !== resolveCurrentLanguageCode(availableLanguages, i18next.language);
 
   if (activeScale) setActiveScale(activeScale);
 
   const assistantChanged = (displayInputs.assistant?.checked || false) !== previousAssistant;
 
-  // User explicitly picked a language here — mark as explicit so provider
-  // default-language no longer overrides on subsequent boots.
-  persistConfigToStorage({ language, languageExplicit: true });
+  // `languageExplicit` defeats the provider default on every subsequent boot, so it may only be set
+  // when the user actually chose a language here. Writing it unconditionally is what turned "changed
+  // an unrelated setting" into a permanent, silent switch to whichever option the control happened
+  // to be showing. An explicit choice made earlier is preserved.
+  const languageExplicit = languageChanged || !!loadSettings()?.languageExplicit;
+  persistConfigToStorage({ language, languageExplicit });
 
   if (languageChanged) {
     // Fetch + cache the new locale BEFORE reload so the post-reload boot
@@ -177,7 +132,9 @@ export async function renderSettingsGrid(
   let storageInputs: any;
   let displayInputs: any;
 
-  const persist = () => persistAll(languageInputs, ratingInputs, scoringInputs, storageInputs, displayInputs);
+  let availableLanguages: string[] = [];
+  const persist = () =>
+    persistAll(availableLanguages, languageInputs, ratingInputs, scoringInputs, storageInputs, displayInputs);
 
   const grid = document.createElement('div');
   grid.className = 'settings-grid';
@@ -191,6 +148,7 @@ export async function renderSettingsGrid(
   const manifest = await fetchManifest({ force: true });
   const knownInI18next = new Set(Object.keys(i18next.options?.resources || {}));
   const languageOptions = buildLanguageOptions(manifest?.locales, knownInI18next, i18next.language);
+  availableLanguages = languageOptions.map((option) => option.value);
 
   const languagePanel = document.createElement('div');
   languagePanel.className = RATINGS_PANEL_BLUE;


### PR DESCRIPTION
Opening Settings for the first time showed **Arabic**, and changing any unrelated setting switched the entire interface to it with no explanation.

## Root cause

`resolveBootLanguage` passes `navigator.language` to `changeLanguage`, so `i18next.language` is region-tagged — `en-US`, not `en`. Translations still resolve through `fallbackLng: 'en'`, so the UI reads English and **nothing appears wrong**. Measured against the installed i18next rather than assumed:

```text
after init   -> i18next.language = "en"
after en-US  -> i18next.language = "en-US"
t('hello')   -> "Hello"          # still English, so the UI looks fine
```

`buildLanguageOptions` marked an option selected with `currentLanguage === entry.code`. The live manifest is `ar, cs, de, en, es, fr, hr, pt-BR, zh-CN` — **none equals `en-US`** — so zero options were selected, and a `<select>` with nothing selected displays its first option. The manifest is alphabetical, so that was `ar`.

`renderOptions` honours `selected` correctly; the list simply never had one.

## The amplifier

`persistAll` read the control's value on every save and wrote `{ language, languageExplicit: true }` unconditionally. So changing an unrelated setting persisted Arabic **as a deliberate user choice** — which also defeats the provider default on every subsequent boot — and reloaded into it.

Anyone whose `navigator.language` carries a region tag absent from the manifest is affected: `en-US`, `en-GB`, `fr-FR`, `de-DE`, `es-ES`. `pt-BR` and `zh-CN` happen to match, which is part of why this survived.

## Changes

- Matching resolves **exact → base language → `en`**, so exactly one option is always selected. Exact-first keeps `pt-BR`/`zh-CN` from collapsing to a base that isn't offered.
- `languageChanged` compares against that resolved code, not raw `i18next.language` — otherwise selecting `en` while i18next holds `en-US` reads as a change and reloads on every save.
- `languageExplicit` is set only when the language actually changed; an earlier explicit choice is preserved.
- The rule moves to `languageOptions.ts` so it is testable without a DOM.

## Verification

lint, format:check, attr-audit, i18n-audit, check-types, build all clean. **154 files / 1712 tests.** Journeys 111 and 81 pass.

Falsified against a pre-fix state that type-checks **and lints clean** (an incoherent revert would fail the build instead of the assertion, which proves nothing):

| probe | result |
|---|---|
| unit, exact-equality matching restored | 8 of 13 fail |
| journey 111, full shipped behaviour restored | both fail — `Expected: "en"  Received: "ar"` |

The journey **stubs the CFS manifest on purpose**: the preview server has no CFS behind it, so the picker would otherwise render a single `en` option and read `en` whether or not the matching rule works — the assertions would have passed against the very bug they exist to catch. It asserts the full list is present with Arabic first *before* asserting the value.