### PR TITLE
chore(deps): pin tods-competition-factory 6.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.35.0",
+    "tods-competition-factory": "6.37.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Fan-out of factory **6.37.0** ([#4751](https://github.com/CourtHive/competition-factory/pull/4751)), which makes `readModel.entryRows()` emit a TEAM entry's **issued** id (`participantOtherIds`) and its issuing organisation.

Levelling only for this repo — the functional consumer is CFS ([#955](https://github.com/CourtHive/competition-factory-server/pull/955)), which is what actually starts the column flowing into the read model.

`package.json` only: `pnpm-lock.yaml` records `specifier: link:../factory`, so the pin never reaches the lockfile.

⚠️ **A green local build proves nothing about this change.** Every consumer resolves the factory through the `link:../factory` override and compiles the canonical checkout, not the pinned version. CI strips the override and installs 6.37.0 — that is the only place the pin is exercised, so CI is the gate here and I am not claiming local verification I did not do.

The published tarball was checked rather than trusted: `organisation_id` is present in 6.37.0's `.d.ts` and production bundle, so the release carries the change.