### PR TITLE
test(e2e): give the server-dependent journeys a live API under TEST_PROD

### DIFF
--- a/e2e/helpers/cfsProxy.ts
+++ b/e2e/helpers/cfsProxy.ts
@@ -1,0 +1,40 @@
+import type { Page } from '@playwright/test';
+import { SERVER } from './role-fixtures';
+
+/** API path prefixes CFS serves and TMX calls. */
+const API_PREFIXES = ['auth', 'provider', 'factory', 'registrations', 'admin', 'declarations'];
+const API_PATTERN = new RegExp(`/(${API_PREFIXES.join('|')})(/|$)`);
+
+/**
+ * Point the page's same-origin API calls at a real CFS, for the handful of
+ * journeys that need a live server.
+ *
+ * Why this is needed at all: Vite's env precedence puts `.env.production`
+ * (`SERVER=`) ahead of `.env.local`, so a `TEST_PROD=1` build calls its OWN
+ * origin. That is correct for real production — CFS serves the built TMX
+ * same-origin — but `vite preview` has no API behind it, so the calls 404
+ * against the preview server. The visible symptom is not an HTTP error: login
+ * silently fails, no token is stored, `getLoginState()` is empty, and
+ * capability-gated UI stays hidden. Specs then fail on a locator, pointing at
+ * the app instead of at the harness.
+ *
+ * Why per-spec rather than a `preview.proxy` in vite.config: a proxy is
+ * server-wide and changes the environment for all ~115 journeys at once.
+ * Measured — it made journey 61 fail, landing the app on the welcome screen
+ * instead of its seeded tournament, because tournament routing behaves
+ * differently once an API is reachable. The rest of the suite is written
+ * against "prod mode has no server"; only these few want one, so only these
+ * few opt in.
+ *
+ * Dev mode needs none of this: `.env.development` points `SERVER` at CFS
+ * directly, so the app already issues absolute cross-origin requests.
+ */
+export async function routeApiToCfs(page: Page): Promise<void> {
+  await page.route(API_PATTERN, async (route) => {
+    const url = new URL(route.request().url());
+    // Absolute calls already aimed at CFS (dev mode) need no rewriting.
+    if (url.origin === new URL(SERVER).origin) return route.continue();
+    const response = await route.fetch({ url: `${SERVER}${url.pathname}${url.search}` });
+    await route.fulfill({ response });
+  });
+}

--- a/e2e/journeys/103-app-shell-fills-viewport.spec.ts
+++ b/e2e/journeys/103-app-shell-fills-viewport.spec.ts
@@ -1,4 +1,5 @@
 import { SERVER, signInSuperAdmin, SUPERADMIN_EMAIL, SUPERADMIN_PASSWORD } from '../helpers/role-fixtures';
+import { routeApiToCfs } from '../helpers/cfsProxy';
 import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
 import { TournamentPage } from '../pages/TournamentPage';
 import { test, expect, type Page } from '@playwright/test';
@@ -108,6 +109,11 @@ test.describe('Journey 103 — the app shell fills the viewport', () => {
   test('the registrations table fills the workspace (CFS-gated)', async ({ page, request }) => {
     const reachable = !!(await signInSuperAdmin(request));
     test.skip(!reachable, `CFS at ${SERVER} / bootstrap super-admin unavailable`);
+
+    // Under TEST_PROD the built app calls its own origin, and `vite preview` has
+    // no API behind it — the login below would 404 and leave no session, hiding
+    // the very nav icon this test asserts on. See cfsProxy for the full why.
+    await routeApiToCfs(page);
 
     // Rows come from the declarations service (:3120), whose player surface is
     // HiveID-guarded — minting one of those tokens is a whole identity chain for

--- a/e2e/journeys/28-server-tournament-creation.spec.ts
+++ b/e2e/journeys/28-server-tournament-creation.spec.ts
@@ -1,3 +1,4 @@
+import { routeApiToCfs } from '../helpers/cfsProxy';
 import { test, expect } from '@playwright/test';
 import { waitForAppReady } from '../helpers/dev-bridge';
 
@@ -32,12 +33,35 @@ const PROVIDER_ABBR = 'TMX';
  *      past via executionQueue, THEN remove — and warn if it still wasn't removed
  *      so the failure is visible instead of silently leaking orphans.
  */
+/**
+ * Fetch the provider calendar as an OPERATOR — including unpublished tournaments.
+ *
+ * CFS 2.29.0 (`f972cdcd`) deliberately split these surfaces: `POST /provider/calendar`
+ * is now the PUBLIC, anonymous feed and returns **published tournaments only**, reduced
+ * to public fields. A tournament this journey has just created through the UI is not
+ * published, so the public feed correctly does not contain it.
+ *
+ * Both call sites below used the public route and broke silently in different ways: the
+ * assertion failed 60 lines from the cause with `expect(serverEntry).toBeTruthy()`
+ * receiving `undefined`, and — worse — the cleanup simply returned early, so every run
+ * since that release has ORPHANED its tournament on the server.
+ *
+ * `calendar/provider` is the operator feed for exactly this case. It is role-gated to
+ * ADMIN / SUPER_ADMIN; the seeded `e2e-client@courthive.com` carries `admin`.
+ */
+async function fetchOperatorCalendar(request: any, token: string): Promise<any[]> {
+  const result = await request.post(`${SERVER}/provider/calendar/provider`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { providerAbbr: PROVIDER_ABBR },
+  });
+  if (!result.ok()) return [];
+  const calendar = await result.json().catch(() => ({}));
+  return calendar?.calendar?.tournaments ?? calendar?.calendar ?? [];
+}
+
 async function cleanupServerTournament(request: any, token: string, tournamentName: string): Promise<void> {
   try {
-    const calendarResult = await request.post(`${SERVER}/provider/calendar`, { data: { providerAbbr: PROVIDER_ABBR } });
-    if (!calendarResult.ok()) return;
-    const calendar = await calendarResult.json();
-    const entries = calendar?.calendar?.tournaments ?? calendar?.calendar ?? [];
+    const entries = await fetchOperatorCalendar(request, token);
     const entry = entries.find((e: any) => (e.tournament?.tournamentName ?? e.tournamentName) === tournamentName);
     const tournamentId = entry?.tournamentId;
     if (!tournamentId) return; // never created (failed before save) or already removed
@@ -145,6 +169,10 @@ test.describe('Journey 28 — Authenticated server tournament creation', () => {
     // Record immediately so afterEach can clean up even if a later step fails.
     createdTournamentName = tournamentName;
 
+    // Under TEST_PROD the built app calls its own origin and `vite preview` has no
+    // API behind it, so the UI login below would 404 silently. See cfsProxy.
+    await routeApiToCfs(page);
+
     await page.goto('/');
     await waitForAppReady(page);
 
@@ -197,17 +225,16 @@ test.describe('Journey 28 — Authenticated server tournament creation', () => {
 
     // ── Verify tournament exists on server ──
     // Check calendar for the tournament
-    const calendarResult = await request.post(`${SERVER}/provider/calendar`, {
-      data: { providerAbbr: PROVIDER_ABBR },
-    });
-    const calendar = await calendarResult.json();
-    const entries = calendar?.calendar?.tournaments ?? calendar?.calendar ?? [];
+    const entries = await fetchOperatorCalendar(request, authToken);
     const serverEntry = entries.find((e: any) => {
       const name = e.tournament?.tournamentName ?? e.tournamentName;
       return name === tournamentName;
     });
 
-    expect(serverEntry).toBeTruthy();
+    expect(
+      serverEntry,
+      `"${tournamentName}" is not on ${PROVIDER_ABBR}'s operator calendar — the UI create did not reach the server`,
+    ).toBeTruthy();
     const tournamentId = serverEntry.tournamentId;
     expect(tournamentId).toBeTruthy();
 

--- a/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
+++ b/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
@@ -1,3 +1,4 @@
+import { routeApiToCfs } from '../helpers/cfsProxy';
 import { test, expect, type Page } from '@playwright/test';
 import { waitForAppReady } from '../helpers/dev-bridge';
 import {
@@ -42,6 +43,11 @@ let providerId = '';
 let provisionerId = '';
 
 async function loginViaModal(page: Page, email: string, password: string): Promise<void> {
+  // Under TEST_PROD the built app calls its own origin and `vite preview` has no API
+  // behind it, so this login 404s and leaves no session — which surfaced here as
+  // intermittent failure rather than a clean one, because the assertions race the
+  // (never-arriving) provider resolution. See cfsProxy.
+  await routeApiToCfs(page);
   await page.goto('/');
   await waitForAppReady(page);
   await page.locator('#login').click();


### PR DESCRIPTION
Fixes the two journeys that failed on a local full-suite run. They had **two unrelated
causes**, and both looked like app bugs. Neither was.

**Suite: 416 passed / 2 failed / 1 flaky → 421 passed / 0 failed / 0 flaky.**

## Journey 103 — failed only under `TEST_PROD`

Vite's env precedence puts `.env.production` ahead of `.env.local`, and `.env.production`
sets `SERVER=`. So a production build calls its **own origin** — correct for real
production, where CFS serves the built TMX same-origin — but `vite preview` has no API
behind it.

Measured rather than inferred: the login POST went to `http://localhost:4173/auth/login`
and returned **404**, no token was written, `getLoginState()` was empty, and
`canManageRegistrations` returned false at its `if (!login)` branch. The nav icon was
correctly hidden — the harness had simply never logged in. The same spec **passes in dev
mode**, where `.env.development` points `SERVER` at CFS.

## Journey 28 — failed in BOTH modes, and for something real

CFS 2.29.0 (`f972cdcd`) deliberately split the calendar surfaces:

| endpoint | audience | contents |
|---|---|---|
| `POST /provider/calendar` | public, anonymous | **published only**, reduced fields |
| `POST /provider/calendar/provider` | authenticated ADMIN/SUPER_ADMIN | full entries, **includes unpublished** |

The journey creates a tournament through the UI — unpublished — then looked for it on the
*public* feed, which legitimately no longer contains it. Now uses the operator feed.

**The break was worse than a failing assertion.** `cleanupServerTournament` read the same
public feed and returned early when it found nothing, so every run since that release has
**orphaned its tournament on the server**. One such orphan was found and removed.

## Why an opt-in helper and not `preview.proxy`

The obvious fix is a proxy in `vite.config.ts`. I implemented it, and **measured that it
breaks journey 61** — the app lands on the welcome screen instead of its seeded
tournament, because tournament routing behaves differently once an API is reachable. A
proxy is server-wide, and the other ~115 journeys are written against "prod mode has no
server". So the routing is a per-spec opt-in (`e2e/helpers/cfsProxy.ts`) and only the
three specs that want a live API take it. Journey 61 verified green again afterwards.

## Journey 36 — same root cause, was flaky rather than failing

`(real login)` hit the identical 404, which surfaced as intermittency because the
assertions raced a provider resolution that never arrived. Now deterministic with
`--retries=0`.

## Verification

- Full suite under `TEST_PROD=1`: **421 passed, 7 skipped, 0 failed, 0 flaky**, exit 0.
- CI lint-job gates all green: `lint`, `format:check`, `attr-audit --ci`, `i18n-audit --ci`,
  `check-types`, plus `check-types:e2e`. Unit suite 1739 passed.
- Diff is **e2e-only** — no `src/` and no config changes.
