### PR TITLE
chore: drop the @pnpm/exe block from the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.3.4
-        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.3.4':
-    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
-
-  '@pnpm/exe@12.3.4':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.3.4
-      '@pnpm/exe.darwin-x64': 12.3.4
-      '@pnpm/exe.linux-arm64': 12.3.4
-      '@pnpm/exe.linux-arm64-musl': 12.3.4
-      '@pnpm/exe.linux-x64': 12.3.4
-      '@pnpm/exe.linux-x64-musl': 12.3.4
-      '@pnpm/exe.win32-arm64': 12.3.4
-      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
## What

Removes the `@pnpm/exe` block from `pnpm-lock.yaml`. Pure deletion — 17 lines, no additions, no dependency resolution changes.

## Why

That block is written **only by a pnpm that does not match this repo's `packageManager` pin**. Such a pnpm self-provisions the pinned version and records the standalone binary it fetched. A pnpm that already matches the pin removes the block again — so its presence left every correctly-provisioned checkout permanently dirty, and made `git status` unable to separate that noise from real work.

That is not hypothetical. On the Button LAN host it was the ambiguity that forced a deploy on 2026-09-03 to stop and hand-preserve a patch which turned out to be this churn.

## Why this is the right direction, not a preference

Measured on two machines with **different pnpm provisioning**, both of which strip the block:

| machine | pnpm | corepack in path | result |
|---|---|---|---|
| Button | corepack shim → 12.3.4 | yes | strips it |
| Lenz | standalone `~/Library/pnpm/bin/pnpm` 12.3.4 | **no** | strips it |

So it is not an artifact of one host's setup or of corepack specifically — it is what any pnpm matching the pin produces.

**16 of the ecosystem's 22 repos never carried this block.** This is one of the remaining six (`CourtHive.com`, `TMX`, `competition-factory-server`, `courthive-query`, `epixodic`, `provider-config`), each getting the identical change, bringing them into line with the majority.

## Risk

Low. The lockfile now matches what a correctly-pinned pnpm generates, so `--frozen-lockfile` in CI should be *more* stable, not less.
