### PR TITLE
fix(scoring): skip a matchUp the inline renderer refuses to score

### DIFF
--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
@@ -150,6 +150,10 @@ function applyInlineScoringWrappers(
       isFinalRound,
       moiety,
     });
+    // renderInlineMatchUp REFUSES a matchUp it cannot score correctly — no matchUpFormat from the
+    // factory, or sides that do not resolve to real participant names — and returns null rather than
+    // scoring it against an invented format. Skip it; the published card stays as it is.
+    if (!inlineEl) continue;
     existing.parentElement.replaceChild(inlineEl, existing);
   }
 }


### PR DESCRIPTION
One line, ahead of a breaking change in courthive-components [#540](https://github.com/CourtHive/courthive-components/pull/540).

## Why

`renderInlineMatchUp` previously defaulted the scoring format:

```ts
const format = matchUpFormat || params.matchUp.matchUpFormat || 'SET3-S:6/TB7';
```

…and handed it to `new ScoringEngine(...)` — **for every consumer, including TMX**. #540 makes it require the factory's `matchUpFormat` and two sides that resolve to real participant names, and return `null` rather than scoring against an invented one.

TMX's own pre-check (`renderDrawView.ts:135`) tests participant *existence* only — no name check, no format check — so TMX has been passing `matchUpFormat: undefined` into the renderer and receiving a fabricated best-of-3.

## Why now rather than with the bump

TMX sets `strictNullChecks: true`, so taking the components bump **without** this would fail `pnpm check-types` at `replaceChild(inlineEl, existing)`. That failure is the intended signal, but a guard that was already correct is a better way to receive it than a red type-check.

Inert against the currently published `3.15.2` (non-nullable return); load-bearing the moment the bump is taken.

Skipping leaves the published card exactly as rendered — the matchUp is simply not offered for scoring, which is the right outcome.

## Verification — TMX's full CI gate set, not just lint

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm check-types` (src + e2e + electron) | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm test --run` | **1751** passed |