### PR TITLE
fix(e2e): start the dev server from the repo root, not from e2e/

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -57,6 +57,17 @@ export default defineConfig({
     command: process.env.TEST_PROD
       ? 'pnpm build && pnpm preview'
       : 'NODE_OPTIONS=--max-old-space-size=4096 pnpm start',
+    // Playwright defaults `cwd` to the CONFIG file's directory, which is `e2e/`
+    // — and `e2e/` has no package.json, so `pnpm start` there dies with
+    // ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND and Playwright reports only
+    // "Process from config.webServer was not able to start. Exit code: 1".
+    //
+    // This was invisible for as long as it existed because `reuseExistingServer`
+    // finds an already-running dev server and never runs the command at all. It
+    // surfaces only when :5173 is genuinely free — which is exactly the state a
+    // full-suite run is supposed to start from, so the failure was reserved for
+    // the one case that matters most.
+    cwd: '..',
     url: process.env.TEST_PROD ? 'http://localhost:4173' : 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,


### PR DESCRIPTION
Found while gating the 8.24.2 release on a full journey run — the suite died in seconds with every PM2 process stopped.

## The defect

Playwright defaults `webServer.cwd` to the directory holding the **config file**. Ours is at `e2e/playwright.config.ts`, so `pnpm start` ran in `e2e/`, which has no `package.json`:

```
[WebServer] Error: ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND
[WebServer]   × No package.json or package.yaml was found in ".../TMX/e2e"
Error: Process from config.webServer was not able to start. Exit code: 1
```

It has been latent for as long as it existed, because `reuseExistingServer: !CI` finds an already-running dev server and never runs the command at all. It surfaces only when `:5173` is **genuinely free** — which is precisely the state the journey runbook tells you to create before a full-suite run, so the failure was reserved for the one case that matters most. Anyone who happened to have a dev server up, or a PM2-managed `tmx`, never saw it.

## Verification

A two-run pair, both with `:5173` free and a normal developer environment:

| config | result |
|---|---|
| with `cwd: '..'` | Playwright starts and owns the server; journey 82 passes **3/3 in 12.1s** |
| `cwd` line removed | `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`, exit 1 |

Gates, all green:

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm check-types` | 0 |
| `pnpm test --run` | 164 files / 1781 tests passed |

The full 117-spec journey suite was run green against a live CFS earlier today on this same `main` — **434 passed / 0 failed / 0 skipped / 0 flaky in 11.5m** — with the dev server started by hand as the workaround for this bug. This change alters only how that server is spawned, and it is spawned with the same cwd the manual start already used, so that run's evidence carries over unchanged.

## One thing worth knowing for the next person

If you run the journeys from a **git worktree**, `pnpm start` will hang instead: `pnpm start` is `pnpm run config --check && vite --open`, and `config.mjs --check` prompts `? Choose an environment` when no `.env` is present. Worktrees do not carry `.env` (correctly — it is gitignored), so the prompt blocks forever and you get a `webServer` timeout rather than this error. Copy `.env*` into the worktree first. Not something this PR changes, but it cost time to diagnose and reads identically from the outside.
