### PR TITLE
fix(scales): stop fabricating a rating of zero from an empty scale value

### DIFF
--- a/attr-audit.allow.json
+++ b/attr-audit.allow.json
@@ -1,0 +1,3 @@
+[
+  "accessors"
+]

--- a/src/components/tables/eventsTable/seeding/generateSeedValues.ts
+++ b/src/components/tables/eventsTable/seeding/generateSeedValues.ts
@@ -3,6 +3,8 @@
  * Automatically assigns seeding based on rating scales with confidence bands.
  */
 import { drawDefinitionConstants, scaleConstants, fixtures } from 'tods-competition-factory';
+import { hasScaleValueNumber } from 'functions/resolveScaleValueNumber';
+import { ratingSortValue } from './ratingSortValue';
 import { getConfidenceBand } from 'components/tables/common/sorters/ratingSorter';
 import { setParticipantScaleItems } from './setParticipantScaleItems';
 import { tournamentEngine } from 'services/factory/engine';
@@ -34,7 +36,15 @@ export function generateSeedValues({ event, group, table, field }: GenerateSeedV
   const reversed = rating ? ratingsParameters[rating.toUpperCase()].ascending : false;
   const accessor = ratingsParameters[rating.toUpperCase()]?.accessor || `${rating}Rating`;
   const getRating = (participant: any) => participant.ratings?.[rating] || { confidence: 0, [accessor]: Infinity };
-  const getRatingValue = (participant: any) => getRating(participant)?.[accessor] || 0;
+  // See `ratingSortValue` — extracted so the decision is unit-testable, and
+  // because `|| 0` here used to seed an unrated participant #1.
+  const getRatingValue = (participant: any) =>
+    ratingSortValue({
+      rawValue: getRating(participant)?.[accessor],
+      scaleName: rating?.toUpperCase(),
+      accessor,
+      reversed,
+    });
 
   const scaleSort = (a: any, b: any) =>
     (scaleType === 'ratings' && reversed
@@ -46,7 +56,10 @@ export function generateSeedValues({ event, group, table, field }: GenerateSeedV
   let ratedParticipants = 0;
   for (const participant of data) {
     const rating = getRating(participant);
-    if (rating[accessor]) ratedParticipants += 1;
+    // Truthiness here would also miss a participant rated exactly 0.
+    if (hasScaleValueNumber(rating[accessor], { scaleName: field.split('.')[1]?.toUpperCase(), accessor })) {
+      ratedParticipants += 1;
+    }
 
     const confidence = rating.confidence ?? 100;
 

--- a/src/components/tables/eventsTable/seeding/ratingSortValue.test.ts
+++ b/src/components/tables/eventsTable/seeding/ratingSortValue.test.ts
@@ -1,0 +1,96 @@
+import { ratingSortValue } from './ratingSortValue';
+import { expect, it, describe } from 'vitest';
+
+const WTN = { scaleName: 'WTN', accessor: 'wtnRating', reversed: true }; // lower is stronger
+const UTR = { scaleName: 'UTR', accessor: 'utrRating', reversed: false }; // higher is stronger
+
+/** Order a field the way the seeding comparator does, strongest first. */
+function seedOrder(entries: { id: string; rawValue: unknown }[], scale: typeof WTN) {
+  return entries
+    .map((entry) => ({ ...entry, sortValue: ratingSortValue({ ...scale, rawValue: entry.rawValue }) }))
+    .toSorted((a, b) => (scale.reversed ? a.sortValue - b.sortValue : b.sortValue - a.sortValue))
+    .map((entry) => entry.id);
+}
+
+describe('ratingSortValue', () => {
+  it('reads a numeric string, which is how ingested records store ratings', () => {
+    expect(ratingSortValue({ ...UTR, rawValue: '12.48' })).toBe(12.48);
+  });
+
+  it('preserves a legitimate zero rather than treating it as unrated', () => {
+    expect(ratingSortValue({ ...UTR, rawValue: 0 })).toBe(0);
+    expect(ratingSortValue({ ...UTR, rawValue: '0' })).toBe(0);
+  });
+
+  it('sinks an unresolvable value in BOTH sort directions', () => {
+    for (const rawValue of ['', '   ', null, undefined, 'unrated']) {
+      expect(ratingSortValue({ ...WTN, rawValue })).toBe(Number.POSITIVE_INFINITY);
+      expect(ratingSortValue({ ...UTR, rawValue })).toBe(Number.NEGATIVE_INFINITY);
+    }
+  });
+});
+
+describe('seeding order — the defect this prevents', () => {
+  it('does NOT seed an unrated participant first on an ascending scale', () => {
+    // The regression. `'' || 0` gave 0, and on WTN (lower is stronger) 0 sorts
+    // ahead of the best real rating — so the unrated player was seeded #1.
+    const order = seedOrder(
+      [
+        { id: 'unrated', rawValue: '' },
+        { id: 'strong', rawValue: '4.13' },
+        { id: 'weak', rawValue: '18.90' },
+      ],
+      WTN,
+    );
+    expect(order[0]).toBe('strong');
+    expect(order.at(-1)).toBe('unrated');
+  });
+
+  it('does not seed an unrated participant first on a descending scale either', () => {
+    const order = seedOrder(
+      [
+        { id: 'unrated', rawValue: '' },
+        { id: 'strong', rawValue: '13.90' },
+        { id: 'weak', rawValue: '9.20' },
+      ],
+      UTR,
+    );
+    expect(order[0]).toBe('strong');
+    expect(order.at(-1)).toBe('unrated');
+  });
+
+  it('seeds a participant rated exactly zero as the weakest, not as unrated', () => {
+    // On a descending scale 0 is the floor but still a real rating; it must sit
+    // above anyone with no rating at all.
+    const order = seedOrder(
+      [
+        { id: 'zero', rawValue: 0 },
+        { id: 'unrated', rawValue: '' },
+        { id: 'strong', rawValue: 900 },
+      ],
+      { scaleName: 'PSA', accessor: 'psaPoints', reversed: false },
+    );
+    expect(order).toEqual(['strong', 'zero', 'unrated']);
+  });
+
+  it('orders string and number representations identically', () => {
+    const asStrings = seedOrder(
+      [
+        { id: 'a', rawValue: '12.48' },
+        { id: 'b', rawValue: '9.20' },
+        { id: 'c', rawValue: '13.90' },
+      ],
+      UTR,
+    );
+    const asNumbers = seedOrder(
+      [
+        { id: 'a', rawValue: 12.48 },
+        { id: 'b', rawValue: 9.2 },
+        { id: 'c', rawValue: 13.9 },
+      ],
+      UTR,
+    );
+    expect(asStrings).toEqual(asNumbers);
+    expect(asStrings).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/src/components/tables/eventsTable/seeding/ratingSortValue.ts
+++ b/src/components/tables/eventsTable/seeding/ratingSortValue.ts
@@ -1,0 +1,37 @@
+import { resolveScaleValueNumber } from 'functions/resolveScaleValueNumber';
+
+/**
+ * The sort key for seeding a field by a rating scale.
+ *
+ * Extracted from `generateSeedValues` so the decision can be tested. TMX has no
+ * jsdom layer, so anything that stays inside a closure gets no unit coverage —
+ * and this particular decision, made wrongly, seeds the wrong player #1.
+ *
+ * The previous implementation was `ratingObject?.[accessor] || 0`, which had two
+ * failure modes that a numeric fixture cannot reach:
+ *
+ * - real records carry `''` for a participant with no rating on this scale, and
+ *   `'' || 0` is `0`. On an ASCENDING scale (WTN, BWF — lower is better) that
+ *   sorts FIRST, so an unrated participant was seeded #1.
+ * - `|| 0` also collapses a legitimate `0`, which PSA, ITTF, BWF and
+ *   SQUASH_LEVELS all declare inside their valid range.
+ *
+ * An unresolvable value now sinks to the end in whichever direction is being
+ * sorted, rather than leading in one of them.
+ */
+export function ratingSortValue({
+  rawValue,
+  accessor,
+  scaleName,
+  reversed,
+}: {
+  rawValue: unknown;
+  accessor?: string;
+  scaleName?: string;
+  /** True for ascending scales, where a LOWER value is stronger. */
+  reversed?: boolean;
+}): number {
+  const resolved = resolveScaleValueNumber(rawValue, { accessor, scaleName });
+  if (resolved !== undefined) return resolved;
+  return reversed ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+}

--- a/src/functions/resolveScaleValueNumber.test.ts
+++ b/src/functions/resolveScaleValueNumber.test.ts
@@ -1,0 +1,40 @@
+import { resolveScaleValueNumber, hasScaleValueNumber } from './resolveScaleValueNumber';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * Shapes copied from production records (ITA regional championships), not
+ * invented. mocksEngine emits numbers, so the string and empty-string cases —
+ * the two that were producing wrong output — cannot be reached by any
+ * generated fixture.
+ */
+
+describe('resolveScaleValueNumber', () => {
+  it('reads a numeric string, which is how ingested records store ratings', () => {
+    expect(resolveScaleValueNumber('12.48')).toBe(12.48);
+    expect(resolveScaleValueNumber({ utrRating: '12.48' }, { scaleName: 'UTR' })).toBe(12.48);
+  });
+
+  it('rejects an empty string rather than reading it as zero', () => {
+    // `Number('')` is 0, and 0 on UTR's [1,16] range is below the floor.
+    expect(resolveScaleValueNumber('')).toBeUndefined();
+    expect(resolveScaleValueNumber({ utrRating: '' }, { scaleName: 'UTR' })).toBeUndefined();
+    expect(hasScaleValueNumber({ utrRating: '' }, { scaleName: 'UTR' })).toBe(false);
+  });
+
+  it('preserves a legitimate zero', () => {
+    // PSA, SQUASH_LEVELS, ITTF and BWF all declare 0 inside their valid range.
+    expect(resolveScaleValueNumber(0)).toBe(0);
+    expect(resolveScaleValueNumber('0')).toBe(0);
+    expect(hasScaleValueNumber(0)).toBe(true);
+  });
+
+  it('takes the rating rather than a sibling attribute for a multi-property scale', () => {
+    expect(resolveScaleValueNumber({ confidence: 90, wtnRating: 4.13 }, { scaleName: 'WTN' })).toBe(4.13);
+  });
+
+  it('rejects nullish, non-numeric and NaN values without coercing them', () => {
+    for (const value of [null, undefined, 'unrated', Number.NaN, {}, [], true]) {
+      expect(resolveScaleValueNumber(value)).toBeUndefined();
+    }
+  });
+});

--- a/src/functions/resolveScaleValueNumber.ts
+++ b/src/functions/resolveScaleValueNumber.ts
@@ -1,0 +1,72 @@
+/**
+ * Turn a scale value into a number, or `undefined` when there isn't one.
+ *
+ * TEMPORARY LOCAL COPY. The factory now owns this — `resolveScaleValueNumber`
+ * is exported from `tods-competition-factory` as of the scale-normalization
+ * fix — but TMX is pinned to 6.33.0 and CI installs the PUBLISHED package
+ * (it strips the `link:` overrides), so importing it here would fail CI until
+ * factory publishes. **Once the pin is bumped past that release, delete this
+ * file and import from the factory instead.**
+ *
+ * Three properties matter, and each corresponds to a defect this prevents:
+ *
+ * 1. **Values may be strings.** Real ingested records store `'12.48'`, not
+ *    `12.48`. `mocksEngine` emits numbers, so a `typeof === 'number'` gate
+ *    passes every test fixture and silently drops every real rating.
+ * 2. **An empty string is not zero.** Records carry `''` for a participant with
+ *    no rating on that scale. `Number('')` is `0`, and 0 on a scale declared
+ *    `[1, 16]` is below the floor — a fabricated rating, not a missing one.
+ * 3. **Zero is a legitimate rating.** PSA, SQUASH_LEVELS, ITTF and BWF all
+ *    declare 0 inside their valid range, so truthiness tests (`value || 0`,
+ *    `if (value)`) erase a real competitor.
+ */
+
+// constants and types
+import { fixtures } from 'tods-competition-factory';
+
+type ResolveParams = {
+  accessor?: string;
+  scaleName?: string;
+};
+
+function primitiveToNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function accessorsFor({ accessor, scaleName }: ResolveParams): string[] {
+  // `accessor` and `accessors` are BOTH real fields on the factory's
+  // ratingsParameters fixture — singular is the primary, plural is the full
+  // list (UTR declares `accessor: 'utrRating'` and `accessors: ['utrRating']`).
+  // attr-audit flags the pair as a possible typo; `accessors` is allow-listed in
+  // attr-audit.allow.json rather than renamed, because renaming a real fixture
+  // field on the tool's say-so is how a working attribute gets broken.
+  const params = scaleName ? (fixtures as any)?.ratingsParameters?.[scaleName] : undefined;
+  return [accessor, params?.accessor, ...(params?.accessors ?? [])].filter(
+    (candidate: unknown): candidate is string => typeof candidate === 'string' && !!candidate,
+  );
+}
+
+export function resolveScaleValueNumber(scaleValue: unknown, params: ResolveParams = {}): number | undefined {
+  const primitive = primitiveToNumber(scaleValue);
+  if (primitive !== undefined) return primitive;
+  if (!scaleValue || typeof scaleValue !== 'object' || Array.isArray(scaleValue)) return undefined;
+
+  const source = scaleValue as Record<string, unknown>;
+  for (const accessor of accessorsFor(params)) {
+    const resolved = primitiveToNumber(source[accessor]);
+    if (resolved !== undefined) return resolved;
+  }
+  for (const value of Object.values(source)) {
+    const resolved = primitiveToNumber(value);
+    if (resolved !== undefined) return resolved;
+  }
+  return undefined;
+}
+
+/** Whether a usable number is present. Use instead of truthiness so 0 counts. */
+export function hasScaleValueNumber(scaleValue: unknown, params: ResolveParams = {}): boolean {
+  return resolveScaleValueNumber(scaleValue, params) !== undefined;
+}

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/buildDrawCardVisualization.ts
@@ -6,6 +6,7 @@
  * back to no-viz behaviour in that case.
  */
 
+import { resolveScaleValueNumber } from 'functions/resolveScaleValueNumber';
 import { computeRatingDistributionStats, fixtures } from 'tods-competition-factory';
 import {
   aggregateCompetitiveness,
@@ -37,16 +38,6 @@ function buildCompetitivenessForMatchUps(matchUps: any[]): HTMLElement | null {
   return wrap;
 }
 
-function unwrapScaleValue(raw: any, accessor: string | undefined): any {
-  if (!raw || typeof raw !== 'object') return raw;
-  if (accessor && raw[accessor] !== undefined) return raw[accessor];
-  // Fallback when the ratingsParameters accessor isn't available — mocksEngine
-  // emits `{ wtnRating, confidence }` and similar; the first numeric field is
-  // always the rating itself.
-  const numeric = Object.values(raw).find((v) => typeof v === 'number');
-  return numeric === undefined ? raw : numeric;
-}
-
 function extractRatingFromParticipant(participant: any, scaleKey: string, accessor: string | undefined): number | null {
   const ratings = participant?.ratings;
   if (!ratings) return null;
@@ -54,9 +45,13 @@ function extractRatingFromParticipant(participant: any, scaleKey: string, access
     if (!Array.isArray(category)) continue;
     for (const item of category) {
       if (String(item?.scaleName ?? '').toUpperCase() !== scaleKey) continue;
-      const raw = unwrapScaleValue(item.scaleValue, accessor);
-      const n = Number(raw);
-      if (Number.isFinite(n)) return n;
+      // Was: unwrap the accessor, then `Number(raw)` with an isFinite guard.
+      // Real records carry '' for a participant with no rating on this scale,
+      // and `Number('')` is 0 — which is finite, so a rating of ZERO was pushed
+      // into the histogram. On UTR's [1,16] range that is a bar a full unit
+      // below the floor, and it shifts min, mean, stddev and the whole binning.
+      const resolved = resolveScaleValueNumber(item.scaleValue, { accessor, scaleName: scaleKey });
+      if (resolved !== undefined) return resolved;
     }
   }
   return null;


### PR DESCRIPTION
Two sites turned a **missing** rating into a **real** one. Real records carry `''` for a participant with no rating on a given scale, and `Number('')` / `|| 0` is `0` — which reads as a valid rating rather than an absence.

Found while running new code against production ITA records; `mocksEngine` emits clean numbers, so no existing fixture could reach either path.

## The two bugs

**`generateSeedValues`** — `getRating(p)?.[accessor] || 0`. On an **ascending** scale (WTN, BWF — lower is stronger) `0` sorts **first**, so an unrated participant was **seeded #1**. The same `|| 0` collapsed a legitimate `0`, which PSA, ITTF, BWF and SQUASH_LEVELS all declare inside their valid range.

**`buildDrawCardVisualization`** — `Number(raw)` behind an `isFinite` guard, so `''` was admitted as `0` and pushed into the draw-card rating histogram. On UTR's `[1,16]` range that is a bar a full unit below the floor, and it moves min, mean, stddev and the entire binning. Every player without a doubles rating contributed one.

## What changed

Both now go through a single `resolveScaleValueNumber` helper:

- **strings are read** — ingested records store `'12.48'`, not `12.48`
- **`''` and non-numeric values resolve to `undefined`**, never `0`
- **a legitimate `0` is preserved** — no truthiness tests

The sort decision is extracted to a pure `ratingSortValue` so it can be tested at all. TMX has no jsdom layer, so a decision left inside a closure gets no unit coverage — and this one seeds the wrong player.

## Note on the helper

It is a **temporary local copy**. The factory now owns this and exports `resolveScaleValueNumber` (CourtHive/competition-factory#4721), but TMX is pinned to `6.33.0` and CI installs the **published** package, so importing it would fail CI until factory publishes. **Delete the local copy when the pin is bumped past that release** — the file says so at the top.

`accessors` is allow-listed for attr-audit rather than renamed: both `accessor` and `accessors` are real fields on the factory's `ratingsParameters` fixture, and renaming a real field on the tool's say-so is how a working attribute gets broken.

## Verification

12 new specs. **Falsified:** restoring the `|| 0` form fails 4 of them, including *"does NOT seed an unrated participant first on an ascending scale"*.

Full CI-gate equivalent run locally:

- `pnpm lint` — 0
- `pnpm check-types` — 0 (src + e2e + electron)
- `pnpm format:check` — clean
- `pnpm attr-audit --ci` — 0
- `pnpm i18n-audit --ci` — 0
- `pnpm test --run` — **159 files / 1751 tests** (from 157/1739)
- `pnpm build` — succeeds

Playwright journeys are local-only and were not run; nothing here touches a journey path.