### PR TITLE
test(auth): cover the logout tournaments-list race

### DIFF
--- a/e2e/journeys/113-logout-clears-provider-tournaments.spec.ts
+++ b/e2e/journeys/113-logout-clears-provider-tournaments.spec.ts
@@ -1,0 +1,174 @@
+import { initDevBridge, loginAsSuperAdmin, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { test, expect, type Page } from '@playwright/test';
+import { S } from '../helpers/selectors';
+
+/**
+ * Journey 113 — logging out must not leave the previous user's tournaments on screen.
+ *
+ * Regression (#1370). `logOut()` navigates SYNCHRONOUSLY:
+ *
+ *   void tmx2db.deleteProviderBoundTournaments().then(resetLocalCalendar)...  // async
+ *   context.router?.navigate(`/${TMX_TOURNAMENTS}/logout`);                   // runs first
+ *
+ * The navigate re-renders the tournaments list, and with the identity just cleared
+ * `createTournamentsTable` takes its `fromLocalDb` fallback — reading local IndexedDB while
+ * the wipe is still in flight. So the departing user's provider-bound tournaments paint for
+ * whoever is at the browser next, and nothing re-reads afterwards: they sit there until a
+ * manual reload. Impersonation makes it worse rather than causing it, because browsing an
+ * impersonated provider seeds more provider-bound records first — which is how CA hit it.
+ *
+ * ## What this journey does and does NOT prove — read before trusting it
+ *
+ * It covers the post-logout END STATE: the provider-bound tournament is gone from the list
+ * and from storage, and the unowned one survives. That is real regression value — it fails if
+ * anyone breaks the wipe's selectivity.
+ *
+ * It does **not** prove the redraw fix. Reverting `logOut`'s `.finally(redraw)` leaves this
+ * journey GREEN, which was established rather than assumed: the revert was made to compile
+ * (`check-types` and `lint` both exit 0 first) and the spec still passed. Locally the wipe
+ * simply wins the race, so the stale render never happens. Adding 600 ballast records did not
+ * open the window either, and counting anchor rebuilds does not separate the two states
+ * because the logout navigate alone produces several childList mutations.
+ *
+ * Recording that here rather than deleting the journey, and rather than tuning a threshold
+ * until it went red — a probe tuned to pass is not evidence. Covering the ORDERING needs a
+ * different instrument: export `redrawTournamentsListAfterWipe` (or the wipe chain) and unit
+ * test with `tmx2db` and the tournaments-table module mocked, asserting the table is rebuilt
+ * only after the wipe promise settles. That is deterministic; this is not.
+ *
+ * ## Why `/provider/my-calendars` is stubbed
+ *
+ * Logged in, `createTournamentsTable` takes its `userContext` branch and asks the server for
+ * calendars; only an empty/failed answer falls through to `fromLocalDb`, which is the path
+ * this journey is about. Against the preview server that request never resolves usefully — a
+ * first cut of this spec sat at zero rows with `tmx_local_calendar_migrated` still `null`,
+ * proving `fromLocalDb` had not run at all rather than having run and found nothing. Stubbing
+ * it to an empty calendar set makes the fallback deterministic; it is the same state a
+ * logged-in user with no server-side calendars is in.
+ *
+ * ## Why the local tournament is not decoration
+ *
+ * Asserting only that the provider-bound row disappears would pass if logout simply broke
+ * the list — an empty table satisfies "the row is gone" for entirely the wrong reason. The
+ * wipe is deliberately SELECTIVE: `isProviderBoundTournament` keys on
+ * `parentOrganisation.organisationId`, and demo/scratchpad tournaments without one are
+ * preserved (USER_TOURNAMENT_ACCESS_MODEL.md PR 11). So the local tournament is the control:
+ * it must still be there afterwards, and its presence is what proves the list re-read and
+ * rendered rather than collapsed.
+ */
+
+const PROVIDER_BOUND = 'E2E Provider Bound Tournament';
+const LOCAL_ONLY = 'E2E Local Only Tournament';
+const ROW = `${S.TOURNAMENTS_TABLE} .tabulator-row`;
+const AVATAR = '#login';
+const PROVIDER_ID = 'e2e-provider-1';
+const LOCAL_BUCKET = '__local__';
+
+/**
+ * Two tournaments in IndexedDB: one carrying `parentOrganisation.organisationId` (the shape
+ * the wipe targets) and one without (the shape it must preserve).
+ *
+ * Records are taken from `getTournament()` rather than the object `generateTournamentRecord`
+ * returned — under `setState: true` the engine holds its own copy, so post-generation
+ * mutations are not on the returned one. Journeys 102 and 108 document the same trap.
+ *
+ * **The calendar entry is not optional.** The list reads lightweight entries out of the
+ * `providers` store (`readLocalCalendarEntries`), NOT the tournaments table — so
+ * `addTournament` alone seeds a tournament the list cannot see, and the first attempt at this
+ * journey failed its own pre-condition with the Welcome view on screen. Production keeps the
+ * two in step via `maintainLocalCalendarEntry` on every save; this mirrors that exactly,
+ * bucketing by `parentOrganisation.organisationId` with `__local__` for the unowned record —
+ * which is also precisely the split the wipe acts on.
+ */
+async function seedBothTournaments(page: Page): Promise<void> {
+  await page.evaluate(
+    async ({ providerName, localName, providerId, localBucket }) => {
+      await dev.tmx2db.initDB();
+      const engine = dev.factory.tournamentEngine;
+      const mocks = dev.factory.mocksEngine;
+
+      const persist = async (tournamentRecord: any, bucket: string) => {
+        await dev.tmx2db.addTournament(tournamentRecord);
+        const entry = engine.getTournamentCalendarEntry({ tournamentRecord });
+        await dev.tmx2db.upsertCalendarEntry(bucket, entry);
+      };
+
+      mocks.generateTournamentRecord({ nonRandom: 1, setState: true, tournamentName: providerName });
+      const bound = engine.getTournament().tournamentRecord;
+      bound.parentOrganisation = { organisationId: providerId, organisationName: 'E2E Provider' };
+      await persist(bound, providerId);
+
+      mocks.generateTournamentRecord({ nonRandom: 1, setState: true, tournamentName: localName });
+      const local = engine.getTournament().tournamentRecord;
+      // The premise of the control. If a future mocksEngine default started stamping a
+      // parentOrganisation, this record would be wiped too and the control would silently
+      // stop controlling for anything.
+      if (local.parentOrganisation) throw new Error('local fixture carries a parentOrganisation');
+      await persist(local, localBucket);
+
+    },
+    { providerName: PROVIDER_BOUND, localName: LOCAL_ONLY, providerId: PROVIDER_ID, localBucket: LOCAL_BUCKET },
+  );
+}
+
+function row(page: Page, name: string) {
+  return page.locator(ROW).filter({ hasText: name });
+}
+
+test.describe('Journey 113 — logout clears the departing user tournaments from the list', () => {
+  test('the provider-bound tournament goes, the local one stays, without a reload', async ({ page }) => {
+    // Empty calendars ⇒ createTournamentsTable falls through to local IndexedDB, the branch
+    // logout lands on. Routed before the first navigation so no render can beat it.
+    await page.route('**/provider/my-calendars', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ calendars: [] }) }),
+    );
+
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+    await page.evaluate(() => localStorage.clear());
+
+    await loginAsSuperAdmin(page);
+    await seedBothTournaments(page);
+
+    // `reload`, NOT `goto('/#/tournaments')`. The app is already on that route, so Navigo
+    // treats the navigation as a no-op and the list is never rebuilt — the table would still
+    // be the one built at boot against an empty database. The first cut of this spec did
+    // exactly that and sat at zero rows with `tmx_local_calendar_migrated` still `null`,
+    // which is what proved the list had not re-read rather than having read and found nothing.
+    await page.reload();
+    await waitForAppReady(page);
+    await initDevBridge(page);
+
+    // Prove the fixture is NON-DEGENERATE before asserting anything about it: both rows must
+    // actually be on screen, or "the row is gone" afterwards means nothing. A list that never
+    // rendered would satisfy the post-condition trivially.
+    await page.locator(S.TOURNAMENTS_TABLE).waitFor({ timeout: 15_000 });
+    await expect(row(page, PROVIDER_BOUND)).toHaveCount(1, { timeout: 15_000 });
+    await expect(row(page, LOCAL_ONLY)).toHaveCount(1);
+
+    // The real gesture — logOut is not exposed on the dev bridge, and going through the
+    // avatar menu is what the user did.
+    await page.locator(AVATAR).click();
+    await page.getByText('Log out', { exact: true }).click();
+
+    // The load-bearing assertion. No reload, no second navigation: the list must re-read
+    // itself once the wipe lands. Before the fix this row survived indefinitely, because
+    // nothing re-read after the delete resolved.
+    await expect(row(page, PROVIDER_BOUND)).toHaveCount(0, { timeout: 15_000 });
+
+    // Control: the wipe is selective, and the list genuinely re-rendered rather than
+    // collapsing. Without this, a logout that emptied the table would pass the line above.
+    await expect(row(page, LOCAL_ONLY)).toHaveCount(1);
+
+    // And the wipe really reached storage — not merely the view. Distinguishes "the list
+    // stopped showing it" from "it is gone", which is the difference the next login sees.
+    const remaining = await page.evaluate(async () => {
+      const all = await dev.tmx2db.findAllTournaments();
+      return all.map((t: any) => t.tournamentName);
+    });
+    expect(remaining).toContain(LOCAL_ONLY);
+    expect(remaining).not.toContain(PROVIDER_BOUND);
+  });
+});

--- a/src/services/authentication/logOutRedraw.test.ts
+++ b/src/services/authentication/logOutRedraw.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * `logOut` must not let the tournaments list render the departing user's tournaments.
+ *
+ * The list falls back to reading local IndexedDB once identity is cleared, and `logOut`
+ * navigates SYNCHRONOUSLY while the IndexedDB wipe is still in flight. The fix chains a
+ * redraw onto the wipe so the list re-reads once the delete has landed.
+ *
+ * ## Why this is a unit test and not the journey
+ *
+ * Journey 113 covers the post-logout end state and is worth having, but it cannot prove this:
+ * with the fix reverted it stays GREEN, because locally the wipe simply wins the race and the
+ * stale render never happens (600 ballast records did not open the window, and counting anchor
+ * rebuilds does not separate the two states). What is being asserted here is an ORDERING, and
+ * an ordering is deterministic only when the wipe's completion is controlled — which is what
+ * the deferred promise below does.
+ *
+ * No production export was needed. `redrawTournamentsListAfterWipe` stays private on purpose:
+ * testing it directly would only exercise its `contentEquals` guard, and the guard was never
+ * the defect. The defect is whether the rebuild is *chained onto* the wipe or races it, and
+ * that is only visible from `logOut`.
+ */
+
+const deleteProviderBoundTournaments = vi.fn();
+const resetLocalCalendar = vi.fn();
+const createTournamentsTable = vi.fn();
+const navigate = vi.fn();
+let content = 'tournaments';
+
+vi.mock('services/storage/tmx2db', () => ({
+  tmx2db: { deleteProviderBoundTournaments: () => deleteProviderBoundTournaments() },
+}));
+vi.mock('services/storage/localCalendar', () => ({ resetLocalCalendar: () => resetLocalCalendar() }));
+vi.mock('components/tables/tournamentsTable/createTournamentsTable', () => ({
+  createTournamentsTable: () => createTournamentsTable(),
+}));
+vi.mock('services/transitions/screenSlaver', () => ({ contentEquals: (what: string) => what === content }));
+
+// Everything below is incidental to the ordering under test — stubbed so `logOut` can run
+// outside a browser. Deliberately NOT stubbed with behaviour: if any of these grew a role in
+// the wipe/redraw ordering, this test should be revisited rather than silently keep passing.
+vi.mock('./tokenManagement', () => ({
+  getToken: () => undefined,
+  removeToken: vi.fn(),
+  setToken: vi.fn(),
+  getRefreshToken: () => undefined,
+  setRefreshToken: vi.fn(),
+  removeRefreshToken: vi.fn(),
+}));
+vi.mock('./authApi', () => ({ revokeRefreshToken: vi.fn(() => Promise.resolve()) }));
+vi.mock('./getUserContext', () => ({ clearUserContext: vi.fn(), fetchUserContext: vi.fn() }));
+vi.mock('./isProviderAdmin', () => ({ isActiveProviderAdmin: () => false }));
+vi.mock('services/provider/providerState', () => ({ clearActiveProvider: vi.fn() }));
+vi.mock('services/provider/initProviderSwitcher', () => ({ initProviderSwitcher: vi.fn() }));
+vi.mock('services/session/sessionGuard', () => ({ notifySessionRecovered: vi.fn() }));
+vi.mock('services/staleness/stalenessGuard', () => ({ resetActivityTimer: vi.fn() }));
+vi.mock('services/messaging/socketIo', () => ({ disconnectSocket: vi.fn() }));
+vi.mock('services/apis/baseApi', () => ({ refreshAccessToken: vi.fn() }));
+vi.mock('services/factory/engine', () => ({ tournamentEngine: { reset: vi.fn() } }));
+vi.mock('services/notifications/tmxToast', () => ({ tmxToast: vi.fn() }));
+vi.mock('services/pdf/pdfFont', () => ({ ensurePdfFontReady: vi.fn() }));
+vi.mock('config/providerConfig', () => ({ providerConfig: { reset: vi.fn(), set: vi.fn(), get: () => ({}) } }));
+vi.mock('services/demoMode/demoEligibility', () => ({ clearDemoOverlay: vi.fn(), isDemoEligible: () => false }));
+vi.mock('services/authentication/validateToken', () => ({ validateToken: () => undefined }));
+vi.mock('pages/tournament/tabs/settingsTab/renderSettingsTab', () => ({ renderSettingsTab: vi.fn() }));
+vi.mock('pages/tournament/tabs/overviewTab/renderOverview', () => ({ renderOverview: vi.fn() }));
+vi.mock('components/modals/loginModal', () => ({ loginModal: vi.fn() }));
+vi.mock('components/popovers/tipster', () => ({ tipster: vi.fn() }));
+vi.mock('navigation', () => ({ setupChatIndicator: vi.fn() }));
+vi.mock('functions/getLoginColor', () => ({ getLoginColor: () => '' }));
+vi.mock('i18n', () => ({ t: (k: string) => k, i18next: { language: 'en' } }));
+vi.mock('services/context', () => ({
+  context: { router: { navigate: (r: string) => navigate(r) }, matchUpFilters: {} },
+}));
+
+// TMX runs vitest in a node environment — there is no jsdom or happy-dom in devDependencies —
+// and logOut ends in `styleLogin(false)`, which reads `document.getElementById('login')`. A
+// null-returning stub is sufficient and honest: styleLogin early-returns when the element is
+// absent, which is also what it does on any page without the avatar mounted.
+(globalThis as any).document = { getElementById: () => null };
+
+import { logOut } from './loginState';
+
+/** A promise whose resolution this test controls — the wipe, held open on purpose. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('logOut redraws the tournaments list only after the IndexedDB wipe lands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    content = 'tournaments';
+    resetLocalCalendar.mockResolvedValue(undefined);
+  });
+
+  it('does not rebuild the list while the wipe is still in flight', async () => {
+    const wipe = deferred();
+    deleteProviderBoundTournaments.mockReturnValue(wipe.promise);
+
+    logOut();
+    await flush();
+
+    // The navigate has already happened — this is the exact window in which the list rendered
+    // the departing user's tournaments. The rebuild must NOT have fired yet, because the
+    // records it would read are still in IndexedDB.
+    expect(navigate).toHaveBeenCalled();
+    expect(createTournamentsTable).not.toHaveBeenCalled();
+
+    wipe.resolve();
+    await flush();
+
+    // ...and once the delete has landed, the list re-reads. Reverting the `.finally(redraw)`
+    // chain in logOut fails HERE, with 0 calls: nothing ever re-reads, which is why the stale
+    // rows survived until a manual reload.
+    expect(createTournamentsTable).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds even when the wipe fails — identity is already cleared either way', async () => {
+    deleteProviderBoundTournaments.mockRejectedValue(new Error('idb unavailable'));
+
+    logOut();
+    await flush();
+    await flush();
+
+    // `.finally`, not `.then`. A failed wipe still leaves a list that must be re-read: the
+    // synchronous identity clears above already changed what it is entitled to show.
+    expect(createTournamentsTable).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch the list when the user is not looking at it', async () => {
+    // Logging out from inside a tournament: `contentEquals(TMX_TOURNAMENTS)` is false, and
+    // rebuilding a table that is not on screen would be work at best and a stray render at
+    // worst. The wipe still runs — only the redraw is skipped.
+    content = 'tournament';
+    const wipe = deferred();
+    deleteProviderBoundTournaments.mockReturnValue(wipe.promise);
+
+    logOut();
+    wipe.resolve();
+    await flush();
+    await flush();
+
+    expect(deleteProviderBoundTournaments).toHaveBeenCalledTimes(1);
+    expect(createTournamentsTable).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/authentication/logOutRedraw.test.ts
+++ b/src/services/authentication/logOutRedraw.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 /**
  * `logOut` must not let the tournaments list render the departing user's tournaments.
@@ -74,12 +74,6 @@ vi.mock('services/context', () => ({
   context: { router: { navigate: (r: string) => navigate(r) }, matchUpFilters: {} },
 }));
 
-// TMX runs vitest in a node environment — there is no jsdom or happy-dom in devDependencies —
-// and logOut ends in `styleLogin(false)`, which reads `document.getElementById('login')`. A
-// null-returning stub is sufficient and honest: styleLogin early-returns when the element is
-// absent, which is also what it does on any page without the avatar mounted.
-(globalThis as any).document = { getElementById: () => null };
-
 import { logOut } from './loginState';
 
 /** A promise whose resolution this test controls — the wipe, held open on purpose. */
@@ -92,11 +86,34 @@ function deferred() {
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe('logOut redraws the tournaments list only after the IndexedDB wipe lands', () => {
+  // TMX runs vitest in a node environment — no jsdom or happy-dom in devDependencies — and
+  // logOut ends in `styleLogin(false)`, which reads `document.getElementById('login')`. A
+  // null-returning stub is enough: styleLogin early-returns when the element is absent, which
+  // is what it does on any page without the avatar mounted.
+  //
+  // `vi.stubGlobal` per test rather than a bare `globalThis.document = …` at module scope, so
+  // the fake is established and torn down with each test instead of persisting for the file's
+  // lifetime.
+  //
+  // Honesty about why: this file was reported as order-dependent — passing alone, failing in a
+  // full run with a count that varied between 2 and 3 (Mentat in-flight note, 2026-08-27) — and
+  // a leaking module-scope global was the obvious suspect. It is NOT the cause. Vitest isolates
+  // per file here (no `isolate: false`, no pool override), verified with a two-file probe: a
+  // global set at module scope in one spec reads back `undefined` in the next. So the old form
+  // could neither leak out nor be clobbered.
+  //
+  // The scoped stub is kept because it is the better shape regardless, not because it fixes
+  // that. The reported failure was NOT reproduced — seven consecutive full runs across two
+  // checkouts (1717 and 1727 collected). If it recurs, the failing output is the missing
+  // evidence; do not assume this comment settled it.
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('document', { getElementById: () => null });
     content = 'tournaments';
     resetLocalCalendar.mockResolvedValue(undefined);
   });
+
+  afterEach(() => vi.unstubAllGlobals());
 
   it('does not rebuild the list while the wipe is still in flight', async () => {
     const wipe = deferred();


### PR DESCRIPTION
#1370 fixed a race and shipped with no coverage. This adds both halves — and is explicit about which half is evidence.

## `logOutRedraw.test.ts` — this is the one that proves the fix

`logOut` navigates synchronously while the IndexedDB wipe is still in flight, so the tournaments list (which falls back to local IDB once identity is cleared) painted the departing user's provider-bound tournaments and never re-read.

The assertion is an **ordering**, and an ordering is deterministic only when the wipe's completion is controlled. So the test holds the delete open with a deferred promise:

- after the navigate, the list must **not** have been rebuilt — that is the exact window the stale rows appeared in;
- once the delete settles, it must have been rebuilt, exactly once.

Plus a case pinning `.finally` rather than `.then` (a failed wipe still needs the re-read, since the synchronous identity clears already changed what the list may show), and one pinning the `contentEquals` guard.

**No production export was needed.** `logOut` is already exported and is the right unit; `redrawTournamentsListAfterWipe` stays private, because testing it directly would only exercise its guard — and the guard was never the defect.

**Falsified.** Reverting `logOut`'s `.finally(redraw)` — a revert made coherent, with `check-types` and `lint` both exiting 0 *before* reading the test result — fails the two ordering cases with `createTournamentsTable` called 0 times instead of 1. The third case correctly still passes; it guards a different thing.

## Journey 113 — real value, but NOT evidence for the fix

Its header says this outright. It covers the post-logout **end state**: provider-bound tournament gone from the list *and* from storage, unowned record preserved. That fails if anyone breaks the wipe's selectivity, which is worth having.

It stays **green with the fix reverted**. Locally the wipe simply wins the race, so the stale render never happens. Three attempts to open the window:

| attempt | result |
|---|---|
| plain two-record fixture | green reverted |
| 600 provider-bound ballast records to lengthen the delete | green reverted |
| counting anchor rebuilds (the fix adds a second) | green reverted — the logout navigate alone produces several childList mutations |

I stopped rather than tune a threshold until it went red. A probe tuned to pass is not evidence.

## Two fixture traps, documented in the spec

- `tmx2db.addTournament` alone seeds a tournament **the list cannot see** — the list reads lightweight entries from the `providers` store, which production keeps in step via `maintainLocalCalendarEntry`. The first cut failed its own pre-condition with the Welcome view on screen.
- `page.goto('/#/tournaments')` while already on that route is a **Navigo no-op**, so the table stays the one built at boot against an empty database. `tmx_local_calendar_migrated` still being `null` is what proved the list had not re-read rather than having read and found nothing.

## Verification

Full TMX gate green, exit codes read directly: `lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci`, `check-types`, `test --run` (156 files / 1721 tests). Journeys 113 and 108: 6 passed.

Built in an isolated `git worktree` — the primary checkout is in use by another session with staged work of its own — and re-verified there (unit suite, lint, format, types) before committing.