### PR TITLE
fix(tables): stop Tabulator warning on every entries and matchUps render

### DIFF
--- a/e2e/journeys/115-tabulator-console-hygiene.spec.ts
+++ b/e2e/journeys/115-tabulator-console-hygiene.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, type Page } from '@playwright/test';
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { TournamentPage } from '../pages/TournamentPage';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 115 — Tabulator warns on the console, and only a browser can hear it.
+ *
+ * Two warnings were reaching production users' consoles on ordinary pages:
+ *
+ *   Invalid column definition option: lockVisible
+ *   Table Not Initialized - Calling the addFilter function before the table is
+ *   initialized may result in inconsistent behavior...
+ *
+ * Neither ever threw, and neither broke a feature: Tabulator keeps the value of
+ * an option it does not recognise, and its `initGuard` warns and then proceeds.
+ * That is exactly why they survived — the only symptom was console noise, so
+ * nothing failed and nothing forced the issue. A unit test can pin the column
+ * keys and the deferral (and does, in `columnDefinitionOptions.test.ts` and
+ * `filterApplyGuard.test.ts`), but only a real Tabulator instance in a real
+ * browser can prove the warnings themselves are gone.
+ *
+ * The second warning needs a filter that is ALREADY SET when a table is built,
+ * which is the restore path — so the filter is applied on one visit and the
+ * assertion is made on the next.
+ */
+
+const TABULATOR_WARNINGS = [/Invalid column definition option/i, /Table Not Initialized/i];
+
+/** Collect every console message for the life of the page. */
+function collectConsole(page: Page): string[] {
+  const messages: string[] = [];
+  page.on('console', (message) => messages.push(message.text()));
+  page.on('pageerror', (error) => messages.push(`pageerror: ${error.message}`));
+  return messages;
+}
+
+function tabulatorComplaints(messages: string[]): string[] {
+  return messages.filter((message) => TABULATOR_WARNINGS.some((pattern) => pattern.test(message)));
+}
+
+async function seedTournamentWithMatchUps(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      tournamentName: 'E2E Console Hygiene',
+      tournamentAttributes: { tournamentId: 'e2e-console-hygiene' },
+      participantsProfile: { scaledParticipantsCount: 16 },
+      drawProfiles: [{ eventName: 'Console Singles', drawSize: 16, drawType: 'SINGLE_ELIMINATION' }],
+    });
+    const record = dev.factory.tournamentEngine.getTournament().tournamentRecord;
+    await dev.tmx2db.addTournament(record);
+    return tournamentRecord.tournamentId as string;
+  });
+}
+
+test.describe('Journey 115 — Tabulator console hygiene', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    // Column visibility is a global field-keyed map in localStorage; start clean
+    // so the entries table builds from its own definitions.
+    await page.evaluate(() => localStorage.clear());
+  });
+
+  test('the entries table builds without Tabulator rejecting a column option', async ({ page }) => {
+    const messages = collectConsole(page);
+    const tournamentId = await seedTournamentWithMatchUps(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToEvents();
+    await tournament.eventsTable.locator('.tabulator-row').first().click();
+    await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
+    if (
+      !(await page
+        .locator(S.ENTRIES_VIEW)
+        .isVisible()
+        .catch(() => false))
+    ) {
+      await page.locator('#eventTabsBar').getByText('Entries').click();
+    }
+    await page.waitForSelector(S.ENTRIES_VIEW, { state: 'visible', timeout: 10_000 });
+
+    // The control. If the table never built, no column definition was ever
+    // validated and the assertion below would hold for the wrong reason —
+    // which is the failure mode of every "assert nothing happened" test.
+    await expect(
+      page.locator(`${S.ENTRIES_VIEW} .tabulator-row`).first(),
+      'the entries table must actually have rendered',
+    ).toBeVisible();
+    await expect(page.locator(`${S.ENTRIES_VIEW} .tabulator-col[tabulator-field="segment"]`)).toBeVisible();
+
+    expect(tabulatorComplaints(messages)).toEqual([]);
+  });
+
+  test('the Grouping and name columns stay out of the column-selector menu', async ({ page }) => {
+    // The marker moved from a bespoke `lockVisible` key onto `cssClass`, which is
+    // the behaviour that key existed for. If the move had silently stopped
+    // working the console would be clean and the feature quietly broken, so the
+    // warning fix is only half the story without this.
+    const tournamentId = await seedTournamentWithMatchUps(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToEvents();
+    await tournament.eventsTable.locator('.tabulator-row').first().click();
+    await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
+    if (
+      !(await page
+        .locator(S.ENTRIES_VIEW)
+        .isVisible()
+        .catch(() => false))
+    ) {
+      await page.locator('#eventTabsBar').getByText('Entries').click();
+    }
+    await page.waitForSelector(`${S.ENTRIES_VIEW} .tabulator-row`, { state: 'visible', timeout: 10_000 });
+
+    // The button is styled `font-size: 0` and revealed on header hover, so it has
+    // no hit box of its own — journey 57 opens the same menu the same way.
+    const menuColumn = page
+      .locator(`${S.ENTRIES_VIEW} .tabulator-col`)
+      .filter({ has: page.locator('.tabulator-header-popup-button') })
+      .first();
+    await menuColumn.hover();
+    await page.locator(`${S.ENTRIES_VIEW} .tabulator-header-popup-button`).first().click({ force: true });
+    const menu = page.locator('.tabulator-menu');
+    await expect(menu).toBeVisible();
+
+    // The control — the menu is populated, so an empty menu cannot pass this.
+    expect(await menu.locator('.tabulator-menu-item').count()).toBeGreaterThan(3);
+    await expect(menu).not.toContainText('Grouping');
+  });
+
+  test('a saved date filter is restored without filtering an unbuilt table', async ({ page }) => {
+    const messages = collectConsole(page);
+    const tournamentId = await seedTournamentWithMatchUps(page);
+
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToMatchUps();
+    await page.waitForSelector(`${S.TOURNAMENT_MATCHUPS} .tabulator-row`, { state: 'visible', timeout: 10_000 });
+
+    // Apply a date filter through the popover, so the NEXT render takes the
+    // restore path — the only path that calls addFilter at construction time.
+    await page.locator('#filterPopoverButton').click();
+    const dateRow = page.locator('.filter-popover-row').filter({ hasText: 'All dates' });
+    await expect(dateRow).toBeVisible();
+    await dateRow.locator('select').selectOption({ label: 'Today' });
+    await page.keyboard.press('Escape');
+
+    // Leave and come back: the matchUps tab re-renders, and every filter module
+    // is re-constructed against a table that has not finished building.
+    await tournament.navigateToEvents();
+    await page.waitForSelector('.tabulator-row', { state: 'visible', timeout: 10_000 });
+    const before = messages.length;
+    await tournament.navigateToMatchUps();
+    await page.waitForSelector(S.TOURNAMENT_MATCHUPS, { state: 'visible', timeout: 10_000 });
+
+    // The control: the return visit really did produce a fresh render, so
+    // "no warnings" is a statement about something that happened.
+    expect(messages.length, 'the second visit must have re-rendered').toBeGreaterThanOrEqual(before);
+    await expect(page.locator('#filterPopoverButton')).toHaveClass(/filter-active/);
+
+    expect(tabulatorComplaints(messages)).toEqual([]);
+  });
+});

--- a/src/components/tables/common/columnDefinitionOptions.test.ts
+++ b/src/components/tables/common/columnDefinitionOptions.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+
+vi.mock('i18n', () => ({ t: (key: string) => key }));
+vi.mock('services/context', () => ({ context: { columns: {} } }));
+// `courthive-components` touches `document` at import time (vanillajs-datepicker
+// calls `document.createRange()` at module scope) and the unit suite runs in node.
+// Nothing it provides is called here — formatters and editors are values in a
+// definition, never invoked — so any export can stand in as a no-op.
+vi.mock('courthive-components', () => ({ renderParticipant: vi.fn() }));
+
+import { LOCK_VISIBLE_CLASS, applyColumnVisibility, isLockedVisible } from './columnIsVisible';
+import { getUnifiedColumns } from '../eventsTable/unified/unifiedColumns';
+import { context } from 'services/context';
+
+/**
+ * Tabulator validates every key in a column definition against its own option
+ * list and warns on the console for anything it does not recognise:
+ *
+ *   Invalid column definition option: lockVisible
+ *
+ * It does not throw, and it does not drop the value — so a bespoke key works
+ * perfectly while producing a warning on every render, in production, forever.
+ * That is exactly how `lockVisible` survived: the feature was fine, only the
+ * console was wrong, so nothing ever forced the issue.
+ *
+ * The accepted set is read from the INSTALLED Tabulator rather than hard-coded,
+ * so bumping the dependency re-derives it instead of silently vindicating a key
+ * the new version no longer takes.
+ */
+function acceptedColumnOptions(): Set<string> {
+  const require = createRequire(import.meta.url);
+  const dist = require.resolve('tabulator-tables/dist/js/tabulator_esm.js');
+  const source = fs.readFileSync(dist, 'utf8');
+
+  // Base defaults, then every option the modules register onto the same list.
+  const base = source.match(/var defaultColumnOptions = \{([\s\S]*?)\n\};/);
+  if (!base) throw new Error('could not locate defaultColumnOptions in the installed Tabulator');
+  const keys = [...base[1].matchAll(/"([A-Za-z0-9_]+)":/g)].map((m) => m[1]);
+  const registered = [...source.matchAll(/registerColumnOption\(\s*["']([A-Za-z0-9_]+)["']/g)].map((m) => m[1]);
+
+  return new Set([...keys, ...registered]);
+}
+
+function collectKeys(columns: any[], into = new Set<string>()): Set<string> {
+  for (const column of columns) {
+    for (const key of Object.keys(column)) into.add(key);
+    if (Array.isArray(column.columns)) collectKeys(column.columns, into);
+  }
+  return into;
+}
+
+const entries = [
+  {
+    participant: { participantId: 'p1', participantName: 'Antelopes', teams: [{ teamId: 't1' }] },
+    participantId: 'p1',
+    drawPosition: 1,
+    seedNumber: 1,
+    ranking: 4,
+  },
+];
+
+describe('Tabulator column definition options', () => {
+  it('derives a non-trivial accepted set from the installed Tabulator', () => {
+    // The control. A failed regex would yield an empty set, and every
+    // assertion below would then pass by matching nothing.
+    const accepted = acceptedColumnOptions();
+    expect(accepted.size).toBeGreaterThan(100);
+    expect(accepted.has('cssClass')).toBe(true);
+    expect(accepted.has('lockVisible'), 'the key that caused this test to exist').toBe(false);
+  });
+
+  it('the unified entries columns use only options Tabulator accepts', () => {
+    const accepted = acceptedColumnOptions();
+    const columns = getUnifiedColumns({ entries, hasDrawDefinitions: true, sortState: undefined } as any);
+
+    expect(columns.length, 'a builder returning nothing would pass vacuously').toBeGreaterThan(5);
+
+    const used = [...collectKeys(columns)];
+    expect(used.length).toBeGreaterThan(10);
+    expect(used.filter((key) => !accepted.has(key))).toEqual([]);
+  });
+});
+
+describe('locked columns', () => {
+  it('recognises the marker, and only the marker', () => {
+    expect(isLockedVisible({ cssClass: LOCK_VISIBLE_CLASS })).toBe(true);
+    // Must survive being combined with real styling classes.
+    expect(isLockedVisible({ cssClass: `tmx-numeric ${LOCK_VISIBLE_CLASS}` })).toBe(true);
+    expect(isLockedVisible({ cssClass: 'tmx-numeric' })).toBe(false);
+    // A prefix match would wrongly lock any class sharing the stem.
+    expect(isLockedVisible({ cssClass: `${LOCK_VISIBLE_CLASS}-header` })).toBe(false);
+    expect(isLockedVisible({})).toBe(false);
+    expect(isLockedVisible(undefined)).toBe(false);
+  });
+
+  it('the entries table still locks the Grouping and name columns', () => {
+    const columns = getUnifiedColumns({ entries, hasDrawDefinitions: true, sortState: undefined } as any);
+    const locked = columns.filter(isLockedVisible).map((column: any) => column.field);
+    expect(locked).toEqual(['segment', 'participant']);
+  });
+
+  it('saved visibility never hides a locked column', () => {
+    const columns: any[] = [
+      { title: 'Grouping', field: 'segment', cssClass: LOCK_VISIBLE_CLASS, visible: true },
+      { title: 'Ranking', field: 'ranking', visible: true },
+    ];
+    // Both fields are marked hidden in saved state; only the unlocked one may yield.
+    (context as any).columns = { segment: false, ranking: false };
+
+    applyColumnVisibility(columns);
+
+    expect(columns[0].visible, 'a locked column ignores saved state').toBe(true);
+    expect(columns[1].visible, 'the control — an ordinary column obeys it').toBe(false);
+  });
+});

--- a/src/components/tables/common/columnIsVisible.ts
+++ b/src/components/tables/common/columnIsVisible.ts
@@ -20,6 +20,23 @@ export function saveColumnVisibility(): void {
 }
 
 /**
+ * Marks a column as always-visible: excluded from the headerMenu toggle list and
+ * never overridden by saved visibility state.
+ *
+ * Carried in `cssClass` rather than as a bespoke `lockVisible` key because
+ * Tabulator validates every column-definition key against its own option list
+ * and warns on the console for anything it does not recognise ("Invalid column
+ * definition option: lockVisible"). `cssClass` is a supported option, so the
+ * marker travels with the definition — which is where it belongs, since
+ * `getDefinition()` is the only handle the headerMenu has on a built column —
+ * without tripping the validator.
+ */
+export const LOCK_VISIBLE_CLASS = 'tmx-lock-visible';
+
+export const isLockedVisible = (def: any): boolean =>
+  typeof def?.cssClass === 'string' && def.cssClass.split(/\s+/).includes(LOCK_VISIBLE_CLASS);
+
+/**
  * Returns true unless the user has explicitly hidden this column.
  * Use for columns that default to visible.
  */
@@ -39,14 +56,14 @@ export const columnVisibility = (field, defaultVisible: boolean) =>
  * value is treated as the default; any value previously saved in
  * `context.columns` overrides it.
  *
- * Columns marked `lockVisible` are always shown: they are excluded from the
- * headerMenu and their visibility is never overridden by saved state (which
- * also shields them from field-name collisions across tables — `context.columns`
- * is a single global map keyed by field name).
+ * Locked columns are always shown: they are excluded from the headerMenu and
+ * their visibility is never overridden by saved state (which also shields them
+ * from field-name collisions across tables — `context.columns` is a single
+ * global map keyed by field name).
  */
 export function applyColumnVisibility(columns: any[]): any[] {
   for (const col of columns) {
-    if (!col.title || !col.field || col.lockVisible) continue;
+    if (!col.title || !col.field || isLockedVisible(col)) continue;
     if (col.field in context.columns) {
       col.visible = context.columns[col.field];
     }

--- a/src/components/tables/common/filters/eventFilter.ts
+++ b/src/components/tables/common/filters/eventFilter.ts
@@ -1,3 +1,4 @@
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { tournamentEngine } from 'services/factory/engine';
 import type { Event } from 'tods-competition-factory';
 import { context } from 'services/context';
@@ -37,10 +38,10 @@ export function getEventFilter(
     if (onChange) onChange();
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(eventFilter);
     eventFilterApplied = true;
+    whenTableBuilt(table, () => eventFilterApplied && table.addFilter(eventFilter));
   }
   const events = tournamentEngine.q.events() || [];
   const allEventsLabel = t('pages.participants.allEvents');

--- a/src/components/tables/common/filters/filterApplyGuard.test.ts
+++ b/src/components/tables/common/filters/filterApplyGuard.test.ts
@@ -27,14 +27,31 @@ import { getSexFilter } from './sexFilter';
  * by behaviour rather than by reading the source.
  */
 
+/**
+ * Models Tabulator's build lifecycle, because the filter modules now defer
+ * restoration until `tableBuilt`. A fake that is permanently "built" would let a
+ * regression back in silently; a fake that never builds would report the
+ * deferred restore as a filter that never applies. So it does both, in
+ * Tabulator's own order: `initialized` is set BEFORE `tableBuilt` dispatches.
+ */
 function fakeTable() {
   const added: any[] = [];
   const removed: any[] = [];
+  const handlers: Record<string, any[]> = {};
   return {
+    initialized: false,
+    on: vi.fn((event: string, fn: any) => {
+      handlers[event] = handlers[event] ?? [];
+      handlers[event].push(fn);
+    }),
     addFilter: vi.fn((fn: any) => added.push(fn)),
     removeFilter: vi.fn((fn: any) => removed.push(fn)),
     added,
     removed,
+    build() {
+      this.initialized = true;
+      for (const fn of handlers.tableBuilt ?? []) fn();
+    },
   };
 }
 
@@ -105,12 +122,58 @@ describe('filter modules do not remove a filter they never added', () => {
       matchUpFilters.status = 'complete';
       const table = fakeTable();
       const { setStatus } = getMatchUpStatusFilter(table as any);
+      table.build();
 
-      // Restoration applies the filter up front...
+      // Restoration applies the filter...
       expect(table.addFilter).toHaveBeenCalledTimes(1);
       setStatus(undefined);
       // ...so clearing it must remove it — the guard must not suppress this.
       expect(table.removeFilter).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Tabulator warns "Table Not Initialized - Calling the addFilter function
+     * before the table is initialized" for every filter restored at construction
+     * time, which is when these modules run. Deferring to `tableBuilt` clears
+     * that, but only if the filter still arrives — hence the pair.
+     */
+    it('restoration waits for tableBuilt rather than filtering an unbuilt table', () => {
+      matchUpFilters.status = 'complete';
+      const table = fakeTable();
+      getMatchUpStatusFilter(table as any);
+
+      expect(table.addFilter, 'nothing may touch the table before it is built').not.toHaveBeenCalled();
+
+      table.build();
+
+      expect(table.addFilter, 'and the saved filter must still be applied').toHaveBeenCalledTimes(1);
+    });
+
+    it('a table that is already built restores immediately', () => {
+      // Tabulator sets `initialized` before dispatching `tableBuilt`, so a module
+      // constructed inside that window would never see the event fire. Without
+      // the `initialized` branch this restores nothing and the saved filter is
+      // silently lost.
+      matchUpFilters.status = 'complete';
+      const table = fakeTable();
+      table.build();
+
+      getMatchUpStatusFilter(table as any);
+
+      expect(table.addFilter).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearing before the table builds does not let the deferred restore resurrect the filter', () => {
+      matchUpFilters.status = 'complete';
+      const table = fakeTable();
+      const { setStatus } = getMatchUpStatusFilter(table as any);
+
+      setStatus(undefined);
+      table.build();
+
+      // The deferred callback re-checks the applied flag; without that it would
+      // re-apply a filter the user had already cleared.
+      expect(table.addFilter).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -8,6 +8,7 @@
  *   - 'YYYY-MM-DD' — a specific date string
  *   - '__none__' — matchUps with no scheduledDate
  */
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { competitionEngine } from 'services/factory/engine';
 import { context } from 'services/context';
@@ -79,10 +80,10 @@ export function getMatchUpDateFilter(table: any): {
     }
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(dateFilter);
     dateFilterApplied = true;
+    whenTableBuilt(table, () => dateFilterApplied && table.addFilter(dateFilter));
   }
 
   // Resolve active dates: prefer tournamentInfo.activeDates, fall back to date range.

--- a/src/components/tables/common/filters/matchUpEventFilter.ts
+++ b/src/components/tables/common/filters/matchUpEventFilter.ts
@@ -2,6 +2,7 @@
  * MatchUp event filter for filterPopoverButton.
  * Filters matchUps by event (using eventId on row data).
  */
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { tournamentEngine } from 'services/factory/engine';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -36,10 +37,10 @@ export function getMatchUpEventFilter(
     }
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(eventFilter);
     eventFilterApplied = true;
+    whenTableBuilt(table, () => eventFilterApplied && table.addFilter(eventFilter));
   }
 
   // Caller can hand in a pre-fetched events list to share one q.events()

--- a/src/components/tables/common/filters/matchUpFlightFilter.ts
+++ b/src/components/tables/common/filters/matchUpFlightFilter.ts
@@ -2,6 +2,7 @@
  * MatchUp flight filter for filterPopoverButton.
  * Filters matchUps by flight (draw).
  */
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { tournamentEngine } from 'services/factory/engine';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -36,10 +37,10 @@ export function getMatchUpFlightFilter(
     }
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(flightFilter);
     flightFilterApplied = true;
+    whenTableBuilt(table, () => flightFilterApplied && table.addFilter(flightFilter));
   }
 
   // Caller can hand in a pre-fetched events list to share one q.events()

--- a/src/components/tables/common/filters/matchUpProfileFilter.ts
+++ b/src/components/tables/common/filters/matchUpProfileFilter.ts
@@ -6,6 +6,7 @@
  * Backs both the popover "Profile" section and click-to-filter on the
  * competitiveness bar; the token values match the bar's bucket keys.
  */
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { isWalkoverProfile } from './matchUpStatusPredicates';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -30,10 +31,10 @@ export function getMatchUpProfileFilter(table: any): {
     return rowData.competitiveProfile?.competitiveness === filterValue;
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(profileFilter);
     profileFilterApplied = true;
+    whenTableBuilt(table, () => profileFilterApplied && table.addFilter(profileFilter));
   }
 
   const updateFilter = (profile?: string) => {

--- a/src/components/tables/common/filters/matchUpStatusFilter.ts
+++ b/src/components/tables/common/filters/matchUpStatusFilter.ts
@@ -8,6 +8,7 @@
  * matchUpStatusPredicates for the shared classification.
  */
 import { classifyTodayBucket, popoverStatusPredicate, TODAY_STATUS_PREFIX } from './matchUpStatusPredicates';
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { context } from 'services/context';
 import { t } from 'i18n';
 
@@ -33,10 +34,10 @@ export function getMatchUpStatusFilter(table: any): {
     return popoverStatusPredicate(rowData, filterValue);
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(statusFilter);
     statusFilterApplied = true;
+    whenTableBuilt(table, () => statusFilterApplied && table.addFilter(statusFilter));
   }
 
   const updateFilter = (status?: string) => {

--- a/src/components/tables/common/filters/matchUpTeamFilter.ts
+++ b/src/components/tables/common/filters/matchUpTeamFilter.ts
@@ -4,6 +4,7 @@
  */
 import { participantConstants, eventConstants, unwrapOr } from 'tods-competition-factory';
 import { getTeamVs, getSideScore, getSide } from 'components/elements/getTeamVs';
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { removeAllChildNodes } from 'services/dom/transformers';
 import { tournamentEngine } from 'services/factory/engine';
 import { context } from 'services/context';
@@ -48,8 +49,8 @@ export function getMatchUpTeamFilter(
       ? rowData.individualParticipantIds.some((id: string) => teamMap[filterValue as string]?.includes(id))
       : true;
 
-  // Restore saved filter
-  if (filterValue) table.addFilter(teamFilter);
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
+  if (filterValue) whenTableBuilt(table, () => filterValue && table.addFilter(teamFilter));
 
   const updateFilter = (teamParticipantId?: string) => {
     if (filterValue) table.removeFilter(teamFilter);

--- a/src/components/tables/common/filters/matchUpTypeFilter.ts
+++ b/src/components/tables/common/filters/matchUpTypeFilter.ts
@@ -2,6 +2,7 @@
  * MatchUp type filter for filterPopoverButton.
  * Filters matchUps by type: singles, doubles, or team.
  */
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { eventConstants } from 'tods-competition-factory';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -21,10 +22,10 @@ export function getMatchUpTypeFilter(
 
   const typeFilter = (rowData: any): boolean => rowData.matchUpType === filterValue;
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(typeFilter);
     typeFilterApplied = true;
+    whenTableBuilt(table, () => typeFilterApplied && table.addFilter(typeFilter));
   }
 
   const updateFilter = (type?: string) => {

--- a/src/components/tables/common/filters/sexFilter.ts
+++ b/src/components/tables/common/filters/sexFilter.ts
@@ -1,3 +1,4 @@
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { genderConstants } from 'tods-competition-factory';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -29,10 +30,10 @@ export function getSexFilter(
     if (onChange) onChange();
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(sexFilter);
     sexFilterApplied = true;
+    whenTableBuilt(table, () => sexFilterApplied && table.addFilter(sexFilter));
   }
   const sexes = [MALE, FEMALE];
   const genders: Record<string, string> = {

--- a/src/components/tables/common/filters/teamFilter.ts
+++ b/src/components/tables/common/filters/teamFilter.ts
@@ -1,3 +1,4 @@
+import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { context } from 'services/context';
 import { t } from 'i18n';
 
@@ -30,10 +31,10 @@ export function getTeamFilter({
     if (onChange) onChange();
   };
 
-  // Restore saved filter
+  // Restore saved filter once the table is built (Tabulator warns if called sooner).
   if (filterValue) {
-    table.addFilter(teamFilter);
     teamFilterApplied = true;
+    whenTableBuilt(table, () => teamFilterApplied && table.addFilter(teamFilter));
   }
   const anyTeamLabel = t('pages.participants.anyTeam');
   const allTeams = {

--- a/src/components/tables/common/headerMenu.ts
+++ b/src/components/tables/common/headerMenu.ts
@@ -1,4 +1,4 @@
-import { saveColumnVisibility } from './columnIsVisible';
+import { isLockedVisible, saveColumnVisibility } from './columnIsVisible';
 import { context } from 'services/context';
 
 const ICON_ON = 'fa-toggle-on';
@@ -28,8 +28,8 @@ export const headerMenu = (displayTitles) => (_, column) => {
 
   for (const column of columns) {
     const def = column.getDefinition();
-    // `lockVisible` columns are always shown and excluded from the toggle menu.
-    if (def.title && !def.lockVisible) {
+    // Locked columns are always shown and excluded from the toggle menu.
+    if (def.title && !isLockedVisible(def)) {
       const visible = column.isVisible();
 
       const icon = document.createElement('i');

--- a/src/components/tables/common/whenTableBuilt.ts
+++ b/src/components/tables/common/whenTableBuilt.ts
@@ -1,0 +1,25 @@
+/**
+ * Run `fn` once a Tabulator instance has finished building.
+ *
+ * Filter modules are constructed synchronously, immediately after the table is
+ * created, but Tabulator builds asynchronously. Restoring a saved filter at that
+ * point calls `addFilter` before Tabulator is initialized, and Tabulator warns:
+ *
+ *   Table Not Initialized - Calling the addFilter function before the table is
+ *   initialized may result in inconsistent behavior...
+ *
+ * The call is not dropped — Tabulator's `initGuard` warns and then proceeds — so
+ * this is about honouring the documented contract (and clearing the console)
+ * rather than repairing a filter that never applied.
+ *
+ * Tabulator sets `initialized = true` *before* it dispatches `tableBuilt`, so
+ * there is a window in which subscribing alone would never fire. Hence the
+ * branch: run now if the table is already up, otherwise wait for the event.
+ */
+export function whenTableBuilt(table: any, fn: () => void): void {
+  if (table?.initialized) {
+    fn();
+  } else {
+    table?.on?.('tableBuilt', fn);
+  }
+}

--- a/src/components/tables/eventsTable/unified/unifiedColumns.ts
+++ b/src/components/tables/eventsTable/unified/unifiedColumns.ts
@@ -7,7 +7,7 @@ import { formatParticipant } from '../../common/formatters/participantFormatter'
 import { flightsFormatter } from '../../common/formatters/flightsFormatter';
 import { teamsFormatter } from '../../common/formatters/teamsFormatter';
 import { createGroupedSorter, SEGMENT_LABELS } from './segmentSorter';
-import { applyColumnVisibility } from '../../common/columnIsVisible';
+import { LOCK_VISIBLE_CLASS, applyColumnVisibility } from '../../common/columnIsVisible';
 import { numericEditor } from '../../common/editors/numericEditor';
 import { getRatingColumns } from '../../common/getRatingColumns';
 import { cellBorder } from '../../common/formatters/cellBorder';
@@ -109,7 +109,7 @@ export function getUnifiedColumns({ entries, hasDrawDefinitions, sortState }: Un
     {
       title: 'Grouping',
       field: 'segment',
-      lockVisible: true,
+      cssClass: LOCK_VISIBLE_CLASS,
       formatter: segmentFormatter,
       hozAlign: CENTER,
       headerHozAlign: CENTER,
@@ -139,7 +139,7 @@ export function getUnifiedColumns({ entries, hasDrawDefinitions, sortState }: Un
       sorter: (a: any, b: any) =>
         (a?.participantName ?? '').localeCompare(b?.participantName ?? '', undefined, { numeric: true }),
       field: 'participant',
-      lockVisible: true,
+      cssClass: LOCK_VISIBLE_CLASS,
       responsive: false,
       resizable: false,
       minWidth: 200,


### PR DESCRIPTION
Two Tabulator warnings were reaching production consoles on ordinary pages, reported by CA:

```
Invalid column definition option: lockVisible
Table Not Initialized - Calling the addFilter function before the table is initialized
may result in inconsistent behavior, Please wait for the `tableBuilt` event...
```

Neither ever threw and neither broke a feature — Tabulator keeps the value of a column
option it does not recognise, and its `initGuard` warns and then proceeds. Both were pure
console noise, which is exactly why they survived: nothing failed, so nothing forced the
issue.

Both turned out to be **classes, not instances**.

## `lockVisible`

TMX's own marker meaning "always visible, and keep this column out of the header toggle
menu". Tabulator 6.5.2 validates every definition key against a 136-entry accepted list
(base defaults plus every `registerColumnOption` call) and offers no way to exempt one key
without silencing genuine typos for the whole table — `debugInvalidOptions` is all or
nothing per table.

The marker moves onto `cssClass`, which Tabulator accepts. It still travels with the
definition, which is where it belongs: `getDefinition()` is the only handle `headerMenu`
has on a built column.

`displayTitle` was the other custom key in the code, but it is only ever *read* and never
set, so it never warned — checked rather than assumed.

## `addFilter` before `tableBuilt`

Shared by **ten** filter modules, all of which restore a saved filter synchronously at
construction, before Tabulator has built. Only one warning was visible because a module
warns only when it actually has a saved value to restore; the other nine are latent.

A shared `whenTableBuilt` helper defers all ten. It branches on `initialized` rather than
only subscribing, because Tabulator sets that flag *before* it dispatches `tableBuilt` —
a module constructed inside that window would otherwise never see the event and would
silently lose the saved filter. The deferred restore re-checks the applied flag, so
clearing a filter before the table builds cannot be undone by a restore arriving after.

## Tests — two layers, because neither alone is sufficient

- **`columnDefinitionOptions.test.ts`** derives the accepted option set from the
  *installed* Tabulator rather than hard-coding it, then asserts no unified entries column
  uses a key outside it. This pins the class: the next bespoke key fails a test instead of
  warning in production forever. Bumping Tabulator re-derives the set rather than
  vindicating a key the new version no longer takes.
- **`filterApplyGuard.test.ts`**'s fake table now models Tabulator's build lifecycle in its
  real order. A fake that was permanently "built" would have let this regression back in
  silently; one that never built would report the deferred restore as a filter that never
  applies.
- **Journey 115** asserts the warnings themselves are absent, which only a real browser can
  do, plus that the Grouping and name columns are still excluded from the column-selector
  menu — the behaviour the marker exists for. Console-clean-but-feature-broken would
  otherwise pass.

## Falsification

Every fix was reverted and the tests re-run:

| mutation | result |
|---|---|
| reintroduce `lockVisible: true` | journey 115 reports `Invalid column definition option: lockVisible` **verbatim, twice** (once per locked column); unit guard red |
| `whenTableBuilt` runs immediately | journey 115 reports `Table Not Initialized...` **verbatim**; unit lifecycle tests red |
| drop the `initialized` branch | "already built restores immediately" red |
| drop the applied re-check | "clearing before the table builds..." red |
| remove the `cssClass` marker | "still locks the Grouping and name columns" red |
| substring instead of class-list match | "recognises the marker, and only the marker" red |
| `applyColumnVisibility` ignores the lock | "saved visibility never hides a locked column" red |

Each turned exactly the intended assertion red with collected counts intact; restoring
returns green.

## Gate

`lint`, `check-types` (src + e2e + electron), `format:check`, `attr-audit`, `i18n-audit`
all clean; **1722 unit tests pass** (up from 1714); journey 115 green (3/3).