### PR TITLE
fix(matchUps): stop the Called column printing "now" for every uncalled matchUp

### DIFF
--- a/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
@@ -16,6 +16,8 @@
  * implementation and the venue-zone one produce identical output, so no
  * assertion on a rendered value could tell them apart even with a DOM.
  */
+import { calledAtClock } from './scheduleStatusFormatter';
+import { venueClock } from 'functions/venueTimeFrame';
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
@@ -48,5 +50,49 @@ describe('scheduleStatusFormatter reads the venue clock, never the browser`s', (
     // is why the module needs both the day and the clock.
     expect(code).toContain('venueClock');
     expect(code).toContain('venueCalendarDate');
+  });
+});
+
+/**
+ * The guards above are source-greps, and source-greps are why the next bug got
+ * to production: #1364's `calledAtFormatter` mentioned `venueClock`, satisfying
+ * every assertion in the block above, while rendering the CURRENT time into the
+ * Called column of every matchUp that had never been called. A tournament a day
+ * before its start date showed its entire draw called to court, all at the same
+ * clock, ticking forward on each redraw.
+ *
+ * The cause is that `venueClock` DEFAULTS TO NOW for empty input, so the
+ * formatter's own `if (!clock) return ''` is unreachable for an absent stamp.
+ * That is a value fact, not a which-imports-does-it-use fact, so it needs a
+ * value test — hence `calledAtClock`, extracted purely so this can exist without
+ * a DOM.
+ */
+describe('calledAtClock renders nothing for a matchUp that was never called', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+  ])('returns empty for %s rather than substituting now', (_label, value) => {
+    expect(calledAtClock(value as any)).toBe('');
+  });
+
+  it('returns empty for an unparseable stamp', () => {
+    expect(calledAtClock('not-a-date')).toBe('');
+  });
+
+  it('still renders a real call stamp as a HH:MM clock', () => {
+    // Asserted as a SHAPE plus agreement with `venueClock`, not as a fixed
+    // string: no tournament record is loaded here, so the venue frame falls back
+    // to the runtime zone and any literal would pin the test to whatever TZ the
+    // runner happened to export. What must hold is that a real stamp survives
+    // the guard and is handed to the venue clock unchanged.
+    const stamp = '2026-08-28T21:02:00.000Z';
+    expect(calledAtClock(stamp)).toMatch(/^\d{2}:\d{2}$/);
+    expect(calledAtClock(stamp)).toBe(venueClock(stamp));
+  });
+
+  it('never returns the current clock for an absent stamp, whatever time it is', () => {
+    const now = new Date().toISOString();
+    expect(calledAtClock(undefined)).not.toBe(calledAtClock(now));
   });
 });

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.ts
@@ -80,8 +80,21 @@ export function scheduleLockFormatter(cell: any): HTMLSpanElement | string {
 // which left the page disagreeing with itself in the sharpest possible way: the
 // row was bucketed as called-today on the venue's clock while the cell beside it
 // printed the operator's.
+//
+// The empty-value guard below is load-bearing, and dropping it is the regression
+// #1364 shipped. `venueClock` DEFAULTS TO NOW when handed nothing, so a matchUp
+// that has never been called rendered the current venue clock — every uncalled
+// row showing the same time, advancing on each redraw, and a tournament that had
+// not started yet reading as though its whole draw had been called to court.
+// `if (!clock)` cannot catch that: "now" is a perfectly valid clock string. The
+// only place the absence can be detected is before the conversion.
+export function calledAtClock(value?: string | number | Date | null): string {
+  if (!value) return '';
+  return venueClock(value);
+}
+
 export function calledAtFormatter(cell: any): HTMLSpanElement | string {
-  const clock = venueClock(cell.getValue());
+  const clock = calledAtClock(cell.getValue());
   if (!clock) return '';
   const el = document.createElement('span');
   el.textContent = clock;


### PR DESCRIPTION
## The bug

Reported from production: the matchUps table showed a call time of 9:02pm against **every** matchUp — on a tournament whose first day had not yet arrived, so no matchUp could have been called at all.

Nothing was called. The column was printing the **current time** for every row that has no `calledAt`.

## Cause

`venueClock` is documented as *"Defaults to now"* — it substitutes `new Date()` for empty input. #1364 rewrote `calledAtFormatter` around it and dropped the `if (!value) return ''` guard the previous implementation had:

```ts
const clock = venueClock(cell.getValue());
if (!clock) return '';
```

The `!clock` guard cannot catch this, because "now" is a perfectly valid clock string. So every uncalled row rendered the current venue clock — identical across rows, advancing on each redraw. 9:02pm was simply when the page was looked at.

## Fix

Restore the guard. It can only live *before* the conversion, which is the whole point.

Extracted as `calledAtClock` so the behaviour can be pinned by value: this file's existing tests are source-greps, and they matched `venueClock` in the broken code and passed throughout. Vitest runs without a DOM here, so a test cannot call the formatter itself — the pure helper is what makes a value assertion possible.

**Falsified:** reintroducing the defect fails 3 of the new assertions. The zone-agnostic assertion (shape + agreement with `venueClock`) is deliberate — an earlier draft pinned a literal `21:02` and passed only under `TZ=UTC`.

## Companion change

`setMatchUpCalledAt` in the factory would also have *accepted* such a stamp — it validated only that the value was a string. A guard refusing a `calledAt` that precedes `tournamentRecord.startDate` goes in separately; this PR is the display half and stands alone.

## Verification

| gate | result |
|---|---|
| `lint` | 0 |
| `format:check` | 0 |
| `attr-audit --ci` | 0 |
| `i18n-audit --ci` | 0 |
| `check-types` | 0 |
| `test --run` | **1757** passed (159 files) |