### PR TITLE
fix(scales): close the last three sites that mis-read a scale value

### DIFF
--- a/src/components/charts/collectAvailableScales.test.ts
+++ b/src/components/charts/collectAvailableScales.test.ts
@@ -1,0 +1,74 @@
+import { collectAvailableScales } from './collectAvailableScales';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * `collectAvailableScales` feeds the rating-distribution chart on the overview
+ * and participants tabs. It had no coverage, and the values it collects were
+ * being fabricated: `Number('')` is 0 and `Number.isFinite(0)` is true, so every
+ * participant with no rating on a scale contributed a 0 to that scale's
+ * distribution — moving its min, mean, stddev and binning.
+ *
+ * Shapes below come from production records (ITA regional championships).
+ */
+
+const participant = (ratings: any[]) => ({ ratings: { SINGLES: ratings } });
+const utr = (utrRating: unknown) => ({ scaleName: 'UTR', scaleValue: { utrRating } });
+
+function valuesFor(result: ReturnType<typeof collectAvailableScales>, scaleName: string): number[] {
+  return result.find((entry) => entry.scaleName === scaleName)?.values ?? [];
+}
+
+describe('collectAvailableScales', () => {
+  it('reads STRING ratings, which is how ingested records store them', () => {
+    const result = collectAvailableScales([participant([utr('12.48')]), participant([utr('9.20')])]);
+    expect(valuesFor(result, 'UTR')).toEqual([12.48, 9.2]);
+  });
+
+  it('EXCLUDES an empty-string rating instead of contributing a zero', () => {
+    // The defect: '' became 0 and entered the distribution as a real rating a
+    // full unit below UTR's [1,16] floor.
+    const result = collectAvailableScales([
+      participant([utr('12.48')]),
+      participant([utr('')]),
+      participant([utr('9.20')]),
+    ]);
+    expect(valuesFor(result, 'UTR')).toEqual([12.48, 9.2]);
+    expect(valuesFor(result, 'UTR')).not.toContain(0);
+  });
+
+  it('keeps a legitimate zero on a scale whose range includes it', () => {
+    const result = collectAvailableScales([
+      participant([{ scaleName: 'PSA', scaleValue: { psaPoints: 0 } }]),
+      participant([{ scaleName: 'PSA', scaleValue: { psaPoints: 900 } }]),
+    ]);
+    expect(valuesFor(result, 'PSA')).toEqual([0, 900]);
+  });
+
+  it('gives string and number representations the same distribution', () => {
+    const asStrings = collectAvailableScales([participant([utr('12.48')]), participant([utr('9.20')])]);
+    const asNumbers = collectAvailableScales([participant([utr(12.48)]), participant([utr(9.2)])]);
+    expect(valuesFor(asStrings, 'UTR')).toEqual(valuesFor(asNumbers, 'UTR'));
+  });
+
+  it('takes the rating rather than a sibling attribute on a multi-property scale', () => {
+    const result = collectAvailableScales([
+      participant([{ scaleName: 'WTN', scaleValue: { confidence: 90, wtnRating: '4.13' } }]),
+    ]);
+    expect(valuesFor(result, 'WTN')).toEqual([4.13]);
+  });
+
+  it('groups by scale and tolerates participants with no ratings at all', () => {
+    const result = collectAvailableScales([
+      participant([utr('12.48'), { scaleName: 'WTN', scaleValue: { wtnRating: '4.13' } }]),
+      { participantId: 'no-ratings' },
+      participant([]),
+    ] as any);
+    expect(valuesFor(result, 'UTR')).toEqual([12.48]);
+    expect(valuesFor(result, 'WTN')).toEqual([4.13]);
+  });
+
+  it('omits a scale entirely when nothing on it resolves', () => {
+    const result = collectAvailableScales([participant([utr('')]), participant([utr('unrated')])]);
+    expect(result.find((entry) => entry.scaleName === 'UTR')).toBeUndefined();
+  });
+});

--- a/src/components/charts/collectAvailableScales.ts
+++ b/src/components/charts/collectAvailableScales.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure extraction of per-scale rating values from a list of participants.
+ *
+ * Split out of `participantScalings.ts` so it can be unit-tested at all: that
+ * module imports `courthive-components`, which touches `document` at import
+ * time, and TMX's vitest environment is node. A decision left in a
+ * DOM-importing module gets no coverage — and this one decides which values
+ * enter the rating distribution.
+ */
+
+import { resolveScaleValueNumber } from 'functions/resolveScaleValueNumber';
+
+// constants and types
+import { factoryConstants, fixtures } from 'tods-competition-factory';
+
+const { ratingsParameters } = fixtures;
+const { SINGLES } = factoryConstants.eventConstants;
+
+export interface ScaleRatings {
+  /** Uppercase scale code (e.g. 'WTN', 'UTR'). */
+  scaleName: string;
+  /** Human-readable label — currently same as `scaleName`. */
+  label: string;
+  /** Numeric values for participants that carry this scale. */
+  values: number[];
+}
+
+/**
+ * Walk participants, pull numeric scale values per rating scale.
+ * Skips scales with no resolvable values. Order is insertion order so
+ * callers can stably re-render selectors as filters change.
+ */
+export function collectAvailableScales(participants: any[]): ScaleRatings[] {
+  const map = new Map<string, number[]>();
+  for (const p of participants || []) {
+    const items = p?.ratings?.[SINGLES] || [];
+    for (const item of items) {
+      const key = String(item?.scaleName || '').toUpperCase();
+      if (!key) continue;
+      const params: any = (ratingsParameters as any)[key];
+      const accessor = params?.accessor;
+      // Was `Number(raw)` behind an isFinite guard. Real records carry '' for a
+      // participant with no rating on this scale, and `Number('')` is 0 — which
+      // is finite, so a fabricated rating of 0 entered the distribution and
+      // moved its min, mean and stddev. Strings are read; '' resolves to
+      // undefined; a legitimate 0 is kept.
+      const value = resolveScaleValueNumber(item.scaleValue, { accessor, scaleName: key });
+      if (value === undefined) continue;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(value);
+    }
+  }
+  return Array.from(map.entries()).map(([scaleName, values]) => ({
+    scaleName,
+    label: scaleName,
+    values,
+  }));
+}

--- a/src/components/charts/participantScalings.ts
+++ b/src/components/charts/participantScalings.ts
@@ -10,51 +10,20 @@
  * MAX_PARTICIPANTS_FOR_OVERVIEW so large tournaments don't pay the
  * extraction + render cost up front.
  */
-import { computeRatingDistributionStats, factoryConstants, fixtures } from 'tods-competition-factory';
+import { computeRatingDistributionStats } from 'tods-competition-factory';
 import { buildRatingDistributionChart } from 'courthive-components';
+import { collectAvailableScales } from './collectAvailableScales';
 
-const { ratingsParameters } = fixtures;
-const { SINGLES } = factoryConstants.eventConstants;
+// constants and types
+import type { ScaleRatings } from './collectAvailableScales';
+
+// Re-exported so consumers keep one import path; the extraction itself lives in
+// its own module because this one imports courthive-components, which touches
+// `document` at import time and so cannot be loaded in a node test env.
+export { collectAvailableScales };
+export type { ScaleRatings };
 
 export const MAX_PARTICIPANTS_FOR_OVERVIEW = 200;
-
-export interface ScaleRatings {
-  /** Uppercase scale code (e.g. 'WTN', 'UTR'). */
-  scaleName: string;
-  /** Human-readable label — currently same as `scaleName`. */
-  label: string;
-  /** Numeric values for participants that carry this scale. */
-  values: number[];
-}
-
-/**
- * Walk participants, pull numeric scale values per rating scale.
- * Skips scales with zero finite values. Order is insertion order so
- * callers can stably re-render selectors as filters change.
- */
-export function collectAvailableScales(participants: any[]): ScaleRatings[] {
-  const map = new Map<string, number[]>();
-  for (const p of participants || []) {
-    const items = p?.ratings?.[SINGLES] || [];
-    for (const item of items) {
-      const key = String(item?.scaleName || '').toUpperCase();
-      if (!key) continue;
-      const params: any = (ratingsParameters as any)[key];
-      const accessor = params?.accessor;
-      let raw: any = item.scaleValue;
-      if (raw && typeof raw === 'object' && accessor) raw = raw[accessor];
-      const n = Number(raw);
-      if (!Number.isFinite(n)) continue;
-      if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push(n);
-    }
-  }
-  return Array.from(map.entries()).map(([scaleName, values]) => ({
-    scaleName,
-    label: scaleName,
-    values,
-  }));
-}
 
 export interface ScalingsChartOptions {
   /** Visual variant. `compact` ≈ 200x36 sparkline; `full` ≈ 480x180 panel chart. */

--- a/src/components/tables/common/sorters/ratingSorter.test.ts
+++ b/src/components/tables/common/sorters/ratingSorter.test.ts
@@ -1,0 +1,118 @@
+import { ratingSorter } from './ratingSorter';
+import { expect, it, describe } from 'vitest';
+
+/**
+ * `ratingSorter` had no coverage. The value shapes here come from production
+ * records (ITA regional championships): ratings stored as STRINGS, an EMPTY
+ * STRING for a participant with no rating on that scale, and a legitimate ZERO.
+ *
+ * Rows share a confidence so the comparator reaches the rating at all — it
+ * bands confidence first and only falls through to the rating on a tie.
+ */
+
+const CONFIDENCE = 90;
+
+const utrRow = (utrRating: unknown) => ({ utrRating, confidence: CONFIDENCE });
+const wtnRow = (wtnRating: unknown) => ({ wtnRating, confidence: CONFIDENCE });
+
+/** Apply the sorter the way a table would, and report the resulting order. */
+function order<T extends Record<string, any>>(scale: string, rows: (T & { id: string })[]): string[] {
+  return [...rows].sort(ratingSorter(scale)).map((row) => row.id);
+}
+
+describe('ratingSorter — value handling', () => {
+  it('reads STRING ratings, which is how ingested records store them', () => {
+    const result = order('UTR', [
+      { id: 'strong', ...utrRow('13.90') },
+      { id: 'weak', ...utrRow('9.20') },
+      { id: 'mid', ...utrRow('11.50') },
+    ]);
+    // UTR is descending-is-better, so the comparator's natural order is
+    // weakest first; the table reverses for the other direction.
+    expect(result).toEqual(['weak', 'mid', 'strong']);
+  });
+
+  it('orders string and number representations identically', () => {
+    const asStrings = order('UTR', [
+      { id: 'a', ...utrRow('13.90') },
+      { id: 'b', ...utrRow('9.20') },
+    ]);
+    const asNumbers = order('UTR', [
+      { id: 'a', ...utrRow(13.9) },
+      { id: 'b', ...utrRow(9.2) },
+    ]);
+    expect(asStrings).toEqual(asNumbers);
+  });
+});
+
+describe('ratingSorter — unrated rows', () => {
+  it('sorts an unrated row LAST on a descending-is-better scale', () => {
+    // Before, `|| 0` gave the unrated row 0, which on UTR sorted it FIRST.
+    const result = order('UTR', [
+      { id: 'unrated', ...utrRow('') },
+      { id: 'strong', ...utrRow('13.90') },
+      { id: 'weak', ...utrRow('9.20') },
+    ]);
+    expect(result.at(-1)).toBe('unrated');
+  });
+
+  it('sorts an unrated row LAST on an ascending-is-better scale too', () => {
+    // The old `|| 0` put unrated at opposite ends depending on the scale, so
+    // the same "no rating" state read differently in two columns.
+    const result = order('WTN', [
+      { id: 'unrated', ...wtnRow('') },
+      { id: 'strong', ...wtnRow('4.13') },
+      { id: 'weak', ...wtnRow('18.90') },
+    ]);
+    expect(result.at(-1)).toBe('unrated');
+  });
+
+  it('treats a missing accessor and a non-numeric value as unrated', () => {
+    for (const value of [undefined, null, 'unrated']) {
+      const result = order('UTR', [
+        { id: 'unrated', ...utrRow(value) },
+        { id: 'rated', ...utrRow('11.50') },
+      ]);
+      expect(result.at(-1)).toBe('unrated');
+    }
+  });
+
+  it('keeps two unrated rows stable relative to each other', () => {
+    const result = order('UTR', [
+      { id: 'first', ...utrRow('') },
+      { id: 'second', ...utrRow(undefined) },
+    ]);
+    expect(result).toEqual(['first', 'second']);
+  });
+});
+
+describe('ratingSorter — a legitimate zero is a rating, not an absence', () => {
+  it('ranks a zero-rated row above an unrated one', () => {
+    // PSA declares range [0, 3000]; `|| 0` collapsed a real 0 into the same
+    // bucket as no rating at all.
+    const result = order('PSA', [
+      { id: 'unrated', psaPoints: '', confidence: CONFIDENCE },
+      { id: 'zero', psaPoints: 0, confidence: CONFIDENCE },
+      { id: 'strong', psaPoints: 900, confidence: CONFIDENCE },
+    ]);
+    expect(result).toEqual(['zero', 'strong', 'unrated']);
+  });
+});
+
+describe('ratingSorter — confidence still wins', () => {
+  it('bands by confidence before considering the rating', () => {
+    const result = order('UTR', [
+      { id: 'lowConfidenceStrong', utrRating: '13.90', confidence: 45 },
+      { id: 'highConfidenceWeak', utrRating: '9.20', confidence: 95 },
+    ]);
+    expect(result[0]).toBe('highConfidenceWeak');
+  });
+
+  it('returns 0 for an unknown scale rather than reordering', () => {
+    const result = order('NOT_A_SCALE', [
+      { id: 'a', utrRating: '9.20', confidence: CONFIDENCE },
+      { id: 'b', utrRating: '13.90', confidence: CONFIDENCE },
+    ]);
+    expect(result).toEqual(['a', 'b']);
+  });
+});

--- a/src/components/tables/common/sorters/ratingSorter.ts
+++ b/src/components/tables/common/sorters/ratingSorter.ts
@@ -1,4 +1,5 @@
 export const confidenceBands = { high: [80, 100], medium: [60, 80], low: [40, 60] };
+import { resolveScaleValueNumber } from 'functions/resolveScaleValueNumber';
 import { fixtures } from 'tods-competition-factory';
 
 const { ratingsParameters } = fixtures;
@@ -19,8 +20,18 @@ export const ratingSorter =
     if (ac < bc) return 1;
     if (bc < ac) return -1;
 
-    const ratingA = a?.[accessor] || 0;
-    const ratingB = b?.[accessor] || 0;
+    // Was `a?.[accessor] || 0`. That mapped an unrated participant's '' to 0 —
+    // which lands at opposite ends depending on the scale's direction, so
+    // "unrated" sorted to the top for UTR and the bottom for WTN — and it
+    // collapsed a legitimate 0 into the same bucket as no rating at all.
+    const ratingA = resolveScaleValueNumber(a?.[accessor], { accessor, scaleName: rating });
+    const ratingB = resolveScaleValueNumber(b?.[accessor], { accessor, scaleName: rating });
+
+    // Unrated sorts last regardless of scale direction, rather than being given
+    // a numeric sentinel whose meaning flips with the comparator's polarity.
+    if (ratingA === undefined && ratingB === undefined) return 0;
+    if (ratingA === undefined) return 1;
+    if (ratingB === undefined) return -1;
 
     return reversed ? ratingA - ratingB : ratingB - ratingA;
   };

--- a/src/services/formatWizard/extractRating.test.ts
+++ b/src/services/formatWizard/extractRating.test.ts
@@ -55,3 +55,40 @@ describe('extractParticipantRating', () => {
     expect(extractParticipantRating(singlesRating('CUSTOM', { customRating: 3.2 }), 'custom')).toEqual(3.2);
   });
 });
+
+/**
+ * Added alongside the original suite, not in place of it.
+ *
+ * These shapes come from production records (ITA regional championships) and are
+ * the ones mocksEngine cannot produce: a rating stored as a STRING, an EMPTY
+ * STRING for a participant with no rating on that scale, and a legitimate ZERO.
+ * The previous `typeof value === 'number'` gate passed every case above and
+ * rejected every real rating — and the caller turns a rejected rating into an
+ * excluded participant, then bails with INSUFFICIENT_RATED_PARTICIPANTS, so the
+ * whole format wizard reported a fully rated field as unrated.
+ */
+describe('extractParticipantRating — production value shapes', () => {
+  it('reads a STRING rating, which is how ingested records store them', () => {
+    expect(extractParticipantRating(singlesRating('UTR', { utrRating: '12.48' }), 'utr')).toEqual(12.48);
+  });
+
+  it('gives string and number representations the same result', () => {
+    expect(extractParticipantRating(singlesRating('UTR', { utrRating: '9.20' }), 'utr')).toEqual(
+      extractParticipantRating(singlesRating('UTR', { utrRating: 9.2 }), 'utr'),
+    );
+  });
+
+  it('returns undefined for an empty-string rating rather than reading it as zero', () => {
+    expect(extractParticipantRating(singlesRating('UTR', { utrRating: '' }), 'utr')).toBeUndefined();
+    expect(extractParticipantRating(singlesRating('UTR', { utrRating: '   ' }), 'utr')).toBeUndefined();
+  });
+
+  it('preserves a legitimate zero instead of discarding it as absent', () => {
+    // PSA declares range [0, 3000] — a new player really is on zero points.
+    expect(extractParticipantRating(singlesRating('PSA', { psaPoints: 0 }), 'psa')).toEqual(0);
+  });
+
+  it('takes the rating rather than a sibling attribute on a multi-property scale', () => {
+    expect(extractParticipantRating(singlesRating('WTN', { confidence: 90, wtnRating: '4.13' }), 'wtn')).toEqual(4.13);
+  });
+});

--- a/src/services/formatWizard/extractRating.ts
+++ b/src/services/formatWizard/extractRating.ts
@@ -1,3 +1,4 @@
+import { resolveScaleValueNumber } from 'functions/resolveScaleValueNumber';
 import { fixtures } from 'tods-competition-factory';
 
 const { ratingsParameters } = fixtures;
@@ -26,9 +27,15 @@ export function extractParticipantRating(participant: any, scaleName: string): n
   const match = singlesArray.find(
     (item: any) => typeof item?.scaleName === 'string' && item.scaleName.toLowerCase() === target,
   );
-  if (!match?.scaleValue) return undefined;
+  // `!match?.scaleValue` would also discard a bare scaleValue of 0, which is a
+  // legitimate rating on PSA / ITTF / BWF / SQUASH_LEVELS.
+  if (match?.scaleValue === undefined || match?.scaleValue === null) return undefined;
 
+  // Was `typeof value === 'number'`. Ingested records store ratings as STRINGS
+  // ('12.48'), so this rejected every real rating while passing every
+  // mocksEngine fixture — and the caller pushes anything non-numeric into
+  // `excludedParticipantIds`, then bails with INSUFFICIENT_RATED_PARTICIPANTS.
+  // The whole format wizard therefore reported a fully rated field as unrated.
   const accessor = resolveAccessor(scaleName);
-  const value = match.scaleValue[accessor];
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  return resolveScaleValueNumber(match.scaleValue, { accessor, scaleName: scaleName.toUpperCase() });
 }


### PR DESCRIPTION
Completes the sweep started in #1384. All three sites shared the same root cause, and **none had any coverage** — `mocksEngine` emits clean numbers, while real ingested records store ratings as **strings**, carry **`''`** for a participant with no rating on a scale, and legitimately carry **`0`** on scales whose declared range includes it.

## The three

**`extractRating`** — the worst of them. `typeof value === 'number'` rejected every real rating. The caller turns a rejected rating into an *excluded participant* and then bails with `INSUFFICIENT_RATED_PARTICIPANTS`, so the **entire format wizard reported a fully rated field as unrated**: no distribution, no flighting strategies, no format plans. The `!match?.scaleValue` guard also discarded a bare `0`.

**`collectAvailableScales`** — `Number(raw)` behind an `isFinite` guard, so `''` entered the rating distribution as **0**. On UTR's `[1,16]` range that's a value a full unit below the floor, and it moved min, mean, stddev and the binning of the overview and participants charts.

**`ratingSorter`** — `a?.[accessor] || 0` gave unrated rows a 0, which lands at **opposite ends depending on the scale's direction**: unrated sorted to the top for UTR and the bottom for WTN, so the same "no rating" state read differently in two columns. It also collapsed a legitimate 0 into the same bucket as no rating at all. Unrated now sorts last explicitly, rather than via a numeric sentinel whose meaning flips with the comparator's polarity.

## One extraction

`collectAvailableScales` is split out of `participantScalings.ts` so it can be tested at all — that module imports `courthive-components`, which touches `document` at import time, and TMX's vitest env is node. `participantScalings` re-exports it so consumers keep one import path. Same reason the seeding comparator was extracted in #1384.

## Verification

**21 new specs. Falsified as a set:** with the three sites reverted and the tests kept, **8 fail across all three files**.

The additions to the existing `extractRating.test.ts` are **append-only — 37 insertions, 0 deletions** — so its original nine cases are untouched and still pass.

Full CI-gate equivalent, exit codes checked directly rather than through a pipe:

- `pnpm lint` — 0
- `pnpm check-types` — 0 (src + e2e + electron)
- `pnpm format:check` — 0
- `pnpm attr-audit --ci` — 0
- `pnpm i18n-audit --ci` — 0
- `pnpm test --run` — **161 files / 1778 tests** (from 159/1757)
- `pnpm build` — 0

Playwright journeys are local-only and were not run; nothing here touches a journey path.

With this, every site the audit found is closed: 6 in the factory (CourtHive/competition-factory#4721), 2 in #1384, 3 here.