### PR TITLE
fix(settings): make the Linked Tournaments beta toggle do something

### DIFF
--- a/e2e/journeys/112-settings-linked-tournaments-toggle.spec.ts
+++ b/e2e/journeys/112-settings-linked-tournaments-toggle.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, loginAsSuperAdmin, resetState, waitForAppReady } from '../helpers/dev-bridge';
+
+/**
+ * Journey 112 — the Linked Tournaments beta toggle must actually do something.
+ *
+ * Regression (#1370): the toggle appeared to do nothing anywhere. Everything around it
+ * worked — the change event fired, the flag persisted to `tmx_settings`, `syncLinkedPanel`
+ * ran, and forcing the gate true rendered the panel correctly. The single cause was the
+ * eligibility gate:
+ *
+ *   const linkedEligible = !options?.excludeTournament && !!getUserContext();
+ *
+ * `getUserContext()` is a SYNCHRONOUS read of a cache that only `/auth/me` populates, and
+ * `fetchUserContext()` is called fire-and-forget at login/boot. So the gate reads undefined
+ * whenever the grid renders before that request resolves — and because the value is captured
+ * by the `syncLinkedPanel` closure, a context arriving later never un-sticks it. The panel
+ * was unavailable for the life of the render.
+ *
+ * It is now `getLoginState()`: the same question (is there an authenticated user), answered
+ * by validating the JWT locally. No network, no race. Deliberately NOT `ensureUserContext()`,
+ * which would fire `/auth/me` for logged-out users — baseApi turns a 401 into a full logout,
+ * the cascade #1218 and #1370 were fixing.
+ *
+ * The second case below is the other half: the Beta Features panel renders on the global
+ * /settings page too, but the panel it controls is tournament-scoped, so the checkbox could
+ * never work there. An inert control is the same defect with a different cause.
+ */
+
+const PANEL = '#linkedTournamentsPanel';
+const CHECKBOX = '#linkedTournaments';
+const LABEL = 'label[for="linkedTournaments"]';
+
+async function seedTournament(page: any): Promise<string> {
+  return page.evaluate(async () => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      tournamentName: 'E2E Linked Tournaments Toggle',
+      drawProfiles: [{ eventName: 'Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+    });
+    await dev.tmx2db.addTournament(tournamentRecord);
+    return tournamentRecord.tournamentId as string;
+  });
+}
+
+test('logged in, the toggle shows and hides the Linked Tournaments panel', async ({ page }) => {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page);
+  await loginAsSuperAdmin(page);
+  const tournamentId = await seedTournament(page);
+
+  await page.goto(`/#/tournament/${tournamentId}/settings`);
+  await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
+
+  // Off by default.
+  await expect(page.locator(PANEL)).toHaveCount(0);
+
+  // `.is-checkradio` hides the real input and styles the label, so click the LABEL —
+  // that is the actual user gesture. Clicking the input would fail as "not visible".
+  await page.locator(LABEL).click();
+  await expect(page.locator(PANEL)).toHaveCount(1);
+  await expect(page.locator(CHECKBOX)).toBeChecked();
+
+  // …and back off again, in place, without a tab re-render.
+  await page.locator(LABEL).click();
+  await expect(page.locator(PANEL)).toHaveCount(0);
+});
+
+test('the toggle is not offered on the global settings page, where it could do nothing', async ({ page }) => {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page);
+  await loginAsSuperAdmin(page);
+
+  await page.goto('/#/settings');
+  await page.locator('.settings-panel').first().waitFor({ timeout: 15_000 });
+
+  // The Beta Features panel IS here — the control, so "checkbox absent" cannot pass
+  // by the panel simply having failed to render.
+  await expect(page.locator('#assistant')).toHaveCount(1);
+  await expect(page.locator(CHECKBOX)).toHaveCount(0);
+});
+
+test('logged out, the toggle does not expose the provider-authenticated panel', async ({ page }) => {
+  const calendarReqs: string[] = [];
+  page.on('request', (r) => {
+    if (r.url().includes('/provider/my-calendars')) calendarReqs.push(r.url());
+  });
+
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page); // logged out
+  await page.evaluate(() => localStorage.clear());
+  const tournamentId = await seedTournament(page);
+
+  await page.goto(`/#/tournament/${tournamentId}/settings`);
+  await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
+
+  await page.locator(LABEL).click();
+  await page.waitForTimeout(600);
+
+  // The panel 401s and baseApi turns that into a full logout, so it must stay hidden.
+  await expect(page.locator(PANEL)).toHaveCount(0);
+  expect(calendarReqs, `my-calendars was called while logged out: ${calendarReqs.join(', ')}`).toEqual([]);
+});

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -7,7 +7,6 @@ import { removeProviderTournament } from 'services/storage/removeProviderTournam
 import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
 import { buildLanguageOptions, resolveCurrentLanguageCode } from './languageOptions';
 import { ensureLocaleCurrent, fetchManifest } from 'i18n/runtime-loader';
-import { getUserContext } from 'services/authentication/getUserContext';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { getLoginState } from 'services/authentication/loginState';
 import { removeTournament } from 'services/apis/servicesApi';
@@ -146,7 +145,18 @@ export async function renderSettingsGrid(
   // Tournament-scoped, and provider-authenticated (it fetches /provider/my-calendars),
   // so it stays hidden when logged out: the panel would 401 and baseApi's interceptor
   // turns a 401 into a full logout, which was breaking the settings tab entirely.
-  const linkedEligible = !options?.excludeTournament && !!getUserContext();
+  // getUserContext() is a SYNCHRONOUS read of a cache that only `/auth/me` fills, so it
+  // returns undefined until that request resolves — and `fetchUserContext()` is called
+  // fire-and-forget at login/boot. This value is then captured by the syncLinkedPanel
+  // closure, so a context arriving later never un-sticks it: the panel stays unavailable
+  // for the life of the render and the beta checkbox appears to do nothing.
+  //
+  // getLoginState() answers the same question — is there an authenticated user — by
+  // validating the JWT locally. Synchronous, no network, no race. Deliberately NOT
+  // `await ensureUserContext()`: that would fire /auth/me for logged-out users, and
+  // baseApi's interceptor turns a 401 into a FULL LOGOUT, which is the exact cascade
+  // #1218/#1370 were fixing.
+  const linkedEligible = !options?.excludeTournament && !!getLoginState();
   const syncLinkedPanel = () => {
     const existing = grid.querySelector(`#${LINKED_TOURNAMENTS_PANEL_ID}`);
     const enabled = linkedEligible && featureFlags.get().linkedTournaments;
@@ -392,19 +402,27 @@ export async function renderSettingsGrid(
       onChange: persist,
       checkbox: true,
     },
-    {
-      label: t('modals.settings.linkedTournaments'),
-      checked: featureFlags.get().linkedTournaments || false,
-      field: 'linkedTournaments',
-      id: 'linkedTournaments',
-      // persistAll writes the flags synchronously before its first await, so the
-      // panel can be added/removed in place rather than forcing a tab re-render.
-      onChange: () => {
-        void persist();
-        syncLinkedPanel();
-      },
-      checkbox: true,
-    },
+    // Tournament-scoped: the panel it controls only exists inside a tournament's
+    // settings tab, so on the global /settings page (excludeTournament) the checkbox
+    // could never do anything. Offering an inert control is the same defect as the
+    // stuck gate above, just with a different cause — so it is not offered there.
+    ...(options?.excludeTournament
+      ? []
+      : [
+          {
+            label: t('modals.settings.linkedTournaments'),
+            checked: featureFlags.get().linkedTournaments || false,
+            field: 'linkedTournaments',
+            id: 'linkedTournaments',
+            // persistAll writes the flags synchronously before its first await, so the
+            // panel can be added/removed in place rather than forcing a tab re-render.
+            onChange: () => {
+              void persist();
+              syncLinkedPanel();
+            },
+            checkbox: true,
+          },
+        ]),
   ]);
 
   if (deviceConfig.get().isElectron) {


### PR DESCRIPTION
The toggle did nothing, **anywhere**.

## Everything around it was already correct

Instrumented in the browser before changing anything, rather than inferred from reading:

| | |
|---|---|
| change event fires | ✅ `changeFired=1` |
| flag persists to `tmx_settings` | ✅ `persisted=true` |
| `syncLinkedPanel` runs, no errors thrown | ✅ `errors=0` |
| panel renders when the gate is forced true | ✅ `panel:0→1` |
| **panel appears in normal use** | ❌ `panel:0→0` |

## The single cause

```ts
const linkedEligible = !options?.excludeTournament && !!getUserContext();
```

`getUserContext()` is a **synchronous read of a cache that only `/auth/me` populates**, and `fetchUserContext()` is called fire-and-forget at login and boot. So the gate reads `undefined` whenever the grid renders before that request resolves — and because the value is then captured by the `syncLinkedPanel` closure, **a context arriving later never un-sticks it**. The panel stays unavailable for the life of the render.

Now `getLoginState()`: the same question — is there an authenticated user — answered by validating the JWT locally. Synchronous, no network, no race, and already imported in this file for the delete-tournament gate.

**Deliberately not `await ensureUserContext()`**, which is the obvious fix and is wrong here: it would fire `/auth/me` for logged-out users, and baseApi's interceptor turns a 401 into a **full logout** — the cascade #1218 and #1370 were fixing. The logged-out guard is preserved and journey 81 still passes.

## Second half — same defect, different cause

The Beta Features panel renders on the global `/settings` page too, but the panel this flag controls is **tournament-scoped**, so there the checkbox could never do anything whatever the gate said. It is no longer offered in that context. Offering an inert control is the same bug as a stuck gate.

## Journey 112, with both halves falsified

| mutation | result |
|---|---|
| gate reverted to the unpopulated read | logged-in case **fails** |
| checkbox re-offered on the global page | second case **fails** |
| *(restored)* | **3 passed** |

The global-page test asserts `#assistant` **is** present as a control, so "checkbox absent" cannot pass by the whole panel having failed to render.

## One note for the next reader

`.is-checkradio` hides the real input and styles the label, so the test clicks the **label**. Clicking the input fails as *"element is not visible"* — which is what a first pass at reproducing this looks like, and is **not** itself evidence of a bug.

---

`lint`, `format:check`, `check-types`, **154 files / 1714 unit tests**, and journeys **81 / 111 / 112** all green.