### PR TITLE
fix(scoring): gate TMX's status promotion on the library's isScorable

### DIFF
--- a/src/pages/tournament/tabs/eventsTab/renderDraws/markReadyMatchUpsInProgress.test.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/markReadyMatchUpsInProgress.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// courthive-components imports CSS side-effects that touch `document` at module load, and TMX's
+// vitest config has no DOM environment. `isScorable`'s OWN behaviour — the format clause, the
+// pair-name path, every refusal case — is tested in courthive-components, which owns it. What this
+// file asserts is TMX's WIRING: that the promotion consults that gate rather than a local
+// approximation of it.
+const isScorable = vi.fn();
+vi.mock('courthive-components', () => ({ isScorable: (m: any) => isScorable(m) }));
+
+import { markReadyMatchUpsInProgress } from './markReadyMatchUpsInProgress';
+
+const ready = (matchUpId: string) => ({ matchUpId, readyToScore: true, matchUpStatus: 'TO_BE_PLAYED' });
+
+describe('markReadyMatchUpsInProgress', () => {
+  // Without this the call-count assertion below accumulates across tests — it caught exactly that.
+  beforeEach(() => isScorable.mockReset());
+  it('promotes a ready matchUp the gate admits', () => {
+    isScorable.mockReturnValue(true);
+    const m: any = ready('m1');
+    markReadyMatchUpsInProgress([m]);
+    expect(m.matchUpStatus).toBe('IN_PROGRESS');
+  });
+
+  it('does NOT promote a matchUp the gate refuses', () => {
+    // The point of the change. Promoting to IN_PROGRESS is what makes applyInlineScoringWrappers pick
+    // a matchUp up, and renderInlineMatchUp then refuses it — leaving a draw that shows a match as in
+    // progress with no way to score it.
+    isScorable.mockReturnValue(false);
+    const m: any = ready('m2');
+    markReadyMatchUpsInProgress([m]);
+    expect(m.matchUpStatus).toBe('TO_BE_PLAYED');
+  });
+
+  it('consults the gate for every matchUp, not just the first', () => {
+    isScorable.mockReturnValue(true);
+    markReadyMatchUpsInProgress([ready('a'), ready('b'), ready('c')] as any[]);
+    expect(isScorable).toHaveBeenCalledTimes(3);
+  });
+
+  it('leaves a matchUp that already has a winner alone', () => {
+    isScorable.mockReturnValue(true);
+    const m: any = { ...ready('m3'), winningSide: 1 };
+    markReadyMatchUpsInProgress([m]);
+    expect(m.matchUpStatus).toBe('TO_BE_PLAYED');
+  });
+
+  it('leaves a matchUp that is not readyToScore alone', () => {
+    isScorable.mockReturnValue(true);
+    const m: any = { matchUpId: 'm4', matchUpStatus: 'TO_BE_PLAYED' };
+    markReadyMatchUpsInProgress([m]);
+    expect(m.matchUpStatus).toBe('TO_BE_PLAYED');
+  });
+
+  it('survives an empty or absent list', () => {
+    expect(() => markReadyMatchUpsInProgress([])).not.toThrow();
+    expect(() => markReadyMatchUpsInProgress(undefined as any)).not.toThrow();
+  });
+});

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/markReadyMatchUpsInProgress.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/markReadyMatchUpsInProgress.ts
@@ -1,0 +1,24 @@
+import { isScorable } from 'courthive-components';
+
+/**
+ * Promote ready matchUps to IN_PROGRESS so the inline-scoring wrapper picks them up.
+ *
+ * Extracted from `renderDrawView` so the gate below is testable: `renderDrawView` reaches the DOM and
+ * TMX has no jsdom, so a decision left inside it gets no unit coverage.
+ *
+ * The gate is the LIBRARY's `isScorable`, not a local approximation. Marking IN_PROGRESS is precisely
+ * what makes `applyInlineScoringWrappers` pick a matchUp up, so a looser rule here promotes matchUps
+ * that `renderInlineMatchUp` then refuses — a draw showing a match as in progress with no way to score
+ * it. The predicate this replaced checked that both sides HAD participants, but not that they could be
+ * NAMED, and never checked `matchUpFormat` at all.
+ *
+ * Mutates in place, matching the previous behaviour and the caller's expectation.
+ */
+export function markReadyMatchUpsInProgress(displayMatchUps: any[]): void {
+  for (const m of displayMatchUps || []) {
+    if (!isScorable(m)) continue;
+    if (m?.readyToScore && !m?.winningSide && (!m?.matchUpStatus || m.matchUpStatus === 'TO_BE_PLAYED')) {
+      m.matchUpStatus = 'IN_PROGRESS';
+    }
+  }
+}

--- a/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
+++ b/src/pages/tournament/tabs/eventsTab/renderDraws/renderDrawView.ts
@@ -3,6 +3,7 @@
  * Handles draw display, participant filtering, and morphdom-based updates.
  */
 import { applySwissScoreGroupShading, sortSwissRoundMatchUpsByScoreGroup } from './applySwissScoreGroupShading';
+import { markReadyMatchUpsInProgress } from './markReadyMatchUpsInProgress';
 import { eventConstants, drawDefinitionConstants, tools, publishingGovernor } from 'tods-competition-factory';
 import { createSwissStandingsTable } from 'components/tables/swissStandingsTable/createSwissStandingsTable';
 import { shouldShowDrawMinimap, wireDrawMinimap, pickMinimapQuarterCount } from './applyDrawMinimap';
@@ -42,6 +43,7 @@ import {
   buildStructureMinimap,
   compositions,
   controlBar,
+  isScorable,
   renderContainer,
   renderInlineMatchUp,
   renderStructure,
@@ -109,16 +111,6 @@ function renderEmptyStructure(
   }
 }
 
-function markReadyMatchUpsInProgress(displayMatchUps: any[]): void {
-  for (const m of displayMatchUps) {
-    const hasBothParticipants = m?.sides?.length === 2 && m.sides[0]?.participant && m.sides[1]?.participant;
-    if (!hasBothParticipants) continue;
-    if (m?.readyToScore && !m?.winningSide && (!m?.matchUpStatus || m.matchUpStatus === 'TO_BE_PLAYED')) {
-      m.matchUpStatus = 'IN_PROGRESS';
-    }
-  }
-}
-
 function applyInlineScoringWrappers(
   structureContent: HTMLElement,
   displayMatchUps: any[],
@@ -132,7 +124,9 @@ function applyInlineScoringWrappers(
     const isInProgress = m?.matchUpStatus === 'IN_PROGRESS' && !m?.winningSide;
     const isIrregularEnding = irregularStatuses.has(m?.matchUpStatus);
     if (!isInProgress && !isIrregularEnding) continue;
-    if (!m?.sides?.length || !m.sides[0]?.participant || !m.sides[1]?.participant) continue;
+    // renderInlineMatchUp refuses these anyway and returns null; checking here keeps the two in step
+    // and skips the work rather than relying on the null path for correctness.
+    if (!isScorable(m)) continue;
 
     const existing = structureContent.querySelector(`#${CSS.escape(m.matchUpId)}`);
     if (!existing?.parentElement) continue;


### PR DESCRIPTION
TMX carried **two local approximations** of the scoring gate, both weaker than the one courthive-components 4.0.0 publishes. Each checked that a side *had* a participant, but not that it could be **named**, and neither checked `matchUpFormat` at all.

## The one that mattered

`markReadyMatchUpsInProgress` promotes a matchUp to `IN_PROGRESS`, and that promotion is **precisely what makes `applyInlineScoringWrappers` pick it up**. `renderInlineMatchUp` then refuses it and returns `null` — so a draw could show a match as *in progress* with no way to score it.

Data integrity was never at risk (the library refuses). The defect was a visible inconsistency between what the draw claimed and what it offered.

Both call sites now use `isScorable`, so TMX and the library cannot drift on what "scorable" means.

## Why it needed extracting

`renderDrawView` reaches the DOM and TMX has no jsdom, so a decision left inside it gets **no unit coverage** — which is exactly how this survived. The change type-checked, linted, and left the suite at **1739 passing without a single test touching it**. That is the shape of change this session has repeatedly caught, so I extracted it rather than shipping it uncovered.

The specs assert TMX's **wiring** — that the promotion consults the gate. `isScorable`'s own behaviour is tested in courthive-components, which owns it and covers it at 100%; asserting it again through a mock here would only be testing the mock.

## Falsified

From a coherently-compiling state (`check-types` and `lint` exit 0): restoring the weak predicate reddens two specs.

A first version of the call-count spec also failed because the mock accumulated across tests — caught by that spec, fixed with a `mockReset`.

## Verification — TMX's full CI gate set

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm check-types` (src + e2e + electron) | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm test --run` | **1745** (from 1739) |
| `pnpm build` | 0 |

`format:check` initially failed on a stray blank line my extraction left in `renderDrawView.ts` — verified as mine rather than pre-existing, and fixed.