### PR TITLE
fix(tournaments): create under the selected provider, not the JWT provider

### DIFF
--- a/src/components/drawers/editTournamentDrawer.ts
+++ b/src/components/drawers/editTournamentDrawer.ts
@@ -3,6 +3,7 @@
  * Allows creating new tournaments or editing existing tournament details.
  */
 import { getSupportedTimeZones, isValidTimeZone } from 'functions/getSupportedTimeZones';
+import { resolveCreationProviderId } from 'services/provider/resolveCreationProviderId';
 import { addTournament as tournamentAdd } from 'services/storage/importTournaments';
 import { submitTournamentDates } from 'services/mutation/submitTournamentDates';
 import { addOrUpdateTournament } from 'services/storage/addOrUpdateTournament';
@@ -296,17 +297,26 @@ export function editTournament({
         if (nextTier) {
           tournamentEngine.setTournamentTier({ tournamentTier: nextTier });
         }
-        if (state?.providerId && newTournamentRecord) {
-          const addProvider = (result: any) => {
-            const provider = result.data?.provider;
+        // `context.provider` first: a super-admin who switched provider keeps the
+        // original JWT, so `state.providerId` alone would silently create the
+        // tournament local-only instead of under the provider on screen.
+        const providerId = resolveCreationProviderId(state, context.provider);
+        if (providerId && newTournamentRecord) {
+          const addProvider = async (result: any) => {
+            const provider = result?.data?.provider;
             newTournamentRecord.parentOrganisation = provider;
             if (provider) {
-              const report = (result: any) => console.log('sendTournament', result);
-              sendTournament({ tournamentRecord: newTournamentRecord }).then(() => {}, report);
+              // Do not add a provider-owned tournament to the visible list until
+              // the server confirms persistence. Otherwise a rejected save looks
+              // successful in this window, then disappears in every other one.
+              // baseApi resolves a failed request to `undefined` and has already
+              // raised the error toast, so the abort is reported, not silent.
+              const saveResult = await sendTournament({ tournamentRecord: newTournamentRecord });
+              if (!saveResult?.data?.success) return undefined;
             }
-            completeTournamentAdd({ tournamentRecord: newTournamentRecord, table, onCreated });
+            return completeTournamentAdd({ tournamentRecord: newTournamentRecord, table, onCreated });
           };
-          getProvider({ providerId: state.providerId }).then(addProvider);
+          getProvider({ providerId }).then(addProvider);
         } else {
           completeTournamentAdd({ tournamentRecord: newTournamentRecord, table, onCreated });
         }

--- a/src/services/provider/resolveCreationProviderId.test.ts
+++ b/src/services/provider/resolveCreationProviderId.test.ts
@@ -1,0 +1,51 @@
+import { resolveCreationProviderId } from './resolveCreationProviderId';
+import { describe, expect, it } from 'vitest';
+
+const SELECTED_PROVIDER = 'selected-provider';
+const NESTED_PROVIDER = 'nested-provider';
+const FLAT_PROVIDER = 'flat-provider';
+const JWT_PROVIDER = 'jwt-provider';
+
+describe('resolveCreationProviderId', () => {
+  it('uses the explicitly selected provider for a provider-less super-admin', () => {
+    const loginState: any = { roles: ['superadmin'] };
+    const activeProvider: any = { organisationId: SELECTED_PROVIDER };
+
+    expect(resolveCreationProviderId(loginState, activeProvider)).toBe(SELECTED_PROVIDER);
+  });
+
+  it('prefers the explicitly selected provider over the JWT provider', () => {
+    const loginState: any = { providerId: JWT_PROVIDER };
+    const activeProvider: any = { organisationId: SELECTED_PROVIDER };
+
+    expect(resolveCreationProviderId(loginState, activeProvider)).toBe(SELECTED_PROVIDER);
+  });
+
+  it('falls back to either login-state provider representation', () => {
+    expect(resolveCreationProviderId({ providerId: FLAT_PROVIDER } as any, undefined)).toBe(FLAT_PROVIDER);
+    expect(resolveCreationProviderId({ provider: { organisationId: NESTED_PROVIDER } } as any, undefined)).toBe(
+      NESTED_PROVIDER,
+    );
+  });
+
+  it('prefers the flat providerId claim over the nested provider object', () => {
+    const loginState: any = { providerId: FLAT_PROVIDER, provider: { organisationId: NESTED_PROVIDER } };
+
+    expect(resolveCreationProviderId(loginState, undefined)).toBe(FLAT_PROVIDER);
+  });
+
+  // The field-omitted case (architectural standards A3: an authorization-shaped
+  // check needs a "field absent" case, not only "field present and wrong"). A
+  // provider object present but carrying no organisationId must fall through to
+  // the JWT rather than resolve to undefined and strand the tournament locally.
+  it('falls through an active provider that carries no organisationId', () => {
+    const loginState: any = { providerId: JWT_PROVIDER };
+
+    expect(resolveCreationProviderId(loginState, {} as any)).toBe(JWT_PROVIDER);
+  });
+
+  it('returns undefined when no provider is active', () => {
+    expect(resolveCreationProviderId({ roles: ['superadmin'] } as any, undefined)).toBeUndefined();
+    expect(resolveCreationProviderId(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/src/services/provider/resolveCreationProviderId.ts
+++ b/src/services/provider/resolveCreationProviderId.ts
@@ -1,0 +1,26 @@
+import type { LoginState, ProviderValue } from 'types/tmx';
+
+/**
+ * Resolve the provider that owns a newly-created tournament.
+ *
+ * `context.provider` is the source of truth after an explicit provider switch.
+ * In particular, super-admin impersonation does not rewrite the provider fields
+ * in the login JWT, so consulting only `LoginState.providerId` silently creates
+ * a local-only tournament instead of sending it to the selected provider.
+ *
+ * The precedence matches what the rest of the client already does inline —
+ * `context.provider || state?.provider` in the dashboard, publishing and
+ * settings tabs, and `context.provider ?? getLoginState()?.provider` in
+ * `homeNavigation`. This is the creation path's copy of that rule, with the
+ * flat `providerId` claim kept as the middle rung because a provider-scoped
+ * user's JWT carries it without a nested `provider` object.
+ *
+ * Returns `undefined` when no provider is active: the caller then keeps the
+ * tournament local rather than guessing an owner.
+ */
+export function resolveCreationProviderId(
+  loginState: LoginState | undefined,
+  activeProvider: ProviderValue | undefined,
+): string | undefined {
+  return activeProvider?.organisationId ?? loginState?.providerId ?? loginState?.provider?.organisationId;
+}


### PR DESCRIPTION
Lifted out of #1404, which bundles it with unrelated Docker work. The implementation and the first three tests are **@woernsn's** — thank you. This PR carries them on their own so they can land without waiting on the Docker review, and adds three cases.

## The bug

Super-admin provider impersonation sets `context.provider` but does **not** rewrite the login JWT. The creation path in `editTournamentDrawer` read only `LoginState.providerId`, so creating a tournament while switched to a provider fell into the `else` branch: no `getProvider` lookup, no `parentOrganisation`, no `sendTournament`. The tournament was created **local-only**, and it looked like it had worked until it failed to appear in any other window.

## The change

`resolveCreationProviderId` makes the precedence explicit and testable:

```
context.provider  ->  loginState.providerId  ->  loginState.provider.organisationId
```

An explicit provider switch wins; the flat `providerId` claim is the middle rung because a provider-scoped user's JWT carries it without a nested `provider` object. This mirrors what the client already does inline at four sites — `context.provider || state?.provider` in `dashboardPanels.ts:532`, `renderPublishingTab.ts:317` and `settingsGrid.ts:589`, and `context.provider ?? getLoginState()?.provider` in `homeNavigation.ts:139`.

TMX has no jsdom, so the decision is a pure function and the drawer keeps only the wiring.

Second, the visible add is now gated on server confirmation. A provider-owned tournament is not added to the table and IndexedDB until `/factory/save` returns `success`. Previously the save was fire-and-forget (`.then(() => {}, report)` into a `console.log`), so a rejected save still looked successful in the window that created it and was absent everywhere else. `baseApi`'s error interceptor resolves a failed request to `undefined` and has already raised the error toast, so the abort is reported to the user rather than silent.

## Verification

All six gates the `lint` job runs, against the `link:` sibling resolution:

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm check-types` | 0 |
| `pnpm test --run` | 164 files / 1777 tests passed (baseline 163 / 1771) |

Tests **falsified**: reverting the helper to the pre-fix precedence (dropping the `context.provider` rung, `_activeProvider` so the revert still compiles — types 0, lint 0) turns exactly the two precedence cases red, `expected undefined to be 'selected-provider'` and `expected 'jwt-provider' to be 'selected-provider'`, with the other four still passing.

Journeys are local-only evidence in this repo and were not run; nothing here touches a journey path.

## Known follow-up, deliberately not in scope

When the save is rejected, `newTournamentRecord` has already been created in the engine and stays there as the current tournament while being absent from the list and IndexedDB. Nothing navigates to it and the next create replaces it, so the exposure is small — but rolling the engine back (`tournamentEngine.reset()`, as `mutationRequest.ts:90` does) is a separate change with its own blast radius and is better made on its own.
