### PR TITLE
chore(deps): take factory 6.35.0 and courthive-components 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.20.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "4.0.0",
+    "courthive-components": "4.0.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.33.0",
+    "tods-competition-factory": "6.35.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
TMX was the **one consumer the 6.35.0 fan-out could not reach**. `bump-factory-consumers.sh` aborts the whole run on any dirty or off-default consumer, and TMX was on `refactor/consume-factory-build-from-sources`, so it was skipped with `--skip TMX`. This is that follow-up, plus the components bump.

| dep | was | now |
|---|---|---|
| `tods-competition-factory` | 6.33.0 | **6.35.0** |
| `courthive-components` | 4.0.0 | **4.0.1** |

Both verified to *resolve* correctly after install, not just to read correctly in the manifest — that distinction is what caught a stale-sibling trap during the courthive-public deploy, where pins said 4.0.0 while the `link:` sibling served 3.15.2.

## Gates

`check-types` 0 · `lint` 0 · **1778 tests across 161 files**.

## Note on scope

There is no `chore/components-4` branch and no components `4.1.0` — published versions end at 4.0.1, and TMX's only other branches are `docs`, `staging`, the renovate lockfile branch, and `release-please--branches--main--components--tmx` (which is PR #1385, the TMX 8.22.1 release, not a components branch). 4.0.1 is the current latest.

The `refactor/consume-factory-build-from-sources` work is separate and now open as **#1392**.