### PR TITLE
ci: fail the build when a lockfile carries an @pnpm/exe block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,32 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      # A pnpm that does not match this repo's `packageManager` pin writes an `@pnpm/exe` block
+      # into the lockfile; a pnpm that DOES match strips it out again. Committed, it makes every
+      # correctly-provisioned checkout permanently dirty and drowns real work in `git status`. It was
+      # cleaned out of six repos on 2026-09-08 and reappeared in two working trees the same
+      # afternoon, so the committed state needs a guard rather than vigilance.
+      #
+      # The pattern excludes `@pnpm/exe.<platform>` — those are legitimate optional deps of `pnpm`
+      # itself and every clean lockfile holds 24 of them, so the obvious grep fails every repo.
+      - name: Lockfiles must not carry an @pnpm/exe block
+        run: |
+          locks=$(git ls-files '*pnpm-lock.yaml')
+          if [ -z "$locks" ]; then
+            echo "::error::no tracked pnpm-lock.yaml found — this check would pass vacuously"
+            exit 1
+          fi
+          bad=0
+          while IFS= read -r f; do
+            if grep -qE "@pnpm/exe[^.]" "$f"; then
+              echo "::error file=$f::$f carries an @pnpm/exe block, written only by a pnpm that does not match this repo's packageManager pin. Reinstall with the pinned pnpm and commit the lockfile."
+              bad=1
+            fi
+          done <<LOCKS
+          $locks
+          LOCKS
+          exit $bad
+
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## What

One step in CI: no tracked `pnpm-lock.yaml` may carry an `@pnpm/exe` block.

## Why

That block is written only by a pnpm that does **not** match this repo's `packageManager` pin; a pnpm that *does* match strips it out again. Committed, it leaves every correctly-provisioned checkout permanently dirty and buries real work in `git status` — which is how a deploy on 2026-09-03 lost an hour hand-preserving a patch that turned out to be this noise.

It was cleaned out of six repos on 2026-09-08 and **reappeared in two working trees the same afternoon**, one of them from nothing more than `pnpm test:run`. The committed state needs a guard rather than vigilance.

## Two details that are easy to get wrong

Both were found by testing the guard rather than reasoning about it:

- **The obvious pattern fails every repo.** `grep '@pnpm/exe'` also matches `@pnpm/exe.darwin-arm64`, `@pnpm/exe.linux-x64` and the rest — legitimate optional dependencies of `pnpm` itself. A *clean* lockfile scores **24** on it. This matches `@pnpm/exe[^.]`: clean **0**, dirty **3**.
- **It fails when it finds no lockfile at all**, rather than passing vacuously — a guard that can report clean must first prove it looked at something. It walks `git ls-files '*pnpm-lock.yaml'`, so nested lockfiles are covered; several repos have two.

## Verification

Validated five ways before rollout: a clean single lockfile, two clean lockfiles in two different repos, an injected block (fails, naming the file), and a repo with no lockfile (fails loudly). Piloted in `#150(pdf-factory)`, where the step is confirmed running in real CI.

Then run against this repo's own lockfiles before the commit was made — the rollout refuses to open a PR anywhere the guard does not already pass. It caught one repo where the block was still committed in a **nested** lockfile, which a root-only audit had missed.
