### PR TITLE
fix(deps): courthive-components 4.1.1 + pdf-factory 0.8.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "morphdom": "2.7.8",
     "navigo": "8.11.1",
     "normalize-text": "2.6.0",
-    "pdf-factory": "0.8.21",
+    "pdf-factory": "0.8.22",
     "pikaday": "1.8.2",
     "qrious": "4.0.2",
     "socket.io-client": "4.8.3",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "axios": "1.20.0",
     "camelcase": "9.0.0",
     "classnames": "2.5.1",
-    "courthive-components": "4.1.0",
+    "courthive-components": "4.1.1",
     "d3-selection": "3.0.0",
     "dayjs": "1.11.23",
     "dexie": "4.4.5",


### PR DESCRIPTION
Brings TMX onto the latest published versions of both libraries that released today.

| dep | was | now |
|---|---|---|
| `courthive-components` | 4.1.0 | **4.1.1** |
| `pdf-factory` | 0.8.21 | **0.8.22** |

`tods-competition-factory` (6.37.2), `@courthive/provider-config` (0.18.0) and `@courthive/scoring-visualizations` (caret range already resolving 0.2.18) were already current — TMX was the only consumer still behind, and only on these two.

Verified: `pnpm install --frozen-lockfile` passes under pnpm v12.3.4, check-types clean, lint clean, suite green.

**Tooling note:** `bump-components-consumers.sh` pushed the components commit straight at `main` and was rejected by branch protection. Its factory sibling handles this via `PR_REQUIRED_REPOS`; the components script has no equivalent, so a components fan-out will always fail on TMX until it gains one.