### PR TITLE
fix: four stale-render defects in settings, schedule, demo eligibility and logout

### DIFF
--- a/e2e/journeys/108-venue-frame-notice.spec.ts
+++ b/e2e/journeys/108-venue-frame-notice.spec.ts
@@ -139,6 +139,39 @@ test.describe('Journey 108 — the venue-frame notice says when the clock is a g
     await expect(page.locator(EDIT_DATES_MARKER)).toHaveCount(1);
   });
 
+  // Regression, #1362 follow-up. The test BELOW this one sets the zone out of
+  // band and re-navigates, so it only ever exercised the path where the action
+  // bar is rebuilt from scratch — which is why it stayed green while the bug
+  // shipped. The reported failure is the in-place path: save from the notice's
+  // OWN modal, no navigation, and the pill outlived the save. Every clock on the
+  // page silently re-framed into the new zone while the footer still said the
+  // zone was unset, which reads as "Save did nothing".
+  test('goes away when the zone is saved from its own modal, without navigating', async ({ page }) => {
+    const tournamentId = await seedZonelessTournament(page);
+    await openGrid(page, tournamentId);
+    await expect(page.locator(NOTICE)).toBeVisible({ timeout: 10_000 });
+
+    await page.locator(NOTICE).click();
+    await expect(page.locator(EDIT_DATES_MARKER)).toHaveCount(1);
+
+    // The zone field arrives pre-filled with the browser-detected zone precisely
+    // so the TD can confirm with one click — so this is the reported gesture,
+    // not a shortcut around it.
+    await page.locator(MODAL).getByRole('button', { name: 'Save' }).click();
+
+    // Controls first: prove the save actually happened. Without these, a pill
+    // that vanished for any unrelated reason would satisfy the assertion below.
+    await expect(page.locator(MODAL)).toHaveCount(0, { timeout: 10_000 });
+    await expect
+      .poll(() => page.evaluate(() => dev.factory.tournamentEngine.getTournament().tournamentRecord.localTimeZone), {
+        timeout: 10_000,
+      })
+      .toBeTruthy();
+
+    // The load-bearing assertion: same bar instance, no re-navigation.
+    await expect(page.locator(NOTICE)).toHaveCount(0);
+  });
+
   test('goes away once the tournament carries a venue zone', async ({ page }) => {
     const tournamentId = await seedZonelessTournament(page);
     await openGrid(page, tournamentId);

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -9,6 +9,8 @@ export interface FeatureFlags {
   assistant: boolean;
   formatWizard: boolean;
   schedulePlan: boolean;
+  /** Linked Tournaments panel in the tournament settings tab. */
+  linkedTournaments: boolean;
   usePublishState: boolean;
   /** Demo-mode lockdown simulator (avatar menu). Off by default. */
   demoMode: boolean;
@@ -18,6 +20,7 @@ const defaults: FeatureFlags = {
   assistant: false,
   formatWizard: false,
   schedulePlan: false,
+  linkedTournaments: false,
   usePublishState: false,
   demoMode: false,
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1155,6 +1155,7 @@
       "minScheduleGridRows": "Minimum schedule grid rows",
       "minScheduleGridRowsError": "Must be a number between 1 and 100",
       "betaFeatures": "Beta features",
+      "linkedTournaments": "Linked Tournaments",
       "pdfPrinting": "PDF printing",
       "googleSheetsImport": "Google Sheets import",
       "topologyBuilder": "Topology builder",

--- a/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
@@ -73,6 +73,16 @@ export interface GridActionBar {
    * reflects the new state without rebuilding the bar. No-op without onTogglePublish.
    */
   setDatePublished: (published: boolean) => void;
+  /**
+   * Re-evaluate the venue-frame notice against the current tournament record.
+   *
+   * The notice is the one control in this bar whose own action removes it: the
+   * modal it opens sets `localTimeZone`, after which `buildVenueFrameNotice`
+   * returns null. Without this the pill outlived a successful save — the grid
+   * re-rendered in the new zone while the footer still said the zone was unset,
+   * which reads as "Save did nothing".
+   */
+  setVenueFrame: () => void;
 }
 
 export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
@@ -98,11 +108,19 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
   bar.appendChild(issuesSlot);
   setIssues(issues);
 
-  // Venue-frame notice — leftmost, and only when the tournament carries no time
-  // zone so every clock on this page is being read off the operator's device.
-  // Null (not an empty box) once a zone is set, so no flex gap is reserved.
-  const venueNotice = buildVenueFrameNotice(params.onVenueTimeZoneSet);
-  if (venueNotice) bar.appendChild(venueNotice);
+  // Venue-frame notice — only when the tournament carries no time zone, so every
+  // clock on this page is being read off the operator's device. Its own
+  // `display: contents` slot: null (not an empty box) once a zone is set, so no
+  // flex gap is reserved, and setVenueFrame can drop it in place once saved.
+  const venueSlot = document.createElement('div');
+  venueSlot.style.display = 'contents';
+  const setVenueFrame = (): void => {
+    venueSlot.replaceChildren();
+    const venueNotice = buildVenueFrameNotice(params.onVenueTimeZoneSet);
+    if (venueNotice) venueSlot.appendChild(venueNotice);
+  };
+  bar.appendChild(venueSlot);
+  setVenueFrame();
 
   bar.appendChild(buildMinCourtWidthStepper(minCourtWidth, onMinCourtWidthChange));
 
@@ -147,7 +165,7 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
     bar.appendChild(buildClearButton(bulkMode, onClearSchedule));
   }
 
-  return { element: bar, setIssues, setTimingAvailable, setDatePublished };
+  return { element: bar, setIssues, setTimingAvailable, setDatePublished, setVenueFrame };
 }
 
 // ── Order-of-play publish pill ──

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -344,6 +344,10 @@ export function renderGridView(
     // order) in the action bar's issues button without rebuilding the bar.
     gridActionBar?.setIssues(freshIssues);
     gridActionBar?.setTimingAvailable(hasCallTimingData());
+    // The venue-frame pill is removed by its own action — setting the zone from
+    // the notice's modal makes the notice obsolete, so it has to be re-evaluated
+    // on the same refresh that re-frames the clocks.
+    gridActionBar?.setVenueFrame();
     refreshActiveStrip(currentDate);
   }
   currentRefresh = refresh;

--- a/src/pages/tournament/tabs/settingsTab/linkedTournaments.ts
+++ b/src/pages/tournament/tabs/settingsTab/linkedTournaments.ts
@@ -98,8 +98,11 @@ async function dispatchUnlink(removeId: string, onDone: () => void): Promise<voi
 // ─── UI ───────────────────────────────────────────────────────────────────
 
 /** Full-width Settings panel listing linked tournaments with add/remove controls. */
+export const LINKED_TOURNAMENTS_PANEL_ID = 'linkedTournamentsPanel';
+
 export function buildLinkedTournamentsPanel(): HTMLElement {
   const panel = document.createElement('div');
+  panel.id = LINKED_TOURNAMENTS_PANEL_ID;
   panel.className = 'settings-panel panel-teal';
   panel.style.gridColumn = '1 / -1';
   void renderPanelContents(panel);

--- a/src/pages/tournament/tabs/settingsTab/renderSettingsTab.ts
+++ b/src/pages/tournament/tabs/settingsTab/renderSettingsTab.ts
@@ -1,5 +1,3 @@
-import { getUserContext } from 'services/authentication/getUserContext';
-import { buildLinkedTournamentsPanel } from './linkedTournaments';
 import { removeAllChildNodes } from 'services/dom/transformers';
 import { renderSettingsGrid } from './settingsGrid';
 
@@ -63,8 +61,4 @@ export function renderSettingsTab(): void {
   ensureSettingsStyles();
   removeAllChildNodes(settingsContent);
   void renderSettingsGrid(settingsContent);
-  // Linked tournaments is a provider-authenticated feature (fetches /provider/my-calendars).
-  // Only show it when logged in — otherwise the panel 401s and baseApi's interceptor logs the
-  // user out, which was breaking the settings tab for logged-out/local users.
-  if (getUserContext()) settingsContent.appendChild(buildLinkedTournamentsPanel());
 }

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -1,11 +1,13 @@
 import { isDesktopNotificationsEnabled, setDesktopNotificationsEnabled } from 'services/notifications/osNotification';
 import { persistConfigToStorage, loadSettings, saveSettings } from 'services/settings/settingsStorage';
 import { getCachedFontCatalog, ensurePdfFontReady, PROVIDER_DEFAULT_FONT } from 'services/pdf/pdfFont';
+import { buildLinkedTournamentsPanel, LINKED_TOURNAMENTS_PANEL_ID } from './linkedTournaments';
 import { connectSocket, connected, disconnectSocket } from 'services/messaging/socketIo';
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
 import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
 import { buildLanguageOptions, resolveCurrentLanguageCode } from './languageOptions';
 import { ensureLocaleCurrent, fetchManifest } from 'i18n/runtime-loader';
+import { getUserContext } from 'services/authentication/getUserContext';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { getLoginState } from 'services/authentication/loginState';
 import { removeTournament } from 'services/apis/servicesApi';
@@ -64,6 +66,7 @@ async function persistAll(
     assistant: displayInputs.assistant?.checked || false,
     formatWizard: displayInputs.formatWizard?.checked || false,
     schedulePlan: displayInputs.schedulePlan?.checked || false,
+    linkedTournaments: displayInputs.linkedTournaments?.checked || false,
   });
 
   let scoringApproach: PreferencesConfig['scoringApproach'];
@@ -138,6 +141,22 @@ export async function renderSettingsGrid(
 
   const grid = document.createElement('div');
   grid.className = 'settings-grid';
+
+  // --- Linked tournaments (teal, full width) — first row of the grid ---
+  // Tournament-scoped, and provider-authenticated (it fetches /provider/my-calendars),
+  // so it stays hidden when logged out: the panel would 401 and baseApi's interceptor
+  // turns a 401 into a full logout, which was breaking the settings tab entirely.
+  const linkedEligible = !options?.excludeTournament && !!getUserContext();
+  const syncLinkedPanel = () => {
+    const existing = grid.querySelector(`#${LINKED_TOURNAMENTS_PANEL_ID}`);
+    const enabled = linkedEligible && featureFlags.get().linkedTournaments;
+    if (enabled && !existing) {
+      grid.prepend(buildLinkedTournamentsPanel());
+    } else if (!enabled && existing) {
+      existing.remove();
+    }
+  };
+  syncLinkedPanel();
 
   // --- Language panel (blue, 1 col) ---
   // Source the language list from the CFS manifest so newly-added locales
@@ -371,6 +390,19 @@ export async function renderSettingsGrid(
       field: 'schedulePlan',
       id: 'schedulePlan',
       onChange: persist,
+      checkbox: true,
+    },
+    {
+      label: t('modals.settings.linkedTournaments'),
+      checked: featureFlags.get().linkedTournaments || false,
+      field: 'linkedTournaments',
+      id: 'linkedTournaments',
+      // persistAll writes the flags synchronously before its first await, so the
+      // panel can be added/removed in place rather than forcing a tab re-render.
+      onChange: () => {
+        void persist();
+        syncLinkedPanel();
+      },
       checkbox: true,
     },
   ]);

--- a/src/services/authentication/loginState.ts
+++ b/src/services/authentication/loginState.ts
@@ -16,6 +16,7 @@ import { clearUserContext, fetchUserContext } from './getUserContext';
 import { clearActiveProvider } from 'services/provider/providerState';
 import { validateToken } from 'services/authentication/validateToken';
 import { resetLocalCalendar } from 'services/storage/localCalendar';
+import { contentEquals } from 'services/transitions/screenSlaver';
 import { disconnectSocket } from 'services/messaging/socketIo';
 import { refreshAccessToken } from 'services/apis/baseApi';
 import { tournamentEngine } from 'services/factory/engine';
@@ -108,7 +109,8 @@ export function logOut(): void {
     .then(() => resetLocalCalendar())
     .catch((err) => {
       console.error('[auth] failed to clear provider-bound tournaments on logout', err);
-    });
+    })
+    .finally(redrawTournamentsListAfterWipe);
   // Stop the staleness timer so a leftover scheduled check can't fire after
   // logout and toast a "Missing tournamentRecord" error for a local-only
   // tournament that was never on the server.
@@ -116,6 +118,32 @@ export function logOut(): void {
   context.matchUpFilters = {};
   context.router?.navigate(`/${TMX_TOURNAMENTS}/logout`);
   styleLogin(false);
+}
+
+/**
+ * Re-read the tournaments list once the logout IDB wipe has landed.
+ *
+ * `logOut` navigates synchronously, and with the identity gone the list falls
+ * back to reading local IndexedDB (`createTournamentsTable` → `fromLocalDb`).
+ * That render happens while `deleteProviderBoundTournaments` +
+ * `resetLocalCalendar` are still in flight, so the departing user's cached
+ * provider-bound tournaments — including any picked up while impersonating —
+ * paint for whoever is at the browser next. The wipe does complete; nothing
+ * re-reads it, which is why the stale rows persist until a manual reload.
+ *
+ * Runs on `finally`: a failed wipe still needs the list re-read, because the
+ * synchronous identity clears above already changed what the list may show.
+ *
+ * Dynamically imported — `createTournamentsTable` imports `getLoginState` from
+ * this module, so a static import would close a cycle.
+ */
+function redrawTournamentsListAfterWipe(): void {
+  if (!contentEquals(TMX_TOURNAMENTS)) return;
+  void import('components/tables/tournamentsTable/createTournamentsTable')
+    .then((m) => m.createTournamentsTable())
+    .catch(() => {
+      /* non-fatal — the next navigation re-reads the list anyway */
+    });
 }
 
 export function logIn({

--- a/src/services/demoMode/demoEligibility.test.ts
+++ b/src/services/demoMode/demoEligibility.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { featureFlags } from 'config/featureFlags';
+import { context } from 'services/context';
 
 vi.mock('services/authentication/tokenManagement', () => ({ getToken: () => mockToken }));
 
@@ -13,20 +14,41 @@ function tokenWithRoles(roles: string[]): string {
 describe('isDemoEligible', () => {
   beforeEach(() => {
     mockToken = undefined;
+    context.provider = undefined;
     featureFlags.set({ demoMode: true });
   });
-  afterEach(() => featureFlags.reset());
+  afterEach(() => {
+    featureFlags.reset();
+    context.provider = undefined;
+  });
 
-  it('is off unless the beta flag is on', async () => {
+  // The flag is the opt-in for a *provider-bearing* session. A session with no
+  // provider is the demo, so it does not wait for a flag nothing can set.
+  it('is available to an anonymous session even with the beta flag off', async () => {
     const { isDemoEligible } = await import('./demoEligibility');
     featureFlags.set({ demoMode: false });
-    expect(isDemoEligible()).toBe(false);
+    expect(isDemoEligible()).toBe(true);
   });
 
   it('is available to an anonymous session', async () => {
     const { isDemoEligible } = await import('./demoEligibility');
     mockToken = undefined;
     expect(isDemoEligible()).toBe(true);
+  });
+
+  // An impersonation handoff can seat a provider without a token; that session
+  // carries a white label the overlay would contradict.
+  it('is NOT available to a tokenless session carrying an impersonated provider', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    context.provider = { organisationId: 'p1', organisationName: 'P', organisationAbbreviation: 'P' };
+    expect(isDemoEligible()).toBe(false);
+  });
+
+  it('requires the beta flag for a super-admin', async () => {
+    const { isDemoEligible } = await import('./demoEligibility');
+    featureFlags.set({ demoMode: false });
+    mockToken = tokenWithRoles(['superadmin', 'client']);
+    expect(isDemoEligible()).toBe(false);
   });
 
   it('is available to a super-admin', async () => {

--- a/src/services/demoMode/demoEligibility.ts
+++ b/src/services/demoMode/demoEligibility.ts
@@ -5,24 +5,49 @@
  * without `demoState` needing to import `loginState` back.
  *
  * Deliberately NOT offered to an ordinary provider member on a live provider:
- * one stray click and they file a support ticket saying TMX is broken. Requires
- * the beta flag AND either an anonymous session or a super-admin.
+ * one stray click and they file a support ticket saying TMX is broken.
+ *
+ * ## Why "no provider" is the default-on case
+ *
+ * A session with no provider — no token and no impersonation — has nothing for
+ * demo mode to misrepresent: no white label to contradict, no server-side
+ * permission set for the overlay to shadow, and no support desk that will be
+ * asked why TMX "broke". That session IS the demo, and it is the only audience
+ * this drawer was ever built for.
+ *
+ * Gating it on `featureFlags.demoMode` made the drawer unreachable for exactly
+ * that audience, because nothing in TMX ever writes that flag — no settings
+ * control, no URL param, no provider default. The flag survives as the opt-in
+ * for the *other* case: a super-admin demonstrating from inside a real,
+ * provider-bearing session.
  */
-import { clearDemoOverlay as clearOverlay } from './demoState';
 import { getToken } from 'services/authentication/tokenManagement';
+import { clearDemoOverlay as clearOverlay } from './demoState';
 import { featureFlags } from 'config/featureFlags';
+import { context } from 'services/context';
 
 export { clearDemoOverlay } from './demoState';
 
 export function isDemoEligible(): boolean {
+  // Decode the raw token rather than reading the resolved login state: this
+  // module is imported BY loginState, and reading it back would be a cycle.
+  // It also keeps a future identity mask from hiding the menu item that turns
+  // the mask off. `context.provider` is read for the same reason — it is the
+  // impersonation slot, and `providerState` imports `loginState`.
+  const raw = (() => {
+    try {
+      return getToken();
+    } catch {
+      return undefined;
+    }
+  })();
+
+  // Anonymous AND unimpersonated — the local-only evaluation session. On by
+  // default; the flag is not consulted because nothing can set it.
+  if (!raw) return !context.provider;
+
   if (!featureFlags.get().demoMode) return false;
   try {
-    // Decode the raw token rather than reading the resolved login state: this
-    // module is imported BY loginState, and reading it back would be a cycle.
-    // It also keeps a future identity mask from hiding the menu item that turns
-    // the mask off.
-    const raw = getToken();
-    if (!raw) return true; // anonymous / local-only session
     const payload = JSON.parse(atob(raw.split('.')[1] ?? ''));
     return !!payload?.roles?.includes('superadmin');
   } catch {

--- a/src/services/settings/settingsStorage.ts
+++ b/src/services/settings/settingsStorage.ts
@@ -20,6 +20,7 @@ export type TMXSettings = {
   assistant?: boolean;
   formatWizard?: boolean;
   schedulePlan?: boolean;
+  linkedTournaments?: boolean;
   /**
    * @deprecated — Reports tab has been promoted to production. The icon
    * is always visible; the flag is no longer read. Retained in the type
@@ -152,6 +153,7 @@ export function hydrateConfigFromStorage(): TMXSettings | null {
   if (settings.assistant !== undefined) flagsPatch.assistant = settings.assistant;
   if (settings.formatWizard !== undefined) flagsPatch.formatWizard = settings.formatWizard;
   if (settings.schedulePlan !== undefined) flagsPatch.schedulePlan = settings.schedulePlan;
+  if (settings.linkedTournaments !== undefined) flagsPatch.linkedTournaments = settings.linkedTournaments;
   if (Object.keys(flagsPatch).length) {
     featureFlags.set(flagsPatch);
   }
@@ -182,6 +184,7 @@ export function persistConfigToStorage(
     assistant: flags.assistant,
     formatWizard: flags.formatWizard,
     schedulePlan: flags.schedulePlan,
+    linkedTournaments: flags.linkedTournaments,
     ...extras,
   });
 }


### PR DESCRIPTION
Four defects reported in one sitting, all the same family: **UI state rendered once and never re-evaluated when the thing it describes changes.**

### 1. Linked Tournaments sat outside the settings grid

`renderSettingsTab` appended the panel to `#tournamentSettings` while `renderSettingsGrid` was still awaiting the locale manifest — so it landed as a *sibling* of `.settings-grid`, before the grid existed (hence rendering first). Outside a grid container its `grid-column: 1 / -1` is inert, and the 16px padding lives on `.settings-grid`, so it had none.

Panel construction moves into `settingsGrid` where every other panel is built, in a `display: contents` slot.

### 2. Linked Tournaments behind a beta flag

New `linkedTournaments` flag, persisted through `settingsStorage` like its neighbours. The checkbox adds/removes the panel in place — `persistAll` writes flags synchronously before its first `await`, so no reload or tab re-render.

### 3. The venue-frame notice outlived its own save

The notice is the one control in the grid action bar whose own action removes it. It was appended once at build time; `refresh()` (what `onVenueTimeZoneSet` calls) re-rendered the issues cluster, timing shortcut and grid — never the notice. A successful save silently re-framed every clock while the footer still said the zone was unset. Reads as "Save did nothing".

Now a slot with a `setVenueFrame` updater called from `refresh()`.

### 4. Logout showed the departing user's tournaments

`logOut` navigates synchronously; the IDB wipe is fire-and-forget. With identity cleared, `createTournamentsTable` falls back to reading local IndexedDB — while `deleteProviderBoundTournaments` and `resetLocalCalendar` are still in flight. Most visible after impersonate → exit → log out, since impersonated browsing seeds more provider-bound records first.

The wipe chain now ends in a redraw when the tournaments list is on screen. On `finally`, not `then`. UX correctness only — the server stays authoritative and the wipe always completed; the defect was the window before it.

### Also: demo mode was unreachable

`isDemoEligible` required `featureFlags.demoMode`, which **nothing in TMX ever writes**. Now default-on when there is no provider — that session has no white label to contradict and no permission set to shadow. The flag remains the opt-in for a super-admin demonstrating from inside a provider-bearing session.

> One consequence worth review: every logged-out visitor now sees a Demo Mode item in the avatar menu, not only demo users.

## Verification

Full TMX CI gate green, each exit code read directly (not through a pipe): `lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci`, `check-types`, `test --run` (154 files / 1714 tests).

`i18n-audit` caught a new hardcoded label mid-review and failed the build; fixed with a real key rather than a baseline update. Red-then-green on that detector.

**Journeys** (local-only — PR CI never runs `e2e/journeys/`): 108, 81, 111 — 8 passed.

Journey 108 already covered the venue-notice surface and **stayed green through the bug**: its existing "goes away once the tournament carries a venue zone" test sets the zone out of band and re-navigates, so it only ever exercised the rebuild path. Added the in-place case, with controls asserting the modal closed and the record carries a zone so a pill vanishing for an unrelated reason cannot satisfy it.

**Falsified:** reverting `gridView`'s `setVenueFrame()` call (revert compiles — `check-types` and `lint` both exit 0 first) fails the new test three times on `venue-frame-notice` count `1 ≠ 0`, while the other four stay green.