### PR TITLE
fix(e2e): stop the CFS proxy from swallowing Vite modules and spec stubs

### DIFF
--- a/e2e/helpers/cfsProxy.ts
+++ b/e2e/helpers/cfsProxy.ts
@@ -3,7 +3,26 @@ import { SERVER } from './role-fixtures';
 
 /** API path prefixes CFS serves and TMX calls. */
 const API_PREFIXES = ['auth', 'provider', 'factory', 'participation', 'registrations', 'admin', 'declarations'];
-const API_PATTERN = new RegExp(`/(${API_PREFIXES.join('|')})(/|$)`);
+
+/**
+ * Anchored at the START of the path — a CFS endpoint is always `/<prefix>/…` at
+ * the root. The anchor is load-bearing: unanchored, this matched anywhere in the
+ * URL, and in dev mode Vite serves every source module from the same origin, so
+ * `/src/services/factory/engine.ts`, `/src/services/provider/providerState.ts`,
+ * `/src/pages/admin/renderAdminPage.ts` and `/src/pages/participation/…` were all
+ * "API calls" — as was `/@fs/…/CourtHive/factory/dist/esm/index.mjs`, the linked
+ * competition-factory bundle, because the repo directory is itself named
+ * `factory`. Each was re-fetched from CFS, 404'd, and took the module graph with
+ * it: the app never booted, and all nine CFS-gated journeys failed identically on
+ * `waitForSelector('#dnav')` against a blank page. Journey 120 guards this.
+ */
+const API_PATH_PATTERN = new RegExp(`^/(${API_PREFIXES.join('|')})(/|$)`);
+
+/** True for a CFS endpoint path, false for anything Vite serves. Exported for journey 120. */
+export const isCfsApiPath = (pathname: string): boolean => API_PATH_PATTERN.test(pathname);
+
+/** Pages this proxy is already installed on — see the idempotence note below. */
+const installedOn = new WeakSet<Page>();
 
 /**
  * Point the page's same-origin API calls at a real CFS, for the handful of
@@ -27,14 +46,34 @@ const API_PATTERN = new RegExp(`/(${API_PREFIXES.join('|')})(/|$)`);
  * few opt in.
  *
  * Dev mode needs none of this: `.env.development` points `SERVER` at CFS
- * directly, so the app already issues absolute cross-origin requests.
+ * directly, so the app already issues absolute cross-origin requests. It still
+ * has to survive being installed there, though — these journeys run in dev like
+ * every other one, so the matcher must not touch anything Vite serves.
  */
 export async function routeApiToCfs(page: Page): Promise<void> {
-  await page.route(API_PATTERN, async (route) => {
-    const url = new URL(route.request().url());
-    // Absolute calls already aimed at CFS (dev mode) need no rewriting.
-    if (url.origin === new URL(SERVER).origin) return route.continue();
-    const response = await route.fetch({ url: `${SERVER}${url.pathname}${url.search}` });
-    await route.fulfill({ response });
-  });
+  // Idempotent, and that matters. Playwright matches the LAST-registered route
+  // FIRST, and `AuthFlow.login()` installs this proxy itself — so a spec that
+  // installed it, then registered its own stub, then logged in would have the
+  // re-installed proxy jump ahead of that stub and silently shadow it. Journey
+  // 103 lost its registrations stub exactly that way: the request escaped to the
+  // real declarations service, 404'd, and the table rendered zero rows.
+  if (installedOn.has(page)) return;
+  installedOn.add(page);
+
+  await page.route(
+    (url) => isCfsApiPath(url.pathname),
+    async (route) => {
+      const request = route.request();
+      // Only ever proxy data calls. A script/stylesheet/document reaching this
+      // handler means the matcher over-matched; passing it through keeps a
+      // future mistake from silently emptying the page again.
+      if (!['xhr', 'fetch'].includes(request.resourceType())) return route.fallback();
+
+      const url = new URL(request.url());
+      // Absolute calls already aimed at CFS (dev mode) need no rewriting.
+      if (url.origin === new URL(SERVER).origin) return route.continue();
+      const response = await route.fetch({ url: `${SERVER}${url.pathname}${url.search}` });
+      await route.fulfill({ response });
+    },
+  );
 }

--- a/e2e/journeys/120-cfs-proxy-scope.spec.ts
+++ b/e2e/journeys/120-cfs-proxy-scope.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { isCfsApiPath, routeApiToCfs } from '../helpers/cfsProxy';
+import { waitForAppReady } from '../helpers/dev-bridge';
+
+/**
+ * Journey 120 — the CFS proxy must not intercept anything Vite serves.
+ *
+ * `routeApiToCfs()` rewrites the page's API calls to a live CFS. Its matcher used
+ * to be an UNANCHORED regex tested against the whole URL, so in dev mode — where
+ * Vite serves every source module from the page's own origin — it also captured
+ * `/src/services/factory/…`, `/src/services/provider/…`, `/src/pages/admin/…`,
+ * `/src/pages/participation/…` and `/@fs/…/CourtHive/factory/dist/esm/index.mjs`
+ * (the repo directory is named `factory`). Those module requests were re-fetched
+ * from CFS, 404'd, and the app never booted: a blank page, and all nine CFS-gated
+ * journeys failing identically on `waitForSelector('#dnav')`.
+ *
+ * Nothing caught it because the whole cluster self-skips unless a server is
+ * reachable, and journeys are in no CI workflow — so the failure only appears
+ * when someone deliberately runs the suite against a live CFS.
+ *
+ * This spec needs no server: it asserts that installing the proxy leaves the app
+ * able to boot, and that no script request dies while it is installed.
+ */
+test.describe('Journey 120 — CFS proxy scope', () => {
+  test('installing the proxy does not break the module graph', async ({ page }) => {
+    const failedScripts: string[] = [];
+    page.on('requestfailed', (request) => {
+      if (['script', 'stylesheet', 'document'].includes(request.resourceType())) {
+        failedScripts.push(`${request.resourceType()} ${new URL(request.url()).pathname}`);
+      }
+    });
+
+    await routeApiToCfs(page);
+    await page.goto('/');
+
+    // The real assertion: the app boots. This is the exact wait that failed for
+    // every CFS-gated journey while the matcher was over-broad.
+    await waitForAppReady(page);
+
+    expect(failedScripts, 'the proxy must not swallow anything Vite serves').toEqual([]);
+  });
+
+  test('re-installing the proxy does not shadow a stub registered in between', async ({ page }) => {
+    // Playwright matches the LAST-registered route FIRST, and `AuthFlow.login()`
+    // installs the proxy itself. Before the installer was made idempotent, the
+    // sequence below let the second install jump ahead of the stub — which is how
+    // journey 103's registrations stub stopped applying: the request escaped to
+    // the real declarations service, 404'd, and the table rendered zero rows
+    // while every geometry assertion after it stayed green for the wrong reason.
+    await routeApiToCfs(page);
+    await page.route('**/registrations?*', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ stub: true }]) }),
+    );
+    await routeApiToCfs(page); // what AuthFlow.login() does
+
+    await page.goto('/');
+    const body = await page.evaluate(() =>
+      fetch('http://localhost:3120/registrations?provider=E2E&tournamentId=probe').then((r) => r.text()),
+    );
+
+    expect(JSON.parse(body), 'the spec-level stub must still win').toEqual([{ stub: true }]);
+  });
+
+  test('the matcher accepts CFS endpoints and rejects Vite paths', () => {
+    for (const apiPath of [
+      '/auth/login',
+      '/provider/list',
+      '/factory/tournament',
+      '/participation/index',
+      '/registrations/profile',
+      '/admin/users',
+      '/declarations/list',
+      '/auth',
+    ]) {
+      expect(isCfsApiPath(apiPath), `${apiPath} should reach CFS`).toBe(true);
+    }
+
+    for (const vitePath of [
+      '/src/services/factory/engine.ts',
+      '/src/services/provider/providerState.ts',
+      '/src/services/provider/initProviderSwitcher.ts',
+      '/src/pages/admin/renderAdminPage.ts',
+      '/src/pages/participation/renderProviderSchedulePage.ts',
+      '/@fs/Users/someone/Development/GitHub/CourtHive/factory/dist/esm/index.mjs',
+      '/node_modules/.vite/deps/tods-competition-factory.js',
+      '/assets/index-D4nT9v.js',
+      '/',
+    ]) {
+      expect(isCfsApiPath(vitePath), `${vitePath} must be served by Vite`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
The nine CFS-gated journeys — 28, 36, 58, 71, 72, 73, 76, 103, 119 — have been failing 15 tests with a single error: `waitForSelector('#dnav')` timing out against a **blank page**. Both causes are in the e2e harness. Nothing is wrong with the app.

They went unseen because that cluster self-skips unless a live CFS is reachable, and journeys are in no CI workflow — so the failures only appear when someone deliberately runs the suite against a running server.

## 1. The proxy matcher was unanchored (14 of the 15)

`routeApiToCfs()` matched `/(auth|provider|factory|participation|registrations|admin|declarations)(/|$)` against the **whole URL**. In dev mode Vite serves every source module from the page's own origin, so those module requests were "API calls" and got re-fetched from CFS.

Instrumented before changing anything — six requests intercepted, all `script`, all 404:

```
/src/services/provider/initProviderSwitcher.ts
/src/services/provider/providerState.ts
/src/services/factory/engine.ts
/src/pages/participation/renderProviderSchedulePage.ts
/src/pages/admin/renderAdminPage.ts
/@fs/…/CourtHive/factory/dist/esm/index.mjs
```

That last one is the linked competition-factory bundle, caught because the repo directory is itself named `factory`. With those 404ing the module graph never resolves: `body.innerHTML` measured 158 characters and `#dnav` never existed — hence the blank screenshot.

**Fix:** anchor at the start of the *path* (`^/(auth|…)(/|$)`) using a URL predicate rather than a whole-URL regex, plus a `resourceType` guard that falls through anything which isn't xhr/fetch — so a future over-match can't silently empty the page again.

## 2. Re-installing the proxy shadowed spec stubs (the 15th)

Playwright matches the **last-registered** route **first** (measured, not assumed). Journey 103 installs the proxy, registers a `**/registrations?*` stub, then calls `AuthFlow.login()` — which installs the proxy *again*, jumping ahead of the stub. The registrations read escaped to the real declarations service on :3120, 404'd, and the table rendered zero rows.

The spec caught this honestly rather than passing vacuously — its own `expect(rowCount).toBeGreaterThan(5)` anti-vacuity guard is what failed, which is why the geometry assertions after it never got a chance to pass for the wrong reason.

**Fix:** the installer is idempotent per page.

## Journey 120 guards both, and both guards were falsified

New spec asserts the app still boots with the proxy installed, that no script/stylesheet/document request dies while it is installed, that a stub registered between two installs still wins, and that the matcher accepts CFS endpoints while rejecting Vite paths.

Reverting each fix makes the corresponding test fail with the original symptom — the `#dnav` timeout for the matcher, and CFS's 404 in place of the stub body for the idempotence. It needs no server, so it runs in a normal local suite.

## Result

| | before | after |
|---|---|---|
| full journey suite | 416 passed / **15 failed** in 22.8m | **434 passed / 0 failed** in 11.6m |

Zero `ERR_CONNECTION_REFUSED` in both runs, so neither number is a dev-server artefact. The run is faster because 15 failures are no longer burning three attempts each. `lint`, `format:check`, `attr-audit`, `i18n-audit` and `check-types` all pass.
