### PR TITLE
refactor(provider): one active-provider rule instead of six inline copies

### DIFF
--- a/src/homeNavigation.ts
+++ b/src/homeNavigation.ts
@@ -6,6 +6,7 @@
 import { getProviderRankingsUrl, providerHasRankings } from 'services/rankings/providerRankings';
 import { hasGlobalAdminRole } from 'services/authentication/hasGlobalAdminRole';
 import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
+import { resolveActiveProvider } from 'services/provider/resolveActiveProvider';
 import { enhancedContentFunction } from 'services/dom/toolTip/plugins';
 import { getLoginState } from 'services/authentication/loginState';
 import { deviceConfig } from 'config/deviceConfig';
@@ -53,7 +54,7 @@ const RANKINGS_ICON = 'h-rankings';
 const RANKINGS_MOBILE_ITEM = 'mobile-nav-rankings';
 
 function activeProviderAbbr(): string | undefined {
-  const provider = context.provider ?? getLoginState()?.provider;
+  const provider = resolveActiveProvider(getLoginState(), context.provider);
   return provider?.organisationAbbreviation;
 }
 
@@ -136,7 +137,7 @@ const SCHEDULE_ICON = 'h-schedule';
 const SCHEDULE_MOBILE_ITEM = 'mobile-nav-schedule';
 
 function activeProviderId(): string | undefined {
-  return (context.provider ?? getLoginState()?.provider)?.organisationId;
+  return resolveActiveProvider(getLoginState(), context.provider)?.organisationId;
 }
 
 function openProviderSchedule(providerId: string): void {

--- a/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
+++ b/src/pages/tournament/tabs/overviewTab/dashboardPanels.ts
@@ -1,6 +1,7 @@
 import { burstChart, fromFactoryDrawData, createCourtSvg, CourtSport } from 'courthive-components';
 import { isActiveProviderAdmin } from 'services/authentication/isProviderAdmin';
 import { consoleGrantsRoute, consoleUrl } from 'services/navigation/consoleUrl';
+import { resolveActiveProvider } from 'services/provider/resolveActiveProvider';
 import { saveTournamentRecord } from 'services/storage/saveTournamentRecord';
 import { openRegistrationProfileEditor } from './registrationProfileEditor';
 import { donutChartFromMatchUps } from '@courthive/scoring-visualizations';
@@ -529,7 +530,7 @@ export function createActionsPanel(): HTMLElement {
   const providerId = provider?.organisationId;
   const state = getLoginState();
   const admin = isActiveProviderAdmin();
-  const activeProvider = context.provider || state?.provider;
+  const activeProvider = resolveActiveProvider(state, context.provider);
 
   if (tournamentRecord && admin) {
     if (shouldShowFormatWizard()) {

--- a/src/pages/tournament/tabs/publishingTab/renderPublishingTab.ts
+++ b/src/pages/tournament/tabs/publishingTab/renderPublishingTab.ts
@@ -4,6 +4,7 @@
  * tournament-level controls, event/draw tree, and embargo management.
  */
 import { getTournamentPublishData, getPublishingTableData } from './publishingData';
+import { resolveActiveProvider } from 'services/provider/resolveActiveProvider';
 import { getPublicTournamentUrl } from 'services/publishing/publicUrl';
 import { getLoginState } from 'services/authentication/loginState';
 import { removeAllChildNodes } from 'services/dom/transformers';
@@ -314,7 +315,7 @@ export function renderPublishingTab(): void {
   removeAllChildNodes(container);
 
   const state = getLoginState();
-  const activeProvider = context.provider || state?.provider;
+  const activeProvider = resolveActiveProvider(state, context.provider);
   const canPublish = featureFlags.get().usePublishState || (!!state && !!activeProvider);
 
   if (!canPublish) {

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -6,6 +6,7 @@ import { connectSocket, connected, disconnectSocket } from 'services/messaging/s
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
 import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
 import { buildLanguageOptions, resolveCurrentLanguageCode } from './languageOptions';
+import { resolveActiveProvider } from 'services/provider/resolveActiveProvider';
 import { ensureLocaleCurrent, fetchManifest } from 'i18n/runtime-loader';
 import { fixtures, factoryConstants } from 'tods-competition-factory';
 import { getLoginState } from 'services/authentication/loginState';
@@ -586,7 +587,7 @@ export async function renderSettingsGrid(
     const createdByUserId = tournamentRecord?.extensions?.find((e) => e?.name === 'createdByUserId')?.value;
     const isCreator = !!createdByUserId && createdByUserId === state?.userId;
     const canDeleteOnServer = superAdmin || isCreator || state?.permissions?.includes('deleteTournament');
-    const activeProvider = context.provider || state?.provider;
+    const activeProvider = resolveActiveProvider(state, context.provider);
 
     const isProviderTournament = !!(activeProvider && providerId);
     if (tournamentRecord && (!isProviderTournament || canDeleteOnServer)) {

--- a/src/services/authentication/isProviderAdmin.ts
+++ b/src/services/authentication/isProviderAdmin.ts
@@ -13,6 +13,7 @@
  * The active provider is the impersonated one (`context.provider`) when set,
  * otherwise the JWT home provider (`state.provider`).
  */
+import { resolveActiveProvider } from 'services/provider/resolveActiveProvider';
 import { getLoginState } from 'services/authentication/loginState';
 import { context } from 'services/context';
 
@@ -24,7 +25,7 @@ export function isActiveProviderAdmin(): boolean {
   if (!state) return false;
   if (state.roles?.includes(SUPER_ADMIN)) return true;
 
-  const activeId = (context.provider ?? state.provider)?.organisationId;
+  const activeId = resolveActiveProvider(state, context.provider)?.organisationId;
   if (activeId) {
     if (state.provisionerProviders?.some((p) => p.providerId === activeId)) return true;
     const association = state.providerAssociations?.find((a) => a.providerId === activeId);

--- a/src/services/provider/resolveActiveProvider.test.ts
+++ b/src/services/provider/resolveActiveProvider.test.ts
@@ -1,0 +1,56 @@
+import { resolveCreationProviderId } from './resolveCreationProviderId';
+import { resolveActiveProvider } from './resolveActiveProvider';
+import { describe, expect, it } from 'vitest';
+
+const SWITCHED = { organisationId: 'switched', organisationName: 'Switched', organisationAbbreviation: 'SW' };
+const FROM_JWT = { organisationId: 'from-jwt', organisationName: 'From JWT', organisationAbbreviation: 'JWT' };
+const FLAT_CLAIM = 'flat-claim';
+
+describe('resolveActiveProvider', () => {
+  it('prefers an explicit provider switch over the JWT provider', () => {
+    const loginState: any = { provider: FROM_JWT };
+
+    expect(resolveActiveProvider(loginState, SWITCHED as any)).toBe(SWITCHED);
+  });
+
+  it('falls back to the JWT provider when nothing was switched to', () => {
+    const loginState: any = { provider: FROM_JWT };
+
+    expect(resolveActiveProvider(loginState, undefined)).toBe(FROM_JWT);
+  });
+
+  it('returns undefined when neither source has a provider', () => {
+    expect(resolveActiveProvider({ roles: ['superadmin'] } as any, undefined)).toBeUndefined();
+    expect(resolveActiveProvider(undefined, undefined)).toBeUndefined();
+  });
+
+  // The call sites this replaced used `||`, not `??`. For an object the two are
+  // equivalent, and this pins that equivalence so a future `null` provider
+  // cannot quietly change which branch wins.
+  it('treats a null active provider as absent, matching the || it replaced', () => {
+    const loginState: any = { provider: FROM_JWT };
+
+    expect(resolveActiveProvider(loginState, null as any)).toBe(FROM_JWT);
+  });
+});
+
+// Guard the one thing a reader is most likely to "simplify": these two helpers
+// look interchangeable and are not. Creation consults the flat `providerId`
+// claim BETWEEN the two rungs, so `resolveActiveProvider(...)?.organisationId`
+// is a different answer whenever a token's flat claim disagrees with its
+// nested provider.
+describe('resolveActiveProvider vs resolveCreationProviderId', () => {
+  it('disagree when the flat providerId claim differs from the nested provider', () => {
+    const loginState: any = { providerId: FLAT_CLAIM, provider: FROM_JWT };
+
+    expect(resolveActiveProvider(loginState, undefined)?.organisationId).toBe('from-jwt');
+    expect(resolveCreationProviderId(loginState, undefined)).toBe(FLAT_CLAIM);
+  });
+
+  it('agree once a provider has been explicitly switched to', () => {
+    const loginState: any = { providerId: FLAT_CLAIM, provider: FROM_JWT };
+
+    expect(resolveActiveProvider(loginState, SWITCHED as any)?.organisationId).toBe('switched');
+    expect(resolveCreationProviderId(loginState, SWITCHED as any)).toBe('switched');
+  });
+});

--- a/src/services/provider/resolveActiveProvider.ts
+++ b/src/services/provider/resolveActiveProvider.ts
@@ -1,0 +1,28 @@
+import type { LoginState, ProviderValue } from 'types/tmx';
+
+/**
+ * Resolve the provider the UI should treat as active.
+ *
+ * An explicit provider switch wins over the login JWT, because super-admin
+ * impersonation sets `context.provider` without rewriting the token — the same
+ * asymmetry that made tournament creation silently local-only before #1420.
+ *
+ * This is the object form. It was inlined at five call sites in three shapes
+ * (`context.provider || state?.provider` in the dashboard, publishing and
+ * settings tabs; `context.provider ?? getLoginState()?.provider` twice in
+ * `homeNavigation`), which is how a rule drifts: each copy is correct until one
+ * of them isn't.
+ *
+ * **Not** the same as `resolveCreationProviderId`, and the difference is
+ * deliberate rather than an oversight. That helper answers "which provider
+ * should own a tournament being created" and consults the flat `providerId`
+ * claim *between* the two rungs here, so it is not this function followed by
+ * `.organisationId`. Collapsing them would silently reorder the JWT rungs for
+ * any token whose flat claim disagrees with its nested provider.
+ */
+export function resolveActiveProvider(
+  loginState: LoginState | undefined,
+  activeProvider: ProviderValue | undefined,
+): ProviderValue | undefined {
+  return activeProvider ?? loginState?.provider;
+}


### PR DESCRIPTION
Follow-up to #1420. "Which provider is active" was inlined at **six** call sites in three shapes:

| site | shape |
|---|---|
| `dashboardPanels.ts:532` | `context.provider \|\| state?.provider` |
| `renderPublishingTab.ts:317` | `context.provider \|\| state?.provider` |
| `settingsGrid.ts:589` | `context.provider \|\| state?.provider` |
| `homeNavigation.ts:56` | `context.provider ?? getLoginState()?.provider` |
| `homeNavigation.ts:139` | `(context.provider ?? getLoginState()?.provider)?.organisationId` |
| `isProviderAdmin.ts:27` | `(context.provider ?? state.provider)?.organisationId` |

Every one is the same expression, so this is **behaviour-preserving**: `||` and `??` diverge only on falsy non-nullish values, and a provider is an object. A test pins that equivalence so a future `null` provider cannot quietly change which branch wins.

The reason to bother rather than leave it: this rule already produced one silent bug. The creation path consulted a *different* copy of it and made a super-admin's tournament local-only (#1420). Six copies is six chances to fix five.

The sixth site — `isProviderAdmin` — was **not** in my original survey. I found it only by sweeping the whole tree instead of trusting a `head`-truncated grep, which is worth stating because it is the site that actually gates admin UI.

## What is deliberately NOT unified

`resolveCreationProviderId` stays separate. It consults the flat `providerId` claim **between** the two rungs, so it is not `resolveActiveProvider(...)?.organisationId`; collapsing them silently reorders the JWT rungs for any token whose flat claim disagrees with its nested provider. Two tests assert the pair disagrees in exactly that case, and the helper's doc comment says why.

## Verification

| gate | result |
|---|---|
| `pnpm lint` | 0 |
| `pnpm format:check` | 0 |
| `pnpm attr-audit --ci` | 0 |
| `pnpm i18n-audit --ci` | 0 |
| `pnpm check-types` | 0 |
| `pnpm test --run` | 165 files / 1787 tests passed (baseline 164 / 1781) |

`isProviderAdmin` gates admin UI, so it is verified by behaviour rather than by reading. Its existing spec passes unchanged, and the real-login, live-CFS journeys covering these surfaces pass **10/10**: 36 (provider switcher + admin gating), 58 (super-admin provider switch), 71 (publishing login gating), 72 (registrations nav visibility), 73 (chat indicator gating).

Both new guards **falsified**, each with a coherent revert that still compiles (types 0):

- flipping the precedence to `loginState?.provider ?? activeProvider` → 2 red, `expected { organisationId: 'from-jwt' } to be { organisationId: 'switched' }`
- collapsing creation into the object helper — the exact "simplification" the guard warns against → **4 red**, `expected 'from-jwt' to be 'flat-claim'`

## Left alone on purpose

`renderPublishingTab.ts`'s import block has a pre-existing longest-first inversion (58 before 59) unrelated to this change. Reordering it would add diff noise to a refactor whose whole point is reviewability, and no gate reports it.

Four other `context.provider` readers are genuinely different rules and were not touched: `providerConfig.ts:203` (branding fallback first, never consults the JWT), `renderProviderSchedulePage.ts:77` (impersonation only, no JWT fallback), `demoEligibility.ts:47` (presence check) and `loginState.ts:66` (id only).
