### PR TITLE
chore(deps): take courthive-components 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.20.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "3.15.2",
+    "courthive-components": "4.0.0",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",


### PR DESCRIPTION
4.0.0's only breaking change is `renderInlineMatchUp` returning `HTMLElement | null`, and this repo's call site was guarded ahead of the release in [#1386](https://github.com/CourtHive/TMX/pull/1386) precisely so the bump would need no adaptation. It does not — this is a one-line pin change.

TMX sets `strictNullChecks`, so **without** that guard this bump would have failed `check-types` at `renderDrawView.ts`. That was the intended signal, and it is why the guard went in first.

Also picks up, none of them breaking:
- pressure: projected vs actual path difficulty (#537)
- pressure: read string rating values (#539)
- tournament-card: render entry fees at the stated scale (#542)

## Verification — TMX's full CI gate set

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm check-types` (src + e2e + electron) | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm test --run` | **1778** passed |
| `pnpm build` | 0 |