### PR TITLE
fix(relay): let a deployment declare that it has no score-relay

### DIFF
--- a/src/services/apis/scoreRelayApi.test.ts
+++ b/src/services/apis/scoreRelayApi.test.ts
@@ -61,7 +61,12 @@ vi.mock('config/providerConfig', () => ({
   providerConfig: { get: () => mockProviderConfig.current },
 }));
 
-import { isScoreRelayConfigured, isCrowdScoringEnabled, getScoreRelayURL } from './scoreRelayApi';
+import {
+  isScoreRelayConfigured,
+  isCrowdScoringEnabled,
+  resolveExplicitRelayURL,
+  getScoreRelayURL,
+} from './scoreRelayApi';
 
 describe('scoreRelayApi crowd surface', () => {
   beforeEach(() => {
@@ -72,6 +77,27 @@ describe('scoreRelayApi crowd surface', () => {
     // localhost dev → standalone relay on :8384
     expect(getScoreRelayURL()).toBe('http://localhost:8384');
     expect(isScoreRelayConfigured()).toBe(true);
+  });
+
+  it('treats the disabled sentinels as deliberately off, case-insensitively', () => {
+    expect(resolveExplicitRelayURL('disabled')).toBe('');
+    expect(resolveExplicitRelayURL('OFF')).toBe('');
+    expect(resolveExplicitRelayURL('false')).toBe('');
+    expect(resolveExplicitRelayURL('  Disabled  ')).toBe('');
+  });
+
+  it('normalizes explicit relay URLs and leaves missing values to derivation', () => {
+    expect(resolveExplicitRelayURL(' https://relay.example/ ')).toBe('https://relay.example');
+    expect(resolveExplicitRelayURL('https://relay.example///')).toBe('https://relay.example');
+    expect(resolveExplicitRelayURL('')).toBeUndefined();
+    expect(resolveExplicitRelayURL('   ')).toBeUndefined();
+    expect(resolveExplicitRelayURL(undefined)).toBeUndefined();
+  });
+
+  // A host that merely CONTAINS a sentinel is a real URL, not a request to
+  // disable — the match is on the whole trimmed value, not a substring.
+  it('does not treat a URL containing a sentinel word as disabled', () => {
+    expect(resolveExplicitRelayURL('https://off.example')).toBe('https://off.example');
   });
 
   it('isCrowdScoringEnabled is true when the provider declares no crowdScoring (default ON)', () => {

--- a/src/services/apis/scoreRelayApi.ts
+++ b/src/services/apis/scoreRelayApi.ts
@@ -50,11 +50,35 @@ function deriveRelayBaseURL(): string {
   return `${serverUrl}/relay`;
 }
 
+/**
+ * Values that mean "this deployment has no relay", as opposed to "no relay was
+ * configured, derive one". Vite inlines `import.meta.env` at build time and
+ * gives a build no way to express an empty string distinguishable from an unset
+ * variable, so a container image that runs without a relay needs a word rather
+ * than a blank to turn the derivation off.
+ */
+const DISABLED_SENTINELS = new Set(['disabled', 'false', 'off']);
+
+/**
+ * Resolve an explicit relay setting.
+ *
+ * - `undefined` — nothing was configured; the caller should derive a default.
+ * - `''` — deliberately disabled; the caller should NOT derive a default.
+ * - anything else — the configured base URL, trimmed, without a trailing slash.
+ */
+export function resolveExplicitRelayURL(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const configured = value.trim();
+  if (DISABLED_SENTINELS.has(configured.toLowerCase())) return '';
+  return configured ? configured.replace(/\/+$/, '') : undefined;
+}
+
 function resolveInitialBaseURL(): string {
-  const fromVite = (import.meta as any)?.env?.VITE_SCORE_RELAY_URL;
-  if (typeof fromVite === 'string' && fromVite.trim()) return fromVite.trim().replace(/\/+$/, '');
+  const fromVite = resolveExplicitRelayURL((import.meta as any)?.env?.VITE_SCORE_RELAY_URL);
+  if (fromVite !== undefined) return fromVite;
   const fromProcess = typeof process === 'undefined' ? undefined : process.env?.SCORE_RELAY_URL;
-  if (typeof fromProcess === 'string' && fromProcess.trim()) return fromProcess.trim().replace(/\/+$/, '');
+  const explicitProcessURL = resolveExplicitRelayURL(fromProcess);
+  if (explicitProcessURL !== undefined) return explicitProcessURL;
   return deriveRelayBaseURL();
 }
 

--- a/src/services/messaging/scoreRelay.test.ts
+++ b/src/services/messaging/scoreRelay.test.ts
@@ -43,14 +43,19 @@ vi.mock('socket.io-client', () => ({
 // Mutable so individual tests can flip between dev (localhost) and prod hosts.
 // `get: () => mockServerConfig` returns the live object, so mutating
 // `mockServerConfig.socketPath` before a connect changes what the module reads.
-const { mockServerConfig } = vi.hoisted(() => ({
+const { mockServerConfig, mockCrowdScoringEnabled } = vi.hoisted(() => ({
   mockServerConfig: { socketPath: 'http://localhost:8383' },
+  mockCrowdScoringEnabled: vi.fn(() => true),
 }));
 
 vi.mock('config/serverConfig', () => ({
   serverConfig: {
     get: () => mockServerConfig,
   },
+}));
+
+vi.mock('services/apis/scoreRelayApi', () => ({
+  isCrowdScoringEnabled: mockCrowdScoringEnabled,
 }));
 
 vi.mock('config/debugConfig', () => ({
@@ -91,6 +96,7 @@ describe('TMX scoreRelay client', () => {
     vi.clearAllMocks();
     handlers.clear();
     mockSocket.connected = false;
+    mockCrowdScoringEnabled.mockReturnValue(true);
     disconnectRelay();
   });
 
@@ -108,6 +114,15 @@ describe('TMX scoreRelay client', () => {
       expect.stringContaining('/live'),
       expect.objectContaining({ transports: ['websocket'] }),
     );
+  });
+
+  it('opens no socket when crowd scoring is disabled', async () => {
+    const { io } = await import('socket.io-client');
+    mockCrowdScoringEnabled.mockReturnValue(false);
+
+    connectRelay('tid-disabled');
+
+    expect(io).not.toHaveBeenCalled();
   });
 
   it('derives local dev relay URL with port 8384', async () => {

--- a/src/services/messaging/scoreRelay.ts
+++ b/src/services/messaging/scoreRelay.ts
@@ -6,6 +6,7 @@
  * - Production: same host, /relay path (nginx proxy)
  * - Local dev: same host, port 8384
  */
+import { isCrowdScoringEnabled } from 'services/apis/scoreRelayApi';
 import { serverConfig } from 'config/serverConfig';
 import { debugConfig } from 'config/debugConfig';
 import { io, Socket } from 'socket.io-client';
@@ -40,6 +41,15 @@ function getRelayConfig(): { origin: string; path: string } {
 }
 
 export function connectRelay(tournamentId: string): void {
+  // Fail closed. No relay base resolves (a deployment that set the disabled
+  // sentinel, or has no server URL at all), or the provider turned crowd
+  // scoring off -> open no socket, and tear down one already open rather than
+  // leaving it reconnecting against a host that is not there.
+  if (!isCrowdScoringEnabled()) {
+    disconnectRelay();
+    slog('[relay] disabled — connection skipped');
+    return;
+  }
   if (relaySocket?.connected && currentTournamentId === tournamentId) return;
 
   disconnectRelay();


### PR DESCRIPTION
Lifted out of #1404, which bundles it with unrelated Docker work. The implementation is **@woernsn's** — thank you. Independent of #1420; neither is stacked on the other.

## The problem

The relay base is *derived* when nothing is configured, so a deployment without a relay had no way to turn it off. TMX opened a websocket and polled REST against a host that does not exist and reconnected forever. A blank `VITE_SCORE_RELAY_URL` cannot express "off" either: Vite inlines `import.meta.env` at build time and gives a build no way to distinguish a blank variable from an unset one.

## The change

`resolveExplicitRelayURL` adds the missing third state:

| value | meaning |
|---|---|
| `undefined` | nothing configured — derive a default (unchanged) |
| `''` | deliberately disabled — do **not** derive |
| anything else | the configured base, trimmed, trailing slashes stripped |

`disabled` / `off` / `false` select the middle one — trimmed, case-insensitive, matched on the **whole** value, so `https://off.example` is still a relay URL and not a request to disable. Previously `VITE_SCORE_RELAY_URL=disabled` was taken literally and became the axios `baseURL`.

Second, `connectRelay` now fails closed on `isCrowdScoringEnabled()` and tears down an existing socket instead of leaving it reconnecting. **This is a second behaviour change worth calling out separately:** `isCrowdScoringEnabled()` is `isScoreRelayConfigured() && resolveCrowdScoringEnabled(providerConfig.get())`, so a provider that had set `crowdScoring.enabled = false` was still opening the socket, and now does not. Crowd scoring remains ON by default — a provider config that has not loaded yet resolves to enabled, so boot-order behaviour is unchanged.

## Verification

All six gates the `lint` job runs, against the `link:` sibling resolution:

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm check-types` | 0 |
| `pnpm test --run` | 163 files / 1775 tests passed (baseline 163 / 1771) |

Tests **falsified**, both reverts made coherently so they still compile (types 0, lint 0):

- dropping the sentinel branch → `expected 'disabled' to be ''`
- dropping the `connectRelay` gate and its import → `expected "vi.fn()" to not be called at all, but actually been called 1 times`

The does-not-over-match case stays green under both reverts, which is the point of it — it is the "safe" half of the pair and must not fire.

Journeys are local-only evidence in this repo and were not run.

## Note on the existing spec

`scoreRelay.test.ts` gains a `vi.hoisted` entry, a module mock and a `beforeEach` reset. That is additive — no existing assertion, case or expectation was changed. The `beforeEach` reset is load-bearing rather than cosmetic: under vitest 5 `clearMocks` defaults to true, and `mockClear` does not reset a return value, so without it a `mockReturnValue(false)` would leak into every later test in the file.
