### PR TITLE
fix(settings): stop offering the Linked Tournaments toggle where it cannot work

### DIFF
--- a/e2e/journeys/112-settings-linked-tournaments-toggle.spec.ts
+++ b/e2e/journeys/112-settings-linked-tournaments-toggle.spec.ts
@@ -102,10 +102,17 @@ test('logged out, the toggle does not expose the provider-authenticated panel', 
   await page.goto(`/#/tournament/${tournamentId}/settings`);
   await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
 
-  await page.locator(LABEL).click();
-  await page.waitForTimeout(600);
+  // The checkbox must not be OFFERED here either. A previous pass hid it only on the
+  // global settings page, leaving it visible-but-inert in a tournament while logged out —
+  // which is the same defect that pass set out to remove, and is what a user reported.
+  // It is now gated on the same `linkedEligible` value the panel uses.
+  await expect(page.locator(CHECKBOX)).toHaveCount(0);
 
-  // The panel 401s and baseApi turns that into a full logout, so it must stay hidden.
+  // The control: the Beta Features panel IS rendered, so "checkbox absent" cannot pass by
+  // the whole panel having failed to render while logged out.
+  await expect(page.locator('#assistant')).toHaveCount(1);
+
+  // …and the provider-authenticated panel stays away, since a 401 here becomes a full logout.
   await expect(page.locator(PANEL)).toHaveCount(0);
   expect(calendarReqs, `my-calendars was called while logged out: ${calendarReqs.join(', ')}`).toEqual([]);
 });

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -402,13 +402,15 @@ export async function renderSettingsGrid(
       onChange: persist,
       checkbox: true,
     },
-    // Tournament-scoped: the panel it controls only exists inside a tournament's
-    // settings tab, so on the global /settings page (excludeTournament) the checkbox
-    // could never do anything. Offering an inert control is the same defect as the
-    // stuck gate above, just with a different cause — so it is not offered there.
-    ...(options?.excludeTournament
-      ? []
-      : [
+    // Gated on `linkedEligible` — the SAME value the panel uses, deliberately.
+    //
+    // A previous pass gated the checkbox on `!excludeTournament` alone while the panel
+    // required `!excludeTournament && logged-in`. Two gates that can disagree, and they
+    // did: logged out inside a tournament the checkbox was still offered and still could
+    // not do anything, which is the exact defect that pass set out to remove. One
+    // condition, two consumers, so they cannot drift apart again.
+    ...(linkedEligible
+      ? [
           {
             label: t('modals.settings.linkedTournaments'),
             checked: featureFlags.get().linkedTournaments || false,
@@ -422,7 +424,8 @@ export async function renderSettingsGrid(
             },
             checkbox: true,
           },
-        ]),
+        ]
+      : []),
   ]);
 
   if (deviceConfig.get().isElectron) {


### PR DESCRIPTION
My previous pass was **half a fix**, and a user reported the other half.

| | gate |
|---|---|
| panel | `!excludeTournament && logged-in` |
| checkbox | `!excludeTournament` **only** |

Two gates that could disagree — and they did. Logged out inside a tournament the checkbox was still offered and still did nothing, which is the exact defect that pass set out to remove.

Both now read `linkedEligible`. **One condition, two consumers**, so they can't drift apart again.

Journey 112's logged-out case now asserts the checkbox is absent as well as the panel, with `#assistant` as the control so "absent" can't pass by the whole Beta Features panel having failed to render.

## What is deliberately NOT in here

The panel's own `fetchSiblings` still guards on the synchronous `getUserContext()`, so on a fresh load it can bail to `[]` and render *"No linked tournaments yet."* with a disabled button — the same unpopulated-cache race, one layer in.

I changed it to `await ensureUserContext()` and **measured the result**:

```
token BEFORE toggle: true
token AFTER toggle:  false      ← logged out
/auth/me calls:      1
```

Ticking the checkbox fired `/auth/me`, which 401s, and baseApi's interceptor turns any 401 into a **full logout**. Considerably worse than an empty panel, so it is reverted.

My justification had been that the render gate already established a valid session. That was wrong: a **locally-valid JWT is not a session the server accepts**. The real fix is to stop treating every 401 as a logout — a design decision beyond this change.

---

`lint`, `format:check`, `check-types`, **154 files / 1714 tests**, journeys **81 / 112 / 114** green.