### PR TITLE
fix(deps): raise fast-uri to a patched version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   brace-expansion@>=4 <5.0.5: ^5.0.5
   courthive-components: link:../courthive-components
   dompurify: ^3.4.12
-  fast-uri: ^4.0.0
+  fast-uri: ^4.1.3
   follow-redirects: ^1.16.0
   pdf-factory: link:../pdf-factory
   picomatch: ^4.0.4
@@ -2500,8 +2500,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5682,7 +5682,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6749,7 +6749,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,10 @@ overrides:
   'brace-expansion@>=4 <5.0.5': ^5.0.5
   courthive-components: link:../courthive-components
   dompurify: ^3.4.12 # GHSA (XSS); transitive via jspdf (^3.3.1). patched 3.4.12
-  fast-uri: ^4.0.0 # GHSA-v2hh-gcrm-f6hx (host confusion, high); transitive via ajv (^3.0.1). patched 3.1.4
+  # A security FLOOR, not a range. It was '^4.0.0' for an earlier advisory and stopped being
+  # a floor when four more landed INSIDE 4.x (host confusion x2, SSRF x2), all first patched
+  # in 4.1.3 while the lockfile sat on 4.1.2. Pin the floor to the patched version.
+  fast-uri: '^4.1.3'
   follow-redirects: ^1.16.0
   pdf-factory: link:../pdf-factory
   picomatch: ^4.0.4


### PR DESCRIPTION
The override was already there and was written as a security FLOOR — its comment says so. It
was expressed as a caret range, which stopped being a floor the moment four further advisories
landed INSIDE that range: host confusion x2 and SSRF x2 (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc,
GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp). So it kept resolving happily while permitting precisely
the versions it was added to exclude.

A caret expresses "compatible with", not "at least as safe as". Where the intent is a security
floor the range has to be pinned to the patched version, or it decays into permission the next time
an advisory lands within it — silently, with the reassuring comment still attached.

Now resolves 4.1.4 .

Transitive dev dependency (commitlint -> ajv), so nothing reaches shipped output; the alerts are
real but their scope is the toolchain. Verified with a real install rather than --lockfile-only,
which updates the lockfile without touching node_modules and would have tested the old version.
