### PR TITLE
fix(e2e): delete the providers and users the journeys create

### DIFF
--- a/e2e/helpers/participationFixtures.ts
+++ b/e2e/helpers/participationFixtures.ts
@@ -1,7 +1,7 @@
 import type { APIRequestContext } from '@playwright/test';
 import { mocksEngine } from 'tods-competition-factory';
 
-import { SERVER, ensureProvider, uniqueAbbr, uniqueSuffix } from './role-fixtures';
+import { SERVER, deleteProvider, ensureProvider, uniqueAbbr, uniqueSuffix } from './role-fixtures';
 
 /**
  * Server-side fixture for the participation (schedule) journey.
@@ -36,6 +36,7 @@ export interface SeededProgramme {
 
 export interface ParticipationFixture {
   governingProviderId: string;
+  governingAbbr: string;
   programmeA: SeededProgramme;
   programmeB: SeededProgramme;
   emptyProgramme: SeededProgramme;
@@ -80,12 +81,8 @@ export async function seedParticipationFixture(
 ): Promise<ParticipationFixture> {
   const suffix = uniqueSuffix();
 
-  const governingProviderId = await ensureProvider(
-    request,
-    token,
-    uniqueAbbr('GOV'),
-    `E2E Governing Body ${suffix}`,
-  );
+  const governingAbbr = uniqueAbbr('GOV');
+  const governingProviderId = await ensureProvider(request, token, governingAbbr, `E2E Governing Body ${suffix}`);
   const programmeA = await seedProgramme(request, token, 'A', suffix);
   const programmeB = await seedProgramme(request, token, 'B', suffix);
   const emptyProgramme = await seedProgramme(request, token, 'Z', suffix);
@@ -114,6 +111,7 @@ export async function seedParticipationFixture(
 
   return {
     governingProviderId,
+    governingAbbr,
     programmeA,
     programmeB,
     emptyProgramme,
@@ -147,4 +145,12 @@ export async function cleanupParticipationFixture(
     headers: authHeaders(token),
     data: { providerId: fixture.governingProviderId, tournamentId: fixture.tournamentId },
   });
+
+  // The tournament was only ever half the fixture. Until this was added, every
+  // run left four providers behind (governing body + three programmes), which is
+  // most of the nine a full journey run used to silt into the dev database.
+  for (const programme of [fixture.programmeA, fixture.programmeB, fixture.emptyProgramme]) {
+    await deleteProvider(request, token, programme.providerId, programme.abbr);
+  }
+  await deleteProvider(request, token, fixture.governingProviderId, fixture.governingAbbr);
 }

--- a/e2e/helpers/role-fixtures.ts
+++ b/e2e/helpers/role-fixtures.ts
@@ -48,6 +48,70 @@ export async function signInSuperAdmin(request: APIRequestContext): Promise<stri
   }
 }
 
+/**
+ * Abbreviations minted by `uniqueAbbr` in THIS process — the only ones
+ * `deleteProvider` will ever act on. See the refusal there for why.
+ */
+const mintedAbbrs = new Set<string>();
+
+/**
+ * Run a teardown call, absorbing anything it throws.
+ *
+ * Teardown runs in `afterAll`, and Playwright attributes a throw there to the
+ * LAST TEST in the file — so a spec that passed every assertion is reported red
+ * for a cleanup that had no bearing on what it proved. Measured, not theorised:
+ * adding the journey 76 user removal turned a passing spec red the first time
+ * `localhost` resolved to `::1` while CFS was listening on IPv4 only.
+ *
+ * Cleanup is best-effort by definition — CFS's `cleanup-test-data.mjs` is the
+ * backstop for whatever a crashed run leaves behind — so every teardown call
+ * goes through here and warns instead.
+ */
+async function bestEffort(label: string, run: () => Promise<void>): Promise<void> {
+  try {
+    await run();
+  } catch (err: any) {
+    console.warn(`teardown ${label} failed (ignored): ${err?.message ?? err}`);
+  }
+}
+
+/**
+ * Delete a provider this run created. Cleanup only — never call it on anything
+ * a run did not mint.
+ *
+ * `POST /provider/:id/delete` is Plan A DESTRUCTIVE: it wipes the provider's
+ * tournaments with no archive row and no revive. That is fine for a fixture that
+ * exists for ninety seconds, and unacceptable for anything else — so this refuses
+ * any abbreviation `uniqueAbbr` did not mint in this process, rather than
+ * trusting an `E2E` prefix. A pattern match would delete a real provider the day
+ * someone names one "E2E Demo", and journey 28's fixed `TMX` abbreviation is
+ * excluded by construction rather than by remembering to special-case it.
+ *
+ * Never throws: a teardown failure must not turn a green run red. Mirrors the
+ * warn-and-continue that journey 28's tournament cleanup already uses.
+ */
+export async function deleteProvider(
+  request: APIRequestContext,
+  token: string,
+  providerId: string | undefined,
+  organisationAbbreviation: string | undefined,
+): Promise<void> {
+  if (!providerId || !organisationAbbreviation) return;
+  if (!mintedAbbrs.has(organisationAbbreviation)) {
+    console.warn(`deleteProvider refused "${organisationAbbreviation}": not minted by this run — leaving it alone.`);
+    return;
+  }
+  await bestEffort(`deleteProvider(${organisationAbbreviation})`, async () => {
+    const res = await request.post(`${SERVER}/provider/${providerId}/delete`, {
+      headers: authHeaders(token),
+      data: { confirm: organisationAbbreviation, acknowledgeDataLoss: true },
+    });
+    if (!res.ok()) {
+      console.warn(`deleteProvider(${organisationAbbreviation}) → ${res.status()}: ${await res.text()}`);
+    }
+  });
+}
+
 export async function ensureProvider(
   request: APIRequestContext,
   token: string,
@@ -113,7 +177,9 @@ export async function createLoginableUser(
 
 export async function removeUser(request: APIRequestContext, token: string, email: string): Promise<void> {
   if (!email) return;
-  await request.post(`${SERVER}/auth/remove`, { headers: authHeaders(token), data: { email } });
+  await bestEffort(`removeUser(${email})`, async () => {
+    await request.post(`${SERVER}/auth/remove`, { headers: authHeaders(token), data: { email } });
+  });
 }
 
 export async function createProvisioner(request: APIRequestContext, token: string, name: string): Promise<string> {
@@ -157,11 +223,13 @@ export async function cleanupProvisioner(
   provisionerId: string,
 ): Promise<void> {
   if (!provisionerId) return;
-  await request.put(`${SERVER}/admin/provisioners/${provisionerId}`, {
-    headers: authHeaders(token),
-    data: { isActive: false },
+  await bestEffort(`cleanupProvisioner(${provisionerId})`, async () => {
+    await request.put(`${SERVER}/admin/provisioners/${provisionerId}`, {
+      headers: authHeaders(token),
+      data: { isActive: false },
+    });
+    await request.delete(`${SERVER}/admin/provisioners/${provisionerId}`, { headers: authHeaders(token) });
   });
-  await request.delete(`${SERVER}/admin/provisioners/${provisionerId}`, { headers: authHeaders(token) });
 }
 
 export function uniqueSuffix(): string {
@@ -178,9 +246,14 @@ export function uniqueSuffix(): string {
  * abbreviation per run sidesteps that entirely. The `E2E` prefix keeps these in
  * scope of CFS's cleanup-test-data.mjs (which matches abbreviation LIKE 'E2E%').
  * Kept short (~8 chars) so it renders cleanly in the provider badge.
+ *
+ * Minting also RECORDS the abbreviation, which is what makes `deleteProvider`
+ * safe: teardown can only touch providers this process created.
  */
 export function uniqueAbbr(tag = ''): string {
   const t = Date.now().toString(36).slice(-4);
   const r = Math.floor(Math.random() * 46_656).toString(36); // up to 3 base-36 chars
-  return `E2E${tag}${t}${r}`.toUpperCase();
+  const abbr = `E2E${tag}${t}${r}`.toUpperCase();
+  mintedAbbrs.add(abbr);
+  return abbr;
 }

--- a/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
+++ b/e2e/journeys/36-provider-switcher-admin-gating.spec.ts
@@ -7,6 +7,7 @@ import {
   uniqueSuffix,
   uniqueAbbr,
   removeUser,
+  deleteProvider,
   ensureProvider,
   createProvisioner,
   signInSuperAdmin,
@@ -36,6 +37,7 @@ const DIRECTOR_EMAIL = `e2e-tmx-director-${suffix}@courthive.test`;
 const REP_EMAIL = `e2e-tmx-rep-${suffix}@courthive.test`;
 const PROVISIONER_NAME = `E2E-TMX-Provisioner-${suffix}`;
 const PROVIDER_NAME = 'E2E TMX Role Provider';
+const providerAbbr = uniqueAbbr('R');
 
 let token: string | null = null;
 let seeded = false;
@@ -68,7 +70,7 @@ test.describe('Journey 36 — provider switcher + admin gating (real login)', ()
     token = await signInSuperAdmin(request);
     if (!token) return; // seed admin unavailable → tests skip below
 
-    providerId = await ensureProvider(request, token, uniqueAbbr('R'), PROVIDER_NAME);
+    providerId = await ensureProvider(request, token, providerAbbr, PROVIDER_NAME);
     await createLoginableUser(request, token, {
       email: PROVIDER_ADMIN_EMAIL,
       roles: ['client'],
@@ -94,6 +96,7 @@ test.describe('Journey 36 — provider switcher + admin gating (real login)', ()
     await removeUser(request, token, PROVIDER_ADMIN_EMAIL);
     await removeUser(request, token, DIRECTOR_EMAIL);
     await removeUser(request, token, REP_EMAIL);
+    await deleteProvider(request, token, providerId, providerAbbr);
   });
 
   test('PROVIDER_ADMIN sees the Admin item in the account menu', async ({ page }) => {

--- a/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
+++ b/e2e/journeys/58-provider-switch-impersonation-persist.spec.ts
@@ -4,6 +4,7 @@ import { routeApiToCfs } from '../helpers/cfsProxy';
 import {
   SERVER,
   ensureProvider,
+  deleteProvider,
   uniqueSuffix,
   uniqueAbbr,
   signInSuperAdmin,
@@ -46,6 +47,9 @@ const PROVIDER_A_NAME = `E2E Switch Alpha ${suffix}`;
 const PROVIDER_B_NAME = `E2E Switch Beta ${suffix}`;
 const PATCH_LAST_SELECTED = '/auth/me/last-selected-provider';
 
+let providerAId: string | undefined;
+let providerBId: string | undefined;
+
 let token: string | null = null;
 let seeded = false;
 
@@ -85,9 +89,15 @@ test.describe('Journey 58 — super-admin provider switch (real login)', () => {
   test.beforeAll(async ({ request }) => {
     token = await signInSuperAdmin(request);
     if (!token) return; // seed admin unavailable → tests skip below
-    await ensureProvider(request, token, PROVIDER_A_ABBR, PROVIDER_A_NAME);
-    await ensureProvider(request, token, PROVIDER_B_ABBR, PROVIDER_B_NAME);
+    providerAId = await ensureProvider(request, token, PROVIDER_A_ABBR, PROVIDER_A_NAME);
+    providerBId = await ensureProvider(request, token, PROVIDER_B_ABBR, PROVIDER_B_NAME);
     seeded = true;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (!token) return;
+    await deleteProvider(request, token, providerAId, PROVIDER_A_ABBR);
+    await deleteProvider(request, token, providerBId, PROVIDER_B_ABBR);
   });
 
   test('selecting a provider persists without an authorisation error and shows its abbreviation', async ({ page }) => {

--- a/e2e/journeys/71-publishing-login-gating.spec.ts
+++ b/e2e/journeys/71-publishing-login-gating.spec.ts
@@ -4,6 +4,7 @@ import { seedTournament, PROFILE_R1_COMPLETE } from '../helpers/seed';
 import {
   SERVER,
   ensureProvider,
+  deleteProvider,
   uniqueSuffix,
   uniqueAbbr,
   signInSuperAdmin,
@@ -35,13 +36,20 @@ const PROVIDER_ABBR = uniqueAbbr('P');
 const PROVIDER_NAME = `E2E Publish ${uniqueSuffix()}`;
 
 let seeded = false;
+let token: string | null = null;
+let providerId: string | undefined;
 
 test.describe('Journey 71 — publishing login gating', () => {
   test.beforeAll(async ({ request }) => {
-    const token = await signInSuperAdmin(request);
+    token = await signInSuperAdmin(request);
     if (!token) return;
-    await ensureProvider(request, token, PROVIDER_ABBR, PROVIDER_NAME);
+    providerId = await ensureProvider(request, token, PROVIDER_ABBR, PROVIDER_NAME);
     seeded = true;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (!token) return;
+    await deleteProvider(request, token, providerId, PROVIDER_ABBR);
   });
 
   test('a real login + active provider unlocks the publishing controls', async ({ page }) => {

--- a/e2e/journeys/73-chat-indicator-gating.spec.ts
+++ b/e2e/journeys/73-chat-indicator-gating.spec.ts
@@ -4,6 +4,7 @@ import { seedTournament, PROFILE_DRAW_GENERATED } from '../helpers/seed';
 import {
   SERVER,
   ensureProvider,
+  deleteProvider,
   uniqueSuffix,
   uniqueAbbr,
   signInSuperAdmin,
@@ -29,13 +30,20 @@ const PROVIDER_ABBR = uniqueAbbr('C');
 const PROVIDER_NAME = `E2E Chat ${uniqueSuffix()}`;
 
 let seeded = false;
+let token: string | null = null;
+let providerId: string | undefined;
 
 test.describe('Journey 73 — chat indicator gating', () => {
   test.beforeAll(async ({ request }) => {
-    const token = await signInSuperAdmin(request);
+    token = await signInSuperAdmin(request);
     if (!token) return;
-    await ensureProvider(request, token, PROVIDER_ABBR, PROVIDER_NAME);
+    providerId = await ensureProvider(request, token, PROVIDER_ABBR, PROVIDER_NAME);
     seeded = true;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (!token) return;
+    await deleteProvider(request, token, providerId, PROVIDER_ABBR);
   });
 
   test('is hidden on a locally-loaded tournament with no login', async ({ page }) => {

--- a/e2e/journeys/76-first-login-password.spec.ts
+++ b/e2e/journeys/76-first-login-password.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   SERVER,
+  removeUser,
   ROLE_PASSWORD,
   uniqueSuffix,
   signInSuperAdmin,
@@ -21,10 +22,11 @@ const NEW_PASSWORD_INPUT = '#firstLoginNewPassword';
 const email = `e2e-firstlogin-${uniqueSuffix()}@courthive.test`;
 
 let seeded = false;
+let token: string | null = null;
 
 test.describe('Journey 76 — forced first-login password change', () => {
   test.beforeAll(async ({ request }) => {
-    const token = await signInSuperAdmin(request);
+    token = await signInSuperAdmin(request);
     if (!token) return;
     // Create the user but do NOT complete first-login, so the account is left in
     // the mustChangePassword state.
@@ -33,6 +35,12 @@ test.describe('Journey 76 — forced first-login password change', () => {
       data: { email, password: ROLE_PASSWORD, roles: [] },
     });
     seeded = res.ok();
+  });
+
+  test.afterAll(async ({ request }) => {
+    // The account is deliberately left in the mustChangePassword state, so it is
+    // not reusable by a later run — and it accumulated one row per run.
+    if (token) await removeUser(request, token, email);
   });
 
   test('logging in as a first-login user forces the password-change modal', async ({ page }) => {


### PR DESCRIPTION
A full journey run against a live CFS left **9 providers and a user behind, every run**. The tournaments were already cleaned up — journey 28 in an `afterEach`, journey 119 via `cleanupParticipationFixture` — but that helper posts to `/factory/remove` with `{providerId, tournamentId}`, so it only ever removed the *tournament*. Providers and users were never cleaned up at all.

## What this adds

- **`deleteProvider()`** in `role-fixtures`, guarded by a `mintedAbbrs` allow-list that `uniqueAbbr()` populates.
- **`cleanupParticipationFixture`** now deletes the four providers it seeds (governing body + programmes A/B/Z) — most of the nine.
- **afterAll teardown** in journeys 36, 58, 71, 73 for their providers, and in 76 for the first-login user it creates. That account is deliberately left in the `mustChangePassword` state, so it is not reusable by a later run and accumulated one row per run.

## Why an allow-list and not a pattern

`POST /provider/:id/delete` is Plan A **destructive**: `cleanupService.wipe()` destroys the provider's tournaments with no archive row and no revive. So teardown refuses any abbreviation this process did not mint, rather than trusting an `E2E` prefix. A `LIKE 'E2E%'` sweep would delete a real provider the day someone names one "E2E Demo" — and journey 28's fixed `TMX` abbreviation is excluded by construction, instead of by remembering to special-case it.

## A defect the verification caught

The first verification run turned a **passing** journey 76 red. `removeUser` did not catch, and `localhost` resolved to `::1` while CFS was listening on IPv4 only. Playwright attributes an `afterAll` throw to the last test in the file, so a spec that proved everything it claimed was reported as a failure for a cleanup that had no bearing on it — which is the worst possible trade for tidier fixtures.

Every teardown helper — `deleteProvider`, `removeUser`, `cleanupProvisioner` — now routes through a `bestEffort` wrapper that warns instead. Cleanup is best-effort by definition; CFS's `cleanup-test-data.mjs` stays the backstop for whatever a crashed run leaves behind.

## Measured, against a live CFS

| | before run | after run |
|---|---|---|
| CFS-gated cluster (10 specs) | — | **23 passed, exit 0** |
| `providers` matching `E2E%` | 9 | **9** |
| `users` matching `e2e-%` | 33 | **33** |

Net zero, with no teardown warnings emitted. The full journey suite is unchanged at **434 passed** in 11.7m, and `lint`, `format:check` and `check-types` pass.

The residue (9 providers / 33 users) predates this change and is deliberately left alone — nothing running minted it, so the guard refuses it. `cleanup-test-data.mjs` sweeps it when you want it gone.
