### PR TITLE
perf(schedule): build one rest evaluator per render pass, not one per card

### DIFF
--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -253,9 +253,41 @@ export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | nu
   };
 }
 
+/**
+ * The evaluator for the pass currently in progress, released as soon as the task
+ * that built it finishes.
+ *
+ * `makeRestEvaluator` is documented as being worth building once per pass, and the
+ * badge ticker duly builds one and reuses it across every card. The render did
+ * not: `renderRestBadge` is `renderCardExtra`, called once per card, and it reached
+ * `evaluateRest`, which built a whole evaluator per call. On a 149-matchUp
+ * tournament that was 149 event-map walks, 149 daily-limit reads and 149
+ * venue-frame resolutions — measured at 307 `getTournament` calls and ~235ms of a
+ * ~300ms schedule render, for work whose answer is identical every time.
+ *
+ * A microtask is the release boundary because it is the tightest one that still
+ * covers a whole synchronous render: every card drawn in one pass shares the
+ * evaluator, and nothing survives into the next task, so no caller can read state
+ * that a mutation has since replaced. It also gives the render the property the
+ * ticker already has deliberately — every badge in a pass agrees about what time
+ * it is, rather than a pass straddling a minute boundary and rendering two cards a
+ * minute apart.
+ */
+let passEvaluator: ReturnType<typeof makeRestEvaluator> | null = null;
+
+function evaluatorForPass(): ReturnType<typeof makeRestEvaluator> {
+  if (!passEvaluator) {
+    passEvaluator = makeRestEvaluator();
+    queueMicrotask(() => {
+      passEvaluator = null;
+    });
+  }
+  return passEvaluator;
+}
+
 /** Rest for one matchUp, resolved against current factory state and the current clock. */
 export function evaluateRest(matchUpId: string, viewedDate: string | null): RestResult {
-  return makeRestEvaluator()(matchUpId, viewedDate);
+  return evaluatorForPass()(matchUpId, viewedDate);
 }
 
 /** `134` → `'2h 14m'`; under an hour drops the hours part entirely. */

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRestPass.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRestPass.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted alongside the spies: `vi.mock` factories are lifted above module-level
+// consts, so a plain `const` here would be undefined inside them.
+const VIEWED_DATE = vi.hoisted(() => '2026-08-27');
+
+const engineWork = vi.hoisted(() => ({
+  allMatchUps: vi.fn(),
+  timingResolver: vi.fn(),
+  dailyLimits: vi.fn(),
+  venueFrame: vi.fn(),
+  analyze: vi.fn(),
+}));
+
+vi.mock('./schedule2DataCache', () => ({
+  getCachedAllMatchUps: (...args: any[]) => {
+    engineWork.allMatchUps(...args);
+    return { matchUps: [{ matchUpId: 'm1' }, { matchUpId: 'm2' }, { matchUpId: 'm3' }] };
+  },
+}));
+vi.mock('./scheduleTimingResolver', () => ({
+  makeTimingResolver: (...args: any[]) => {
+    engineWork.timingResolver(...args);
+    return () => undefined;
+  },
+}));
+vi.mock('services/factory/engine', () => ({
+  competitionEngine: {
+    getMatchUpDailyLimits: (...args: any[]) => {
+      engineWork.dailyLimits(...args);
+      return { matchUpDailyLimits: { total: 3 } };
+    },
+  },
+}));
+vi.mock('functions/venueTimeFrame', () => ({
+  resolveVenueFrame: (...args: any[]) => {
+    engineWork.venueFrame(...args);
+    return { timeZone: 'UTC' };
+  },
+  venueDayMinutes: () => 600,
+  venueCalendarDate: () => VIEWED_DATE,
+}));
+vi.mock('./participantRest', () => ({
+  analyzeParticipantRest: (params: any) => {
+    engineWork.analyze(params);
+    return { state: 'ok', matchUpId: params.matchUpId };
+  },
+}));
+vi.mock('i18n', () => ({ t: (key: string) => key }));
+
+import { evaluateRest, makeRestEvaluator } from './inspectorRest';
+
+/**
+ * `makeRestEvaluator` is documented as being worth building once per pass — it
+ * walks the tournament's events, reads daily limits from the engine and resolves
+ * the venue frame, none of which vary per matchUp.
+ *
+ * The 30-second badge ticker honoured that. The RENDER did not: `renderRestBadge`
+ * is `renderCardExtra`, called once per card, and it reached `evaluateRest`, which
+ * built a whole evaluator every call. Measured on a 149-matchUp tournament that
+ * was 307 `getTournament` calls and ~245ms of a ~305ms schedule render; sharing
+ * one evaluator per pass took the same render to ~63ms and 11 calls.
+ *
+ * Nothing was WRONG before — the answers were identical, which is precisely why
+ * it went unnoticed. So these tests are about call counts, and each one needs its
+ * control: a cache that never refreshed would satisfy "called once" perfectly.
+ */
+describe('the rest evaluator is built once per pass', () => {
+  beforeEach(() => {
+    for (const spy of Object.values(engineWork)) spy.mockClear();
+  });
+
+  const flushMicrotasks = () => Promise.resolve();
+
+  it('shares one evaluator across every call in a synchronous pass', () => {
+    for (const id of ['m1', 'm2', 'm3']) evaluateRest(id, VIEWED_DATE);
+
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(1);
+    expect(engineWork.dailyLimits).toHaveBeenCalledTimes(1);
+    expect(engineWork.venueFrame).toHaveBeenCalledTimes(1);
+    expect(engineWork.allMatchUps).toHaveBeenCalledTimes(1);
+
+    // The control. Sharing the SETUP must not share the ANSWER — every matchUp
+    // is still evaluated on its own, which a cache keyed too coarsely would break.
+    expect(engineWork.analyze).toHaveBeenCalledTimes(3);
+    expect(engineWork.analyze.mock.calls.map(([p]: any[]) => p.matchUpId)).toEqual(['m1', 'm2', 'm3']);
+  });
+
+  it('scales: the engine work does not grow with the number of matchUps', () => {
+    // The shape of the defect. One hundred cards used to mean one hundred event-map
+    // walks; a test that only ever asks for three could pass while still being linear.
+    for (let i = 0; i < 100; i++) evaluateRest('m1', VIEWED_DATE);
+
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(1);
+    expect(engineWork.analyze).toHaveBeenCalledTimes(100);
+  });
+
+  it('releases at the end of the task, so the next pass re-reads the engine', async () => {
+    evaluateRest('m1', VIEWED_DATE);
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+
+    // A cache that outlived its pass would freeze both the clock and the factory
+    // state — the badge counts up, and a mutation between renders must be seen.
+    evaluateRest('m1', VIEWED_DATE);
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves makeRestEvaluator itself unshared, which the ticker relies on', () => {
+    // `tick()` builds its own evaluator deliberately and must keep getting a fresh
+    // one — that is how every badge in a tick agrees about what time it is.
+    //
+    // A pass has to be OPEN for this to mean anything. Written first without the
+    // `evaluateRest` line, it passed against a `makeRestEvaluator` that returned
+    // the shared evaluator whenever one existed — because none ever did.
+    evaluateRest('m1', VIEWED_DATE);
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(1);
+
+    makeRestEvaluator();
+    expect(engineWork.timingResolver).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
> CA: *"I'm noticing that the schedule page is now slower to render than previously. Any
> optimizations possible?"*

Measured rather than guessed.

## The measurement

A throwaway Playwright harness wrapping the engine singleton (`competitionEngine` and
`tournamentEngine` are the same object) and attributing each call to its stack, on **4
draws / 149 matchUps / 20 courts across 2 venues**:

```
WALL 305ms | engine total 256ms
  307x   237ms  getTournament
    1x     9ms  allTournamentMatchUps
  149x     1ms  getMatchUpDailyLimits
```

`getTournament` alone was **~80% of the render**. By call site:

| calls | site |
|---|---|
| 149x | `makeTimingResolver → buildEventMap → getTournament` |
| 149x | `readDailyLimits → getMatchUpDailyLimits` |
| 149x | `resolveVenueFrame → q.tournament → getTournament` |

All three come from `makeRestEvaluator`, reached through `evaluateRest` — **once per
matchUp**. One per card, on a screen full of cards.

## The cause

`makeRestEvaluator`'s own docstring already argues for the opposite:

> *A rest evaluator valid for one pass, sharing the engine work across every matchUp it is
> asked about. … Paying for both once is fine for the Inspector's single matchUp and wrong
> for the catalog, where the badge ticker re-reads every visible card on a timer.*

The 30-second ticker (`tick()`) does exactly that — one evaluator, reused across every
badge. **The render did not.** `renderRestBadge` is the `renderCardExtra` callback, invoked
once per card, and it called `evaluateRest`, which constructs a whole evaluator per call.

The optimization was applied to the ticker that runs later, and not to the render that runs
first and for every card.

**Nothing was ever wrong.** All 149 evaluators computed the same answer from the same
state, which is precisely why this went unnoticed — the only symptom was time.

## The fix

`evaluateRest` now shares one evaluator for the pass in progress, released on a microtask.

A microtask is the tightest boundary that still spans a whole synchronous render: every
card in a pass shares the evaluator, and nothing survives into the next task, so no caller
can read state a mutation has since replaced. It also gives the render the property the
ticker has deliberately — every badge in a pass agrees about what time it is, rather than a
pass straddling a minute boundary and rendering two cards a minute apart.

`makeRestEvaluator` itself is untouched and still returns a fresh evaluator, which is what
the ticker depends on.

## Result

Same branch, same harness, same machine, three runs each:

| | wall | `getTournament` | engine time |
|---|---|---|---|
| before | 303 / 309 / 304 ms | 307 | ~261 ms |
| after | **65 / 61 / 63 ms** | **11** | **~27 ms** |

**~4.8× faster**, and no longer linear in matchUp count.

Consistent with "now slower than previously": participant rest is recent (#1326, #1346), so
none of this ran before it landed.

## Falsification

| mutation | result |
|---|---|
| revert to a per-call evaluator | "shares one evaluator" + "scales" red |
| never release the evaluator | "scales" + "releases at end of task" red |
| share `makeRestEvaluator` too | the ticker test red |

The ticker test was **vacuous when first written** — it called `makeRestEvaluator` twice
with no pass open, so a mutation returning the shared evaluator "whenever one exists"
passed against it happily. It now opens a pass first, and the trap is recorded in the file
so it is not re-set.

The "scales" test exists for the same reason: a test that only ever asks for three matchUps
can pass while the work is still linear.

## Gate

`lint`, `check-types`, `format:check` green. Four new unit tests. **20 schedule journeys
green** — 98 (participant rest), 106 (inspector actions), 29 (active strip), 102 (BYE holds
court).

**Unrelated, flagged not fixed:** `src/services/authentication/logOutRedraw.test.ts` is
another session's *uncommitted* file in this shared checkout. It fails in a full `pnpm test`
run and passes in isolation — with or without this change, and with a failure count that
varies between runs, so it is order-dependent. Left alone rather than edited.