### PR TITLE
chore(deps): pin pnpm to 11.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmx",
-  "packageManager": "pnpm@11.23.0",
+  "packageManager": "pnpm@11.24.0",
   "license": "MIT",
   "private": true,
   "version": "8.21.0",


### PR DESCRIPTION
Aligns this repo with factory, which moved to 11.24.0 in [#4713](https://github.com/CourtHive/factory/pull/4713) earlier today, and with the version renovate is now offering ecosystem-wide.

Part of a five-repo sweep (TMX, courthive-components, courthive-public, competition-factory-server, CourtHive.com). factory is already there and needs no change.

### Verification

Global `pnpm` is **11.9.0** while this repo resolves **11.24.0** — so corepack is genuinely honouring the pin, and the checks below exercised the new toolchain rather than a global binary that happened to match.

install --frozen-lockfile, lint, format:check, check-types, test --run (154 files / 1714 tests) — all exit 0.

`--frozen-lockfile` throughout: the pin moved with **no lockfile churn**.