### PR TITLE
chore(deps): tods-competition-factory 6.37.2 -> 6.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "tabulator-tables": "6.5.2",
     "timepicker-ui": "4.4.0",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.37.2",
+    "tods-competition-factory": "6.38.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
6.38.0 carries two changes:

  feat(readModel): export the column manifest as runtime data (#4774)
  fix(scales): rank drawSize and drawSizes identically for profile
    specificity (#4772)

Neither is breaking for this consumer; the readModel export is purely
additive and the scales fix moves award-profile SELECTION, where the
singular `drawSize` scope previously scored 0 and tied with a catch-all.

No lockfile change: this repo resolves the factory through the
`link:../factory` override in `pnpm-workspace.yaml`, so the lockfile records
no version and CI strips the link and installs the pin.

Gates on this branch: lint, check-types, test and build all green, with test
counts identical to the pre-bump baseline.