### PR TITLE
chore(deps): bump published deps to 6.33.0 / 3.15.2 / 0.8.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.19.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.15.1",
+    "courthive-components": "3.15.2",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",
@@ -133,14 +133,14 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.20",
+    "pdf-factory": "0.8.21",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.32.0",
+    "tods-competition-factory": "6.33.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
| package | from | to |
|---|---|---|
| `tods-competition-factory` | 6.32.0 | **6.33.0** |
| `courthive-components` | 3.15.1 | **3.15.2** |
| `pdf-factory` | 0.8.20 | **0.8.21** |

**`package.json` only, and that is not an oversight.** TMX's lockfile records the `link:../` overrides rather than npm versions, so a pin change leaves it untouched. These pins are what **CI and production** resolve, since both strip the overrides — the local build is unaffected either way.

TMX was also a factory **minor** behind everything else in the ecosystem, which the overrides had been hiding locally.

## Verification

`lint`, `format:check`, `check-types`, `attr-audit --ci`, `i18n-audit --ci` and **154 files / 1714 tests** all green.

Both audits print advisory output and **exit 0** — checked against `main` too, so the findings are pre-existing and unrelated to a version bump.