### PR TITLE
chore: converge packageManager on pnpm@11.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmx",
-  "packageManager": "pnpm@11.24.0",
+  "packageManager": "pnpm@11.25.0",
   "license": "MIT",
   "private": true,
   "version": "8.24.0",


### PR DESCRIPTION
Step 2 of `Mentat/planning/PNPM_12_UPGRADE_ASSESSMENT.md`, and the last of 16 repos.

The build box (`courthive-mentat`) and production (`courthive-nest`) both already run **pnpm 11.25.0**, while repo pins spanned 11.21.0 / 11.22.0 / 11.24.0. TMX was on 11.24.0 — pinned *below* the pnpm that actually installs it. Converging first means the pnpm 12 upgrade changes one variable instead of two.

**Manifest only — no lockfile change.** That was established by trial rather than assumed: an earlier scratch run failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE`, and it would have been easy to generalise from that into "packageManager bumps need a lockfile update". The real behaviour is narrower — under pnpm 11 the bump leaves the lockfile untouched; the failure came from pinning to **pnpm 12**, which records `packageManagerDependencies` in the lockfile and so desyncs it. That is a later-step concern and is written up in the assessment.

Verified with the exact command CI runs: `pnpm install --frozen-lockfile` passes and reports `pnpm v11.25.0`.

The other 15 repos took a direct push (the sanctioned pattern for dep cascades); TMX protects `main`, so it gets a PR.