### PR TITLE
feat(policies): bind a seeding policy to the tournament, and let a draw see it

### DIFF
--- a/e2e/journeys/119-settings-seeding-policy.spec.ts
+++ b/e2e/journeys/119-settings-seeding-policy.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { initDevBridge, loginAsSuperAdmin, resetState, waitForAppReady } from '../helpers/dev-bridge';
+
+/**
+ * Journey 119 — a seeding policy attached to the tournament is what makes national seeding
+ * compliance reachable.
+ *
+ * The mechanism already existed on both ends and connected to nothing in the middle:
+ * `seedsCountThresholds` is the factory's extension point for a governing body's seeding depth,
+ * courthive-components ships an editor for it, and the `/policies` page persists what that editor
+ * produces. But no surface bound one of those policies to a tournament, so the two positioning
+ * presets in the draw form — which encode the same drawSize/4 progression as each other — were the
+ * only seeding any draw could get.
+ *
+ * Binding is at the TOURNAMENT, not per draw: every draw in a sanctioned competition seeds by the
+ * same rule, including one regenerated later, and the draw form's "Inherited" option already reads
+ * a tournament-level policy.
+ */
+
+const PANEL = '#seedingPolicyPanel';
+
+async function seedTournament(page: any): Promise<string> {
+  return page.evaluate(async () => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      tournamentName: 'E2E Seeding Policy',
+      drawProfiles: [{ eventName: 'Singles', drawSize: 32, participantsCount: 32, generate: false }],
+    });
+    await dev.tmx2db.addTournament(tournamentRecord);
+    return tournamentRecord.tournamentId as string;
+  });
+}
+
+async function openSettings(page: any, tournamentId: string) {
+  await page.goto(`/#/tournament/${tournamentId}/settings`);
+  await page.locator('#tournamentSettings .settings-panel').first().waitFor({ timeout: 15_000 });
+}
+
+test('the seeding policy panel attaches a policy to the tournamentRecord', async ({ page }) => {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page);
+  await loginAsSuperAdmin(page);
+  const tournamentId = await seedTournament(page);
+
+  await openSettings(page, tournamentId);
+  await expect(page.locator(PANEL)).toHaveCount(1);
+
+  const select = page.locator(`${PANEL} select`);
+  await expect(select).toBeVisible();
+
+  // Nothing attached yet, so the explicit "none" entry is what is selected.
+  await expect(select).toHaveValue('__none__');
+
+  // The threshold table is the point: a policy's NAME never says how deeply it seeds.
+  await select.selectOption('builtin-seeding');
+  await expect(page.locator(`${PANEL} div`).filter({ hasText: '32 →' }).first()).toBeVisible();
+
+  await page.locator(`${PANEL} button`).click();
+
+  // The attached policy comes back as a first-class entry, so re-saving is a no-op rather than a
+  // churning re-attach.
+  await expect(select).toHaveValue('__attached__', { timeout: 10_000 });
+  await expect(select.locator('option[value="__attached__"]')).toContainText('Attached —');
+
+  // And it is genuinely on the record, where the draw form's "Inherited" option will find it.
+  // Attached policies live in the `appliedPolicies` extension, so read them the way the factory
+  // does rather than looking for a `policyDefinitions` property that attachPolicies never writes.
+  const attached = await page.evaluate(
+    () => dev.factory.tournamentEngine.getPolicyDefinitions({ policyTypes: ['seeding'] })?.policyDefinitions?.seeding,
+  );
+  expect(attached?.seedsCountThresholds?.length).toBeGreaterThan(0);
+});
+
+test('the draw form offers Inherited once a tournament seeding policy is attached', async ({ page }) => {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await initDevBridge(page);
+  await resetState(page);
+  await loginAsSuperAdmin(page);
+  const tournamentId = await seedTournament(page);
+
+  await openSettings(page, tournamentId);
+  await page.locator(`${PANEL} select`).selectOption('builtin-seeding');
+  await page.locator(`${PANEL} button`).click();
+  await expect(page.locator(`${PANEL} select`)).toHaveValue('__attached__', { timeout: 10_000 });
+
+  await page.goto(`/#/tournament/${tournamentId}/events`);
+  await page.locator('.tabulator-row').first().click();
+  await page.waitForSelector('#eventTabsBar', { state: 'visible', timeout: 10_000 });
+  await page.getByRole('button', { name: 'Add draw' }).click();
+
+  const seedingSelect = page.locator('.drawer .field:has(.label:text-is("Seeding policy"))').locator('select');
+  await expect(seedingSelect).toBeVisible({ timeout: 10_000 });
+  // "Inherited" is the compliance path — it is what defers to the tournament policy.
+  await expect(seedingSelect.locator('option')).toContainText(['Inherited']);
+  await expect(seedingSelect).toHaveValue('INHERIT');
+});

--- a/src/components/drawers/addDraw/getDrawFormItems.ts
+++ b/src/components/drawers/addDraw/getDrawFormItems.ts
@@ -81,11 +81,18 @@ export function getDrawFormItems({ event, mode }: { event: any; mode: DrawFormMo
   const drawType = SINGLE_ELIMINATION;
   const isQualifyingMode = QUALIFYING_KINDS.has(mode.kind);
 
-  // Check for existing seeding policy at event or tournament level
-  const tournamentRecord = tournamentEngine.q.tournament();
-  const existingEventPolicy = event?.policyDefinitions?.[POLICY_TYPE_SEEDING];
-  const existingTournamentPolicy = (tournamentRecord as any)?.policyDefinitions?.[POLICY_TYPE_SEEDING];
-  const hasExistingPolicy = existingEventPolicy || existingTournamentPolicy;
+  // An attached policy lives in the `appliedPolicies` EXTENSION, not in a `policyDefinitions`
+  // property — `attachPolicies` goes through `addExtension` and never writes such a property, so the
+  // direct reads this used to do could not see one. That mattered more than a missing menu entry:
+  // with no "Inherited" option the form defaulted to a positioning preset, and a preset is sent as
+  // `policyDefinitions`, which the factory prefers over the attached policy
+  // (`validateAndDeriveDrawValues`: `policyDefinitions?.[seeding] ?? appliedPolicies?.[seeding]`).
+  // A tournament carrying its governing body's seeding rules would have had them silently
+  // overridden by every draw generated from this form.
+  const hasExistingPolicy = !!tournamentEngine.getPolicyDefinitions({
+    policyTypes: [POLICY_TYPE_SEEDING],
+    event,
+  })?.policyDefinitions?.[POLICY_TYPE_SEEDING];
 
   const flightProfile = tournamentEngine.q.flightProfile({ event });
   const flight = flightProfile?.flights?.find((f: any) => f.drawId === drawId);
@@ -113,11 +120,16 @@ export function getDrawFormItems({ event, mode }: { event: any; mode: DrawFormMo
     { label: t('drawers.addDraw.custom'), value: CUSTOM },
   ];
 
-  const seedingPolicyOptions = [
-    ...(hasExistingPolicy ? [{ label: t('drawers.addDraw.inherited'), value: INHERIT, selected: true }] : []),
-    { label: t('drawers.addDraw.separatedUsta'), value: SEPARATE, selected: !hasExistingPolicy },
-    { label: t('drawers.addDraw.adjacentItf'), value: CLUSTER },
-  ];
+  // A provider that declares a seeding policy AND withholds canModifyPolicies is stating a rule.
+  // Offering the two positioning presets here would let an operator override it per draw, which is
+  // the one thing compliance does not permit — so the selector collapses to a single entry.
+  const seedingPolicyOptions = providerConfig.isSeedingPolicyLocked()
+    ? [{ label: t('drawers.addDraw.providerSeedingPolicy'), value: INHERIT, selected: true }]
+    : [
+        ...(hasExistingPolicy ? [{ label: t('drawers.addDraw.inherited'), value: INHERIT, selected: true }] : []),
+        { label: t('drawers.addDraw.separatedUsta'), value: SEPARATE, selected: !hasExistingPolicy },
+        { label: t('drawers.addDraw.adjacentItf'), value: CLUSTER },
+      ];
   // `acceptedEntriesCount` is the same count `updateDrawSize` feeds the selector on every later
   // interaction. Rendering from a different notion of "how many entries" (drawEntries includes
   // cross-stage entries that never occupy a position) made the initial list disagree with itself

--- a/src/components/drawers/addDraw/submitDrawParams.ts
+++ b/src/components/drawers/addDraw/submitDrawParams.ts
@@ -7,6 +7,7 @@ import type { RoundProfileEditorController } from './roundProfileEditor';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
+import { providerConfig } from 'config/providerConfig';
 import { validators } from 'courthive-components';
 import { generateDraw } from './generateDraw';
 import { isFunction } from 'functions/typeOf';
@@ -350,6 +351,14 @@ function getStructureOptions(drawType: string, inputs: any): any {
 }
 
 function getSeedingPolicyDefinition(selectedSeedingPolicy: string): any {
+  // A locked provider policy is passed explicitly rather than left to INHERIT. Inheriting requires
+  // someone to have attached it on the settings tab first, and a draw created before anyone did
+  // would generate silently non-compliant — the one failure mode a locked policy exists to prevent.
+  // Attaching it as well is not a conflict: same policy, same seeding.
+  if (providerConfig.isSeedingPolicyLocked()) {
+    const providerPolicy = providerConfig.getSeedingPolicy();
+    if (providerPolicy) return { [POLICY_TYPE_SEEDING]: providerPolicy };
+  }
   if (selectedSeedingPolicy === SEPARATE) {
     return POLICY_SEEDING_DEFAULT;
   } else if (selectedSeedingPolicy === CLUSTER) {

--- a/src/config/providerConfig.test.ts
+++ b/src/config/providerConfig.test.ts
@@ -325,4 +325,47 @@ describe('providerConfig', () => {
       expect(providerConfig.getAllowedList('allowedCategories')).toHaveLength(2);
     });
   });
+
+  describe('seeding policy', () => {
+    const DEEP_SEEDING = {
+      policyName: 'Deep National',
+      seedsCountThresholds: [{ drawSize: 32, minimumParticipantCount: 24, seedsCount: 16 }],
+    };
+
+    it('reports no policy when the provider declares none', () => {
+      expect(providerConfig.getSeedingPolicy()).toBeUndefined();
+      expect(providerConfig.isSeedingPolicyLocked()).toBe(false);
+    });
+
+    it('returns the declared policy as a bare body, with no policy-type wrapper', () => {
+      providerConfig.set({ policies: { seedingPolicy: DEEP_SEEDING } } as any);
+      expect(providerConfig.getSeedingPolicy()).toEqual(DEEP_SEEDING);
+    });
+
+    it('does not lock on a declared policy alone — that is a default, not a rule', () => {
+      providerConfig.set({ policies: { seedingPolicy: DEEP_SEEDING } } as any);
+      expect(providerConfig.isSeedingPolicyLocked()).toBe(false);
+    });
+
+    it('locks only when a policy is declared AND canModifyPolicies is withheld', () => {
+      providerConfig.set({
+        policies: { seedingPolicy: DEEP_SEEDING },
+        permissions: { canModifyPolicies: false },
+      } as any);
+      expect(providerConfig.isSeedingPolicyLocked()).toBe(true);
+    });
+
+    it('does not lock when the permission is withheld but nothing is declared', () => {
+      // Otherwise a provider that merely restricts policy editing would strand every tournament
+      // with no seeding policy and no way to choose one.
+      providerConfig.set({ permissions: { canModifyPolicies: false } } as any);
+      expect(providerConfig.isSeedingPolicyLocked()).toBe(false);
+    });
+
+    it('ignores a non-object seedingPolicy rather than trusting it', () => {
+      providerConfig.set({ policies: { seedingPolicy: 'ITF' } } as any);
+      expect(providerConfig.getSeedingPolicy()).toBeUndefined();
+      expect(providerConfig.isSeedingPolicyLocked()).toBe(false);
+    });
+  });
 });

--- a/src/config/providerConfig.ts
+++ b/src/config/providerConfig.ts
@@ -116,6 +116,31 @@ export const providerConfig = {
     if (key === 'allowedTierSystems') return active.policies?.allowedTierSystems ?? [];
     return (active.permissions?.[key as keyof ProviderPermissions] as any[]) ?? [];
   },
+  /**
+   * The seeding policy this provider declares, as a bare policy body (no `{ seeding: ... }`
+   * wrapper) — or undefined when the provider declares none.
+   *
+   * This is how a governing body's own seeding rules reach a tournament. `seedsCountThresholds`
+   * is the factory's extension point for them, and the two policies TMX ships as presets encode
+   * the same drawSize/4 progression as each other, so a federation seeding to a different depth
+   * has nowhere else to say so.
+   */
+  getSeedingPolicy: (): Record<string, any> | undefined => {
+    const declared = resolved().policies?.seedingPolicy;
+    return declared && typeof declared === 'object' ? declared : undefined;
+  },
+  /**
+   * Whether a declared provider seeding policy may be swapped out per tournament.
+   *
+   * Locked only when the provider both declares a policy AND withholds `canModifyPolicies`.
+   * A provider that declares a policy without restricting the permission is expressing a
+   * default, not a rule — which is how every other `policies.*` field behaves today.
+   */
+  isSeedingPolicyLocked: (): boolean => {
+    const declared = resolved().policies?.seedingPolicy;
+    if (!declared || typeof declared !== 'object') return false;
+    return !providerConfig.isAllowed('canModifyPolicies');
+  },
 } as const;
 
 const PROVIDER_THEME_LINK_ID = 'tmx-provider-theme';

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -34,6 +34,7 @@ export const ASSIGN_TIE_MATCHUP_PARTICIPANT_ID = 'assignTieMatchUpParticipantId'
 export const ATTACH_FLIGHT_PROFILE = 'attachFlightProfile';
 export const ATTACH_QUALIFYING_STRUCTURE = 'attachQualifyingStructure';
 export const ATTACH_POLICIES = 'attachPolicies';
+export const REMOVE_POLICY = 'removePolicy';
 export const AUTOMATED_PLAYOFF_POSITIONING = 'automatedPlayoffPositioning';
 export const BULK_SCHEDULE_MATCHUPS = 'bulkScheduleMatchUps';
 export const DELETE_ADHOC_MATCHUPS = 'deleteAdHocMatchUps';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -263,6 +263,12 @@
     "weekdaysShort_6": "Sat"
   },
   "settings": {
+    "seedingPolicy": {
+      "title": "Seeding policy",
+      "intro": "Applies to every draw in this tournament. Draws created with \u201cInherited\u201d seeding use it, including draws regenerated later.",
+      "locked": "Your provider sets the seeding policy for this tournament. It applies to every draw and cannot be changed here.",
+      "thresholds": "Draw size \u2192 seeds:"
+    },
     "help": "Help",
     "pagesize": "Page Size",
     "schedule": "Schedule",
@@ -1836,6 +1842,7 @@
       "creation": "Creation",
       "scoreFormat": "Score format",
       "seedingPolicy": "Seeding policy",
+      "providerSeedingPolicy": "Provider policy",
       "seedsCount": "Seed count",
       "automaticSeedsCount": "Automatic (policy)",
       "scorecard": "Scorecard",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -267,7 +267,11 @@
       "title": "Seeding policy",
       "intro": "Applies to every draw in this tournament. Draws created with \u201cInherited\u201d seeding use it, including draws regenerated later.",
       "locked": "Your provider sets the seeding policy for this tournament. It applies to every draw and cannot be changed here.",
-      "thresholds": "Draw size \u2192 seeds:"
+      "thresholds": "Draw size \u2192 seeds:",
+      "providerPolicy": "Provider policy",
+      "none": "None \u2014 factory default",
+      "custom": "Custom policy",
+      "attached": "Attached \u2014 {{name}}"
     },
     "help": "Help",
     "pagesize": "Page Size",

--- a/src/pages/tournament/tabs/settingsTab/seedingPolicyPanel.ts
+++ b/src/pages/tournament/tabs/settingsTab/seedingPolicyPanel.ts
@@ -1,0 +1,128 @@
+/**
+ * Tournament seeding-policy panel.
+ *
+ * Binds a seeding policy to the tournamentRecord, which is where seeding compliance belongs: every
+ * draw in the competition then seeds by the same rule, including one regenerated a week later, and
+ * the add-draw form's existing "Inherited" option is already the path that reads it.
+ *
+ * The catalog side of this already existed — a seeding editor in courthive-components, a `/policies`
+ * page that persists what it produces. This panel is the missing link between a policy sitting in
+ * that catalog and a draw actually being seeded by it.
+ */
+import {
+  ATTACHED_POLICY_ID,
+  NO_POLICY_ID,
+  SeedingPolicyChoice,
+  buildAttachedChoice,
+  describeThresholds,
+  loadSeedingChoices,
+  resolveAttachedChoiceId,
+} from 'services/policies/seedingPolicyChoices';
+import { ATTACH_POLICIES, REMOVE_POLICY } from 'constants/mutationConstants';
+import { mutationRequest } from 'services/mutation/mutationRequest';
+import { tournamentEngine } from 'services/factory/engine';
+import { tmxToast } from 'services/notifications/tmxToast';
+import { providerConfig } from 'config/providerConfig';
+import { policyConstants } from 'tods-competition-factory';
+import { t } from 'i18n';
+
+const { POLICY_TYPE_SEEDING } = policyConstants;
+
+export const SEEDING_POLICY_PANEL_ID = 'seedingPolicyPanel';
+
+/** The seeding policy attached to the tournamentRecord, or null. */
+function attachedPolicy(): Record<string, any> | null {
+  const result: any = tournamentEngine.getPolicyDefinitions({ policyTypes: [POLICY_TYPE_SEEDING] });
+  return result?.policyDefinitions?.[POLICY_TYPE_SEEDING] ?? null;
+}
+
+export function buildSeedingPolicyPanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = SEEDING_POLICY_PANEL_ID;
+  panel.className = 'settings-panel panel-indigo';
+  panel.style.gridColumn = '1 / -1';
+  void renderPanelContents(panel);
+  return panel;
+}
+
+async function renderPanelContents(panel: HTMLElement): Promise<void> {
+  const attached = attachedPolicy();
+  const choices = await loadSeedingChoices();
+  const matchedId = resolveAttachedChoiceId(attached, choices);
+  const locked = providerConfig.isSeedingPolicyLocked();
+
+  // An attached policy that matches no catalog entry would otherwise be unrepresentable in the
+  // select — it would silently display as whatever sits first, and saving would replace it.
+  const options = attached
+    ? [buildAttachedChoice(attached, choices.find((choice) => choice.id === matchedId)?.label ?? null), ...choices]
+    : choices;
+
+  panel.innerHTML = `<h3><i class="fa-solid fa-list-ol"></i> ${t('settings.seedingPolicy.title')}</h3>`;
+
+  const description = document.createElement('p');
+  description.style.cssText = 'margin: 0 0 12px 0; color: var(--tmx-text-secondary); font-size: 0.85rem;';
+  description.textContent = locked ? t('settings.seedingPolicy.locked') : t('settings.seedingPolicy.intro');
+  panel.appendChild(description);
+
+  const select = document.createElement('select');
+  select.className = 'input';
+  select.style.cssText = 'max-width: 420px;';
+  select.disabled = locked && options.length <= 1;
+  for (const choice of options) {
+    const option = new Option(choice.label, choice.id);
+    option.selected = attached ? choice.id === ATTACHED_POLICY_ID : choice.id === NO_POLICY_ID;
+    select.add(option);
+  }
+  panel.appendChild(select);
+
+  const thresholds = document.createElement('div');
+  thresholds.style.cssText =
+    'margin: 10px 0 0 0; color: var(--tmx-text-secondary); font-size: 0.8rem; font-family: var(--tmx-font-mono, monospace);';
+  const paintThresholds = () => {
+    const selected = options.find((choice) => choice.id === select.value);
+    const pairs = describeThresholds(selected?.definition?.[POLICY_TYPE_SEEDING]);
+    // Naming a policy does not say how deeply it seeds; the threshold table does.
+    thresholds.textContent = pairs.length ? `${t('settings.seedingPolicy.thresholds')}  ${pairs.join('   ')}` : '';
+  };
+  paintThresholds();
+  select.addEventListener('change', paintThresholds);
+  panel.appendChild(thresholds);
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'margin-top: 12px; display: flex; gap: 8px;';
+  const save = document.createElement('button');
+  save.className = 'button is-info is-small';
+  save.textContent = t('common.save');
+  save.onclick = () => applySelection(options, select.value, () => void renderPanelContents(panel));
+  actions.appendChild(save);
+  panel.appendChild(actions);
+}
+
+function applySelection(choices: SeedingPolicyChoice[], selectedId: string, refresh: () => void): void {
+  // Re-selecting what is already attached is a no-op, not a re-attach: attaching rewrites the
+  // extension and would churn the tournamentRecord for no change.
+  if (selectedId === ATTACHED_POLICY_ID) return;
+
+  const choice = choices.find((entry) => entry.id === selectedId);
+  if (!choice) return;
+
+  const methods = choice.definition
+    ? [
+        {
+          method: ATTACH_POLICIES,
+          params: { policyDefinitions: choice.definition, allowReplacement: true },
+        },
+      ]
+    : [{ method: REMOVE_POLICY, params: { policyType: POLICY_TYPE_SEEDING } }];
+
+  mutationRequest({
+    methods,
+    callback: (result: any) => {
+      if (result?.success) {
+        refresh();
+      } else {
+        tmxToast({ message: t('common.error'), intent: 'is-danger' });
+      }
+    },
+  });
+}

--- a/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
+++ b/src/pages/tournament/tabs/settingsTab/settingsGrid.ts
@@ -2,6 +2,7 @@ import { isDesktopNotificationsEnabled, setDesktopNotificationsEnabled } from 's
 import { persistConfigToStorage, loadSettings, saveSettings } from 'services/settings/settingsStorage';
 import { getCachedFontCatalog, ensurePdfFontReady, PROVIDER_DEFAULT_FONT } from 'services/pdf/pdfFont';
 import { buildLinkedTournamentsPanel, LINKED_TOURNAMENTS_PANEL_ID } from './linkedTournaments';
+import { buildSeedingPolicyPanel } from './seedingPolicyPanel';
 import { connectSocket, connected, disconnectSocket } from 'services/messaging/socketIo';
 import { removeProviderTournament } from 'services/storage/removeProviderTournament';
 import { preferencesConfig, type PreferencesConfig } from 'config/preferencesConfig';
@@ -172,6 +173,13 @@ export async function renderSettingsGrid(
     }
   };
   syncLinkedPanel();
+
+  // Tournament-scoped: a seeding policy is attached to the tournamentRecord, so it has nothing to
+  // bind to on the app-level settings screen. Unlike the linked-tournaments panel this needs no
+  // authentication — the catalog is local and the mutation is an ordinary tournament mutation.
+  if (!options?.excludeTournament) {
+    grid.appendChild(buildSeedingPolicyPanel());
+  }
 
   // --- Language panel (blue, 1 col) ---
   // Source the language list from the CFS manifest so newly-added locales

--- a/src/services/policies/seedingPolicyChoices.test.ts
+++ b/src/services/policies/seedingPolicyChoices.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getBuiltinPoliciesMock, loadUserPoliciesMock } = vi.hoisted(() => ({
+  getBuiltinPoliciesMock: vi.fn(),
+  loadUserPoliciesMock: vi.fn(),
+}));
+
+vi.mock('pages/policies/policyBridge', () => ({
+  getBuiltinPolicies: getBuiltinPoliciesMock,
+  loadUserPolicies: loadUserPoliciesMock,
+}));
+
+import {
+  ATTACHED_POLICY_ID,
+  NO_POLICY_ID,
+  PROVIDER_POLICY_ID,
+  buildAttachedChoice,
+  describeThresholds,
+  loadSeedingChoices,
+  resolveAttachedChoiceId,
+} from './seedingPolicyChoices';
+import { providerConfig } from 'config/providerConfig';
+
+/** A federation seeding 16 in a 32 draw — deeper than either policy TMX ships as a preset. */
+const DEEP_SEEDING = {
+  policyName: 'Deep National',
+  seedsCountThresholds: [
+    { drawSize: 16, minimumParticipantCount: 12, seedsCount: 8 },
+    { drawSize: 32, minimumParticipantCount: 24, seedsCount: 16 },
+  ],
+};
+
+const BUILTIN_ID = 'builtin-seeding';
+const BUILTIN_NAME = 'Default Seeding';
+
+const BUILTIN_SEEDING = {
+  id: BUILTIN_ID,
+  name: BUILTIN_NAME,
+  policyType: 'seeding',
+  source: 'builtin',
+  policyData: { seedsCountThresholds: [{ drawSize: 32, minimumParticipantCount: 24, seedsCount: 8 }] },
+};
+
+beforeEach(() => {
+  getBuiltinPoliciesMock.mockReturnValue([BUILTIN_SEEDING, { id: 'sched', policyType: 'scheduling', policyData: {} }]);
+  loadUserPoliciesMock.mockResolvedValue([]);
+  providerConfig.reset();
+});
+
+afterEach(() => {
+  providerConfig.reset();
+  vi.clearAllMocks();
+});
+
+describe('loadSeedingChoices', () => {
+  it('offers seeding policies only, plus an explicit "none"', async () => {
+    const choices = await loadSeedingChoices();
+    expect(choices.map((c) => c.id)).toEqual([BUILTIN_ID, NO_POLICY_ID]);
+  });
+
+  it('survives an unreadable catalog rather than returning nothing', async () => {
+    loadUserPoliciesMock.mockRejectedValue(new Error('IndexedDB unavailable'));
+    const choices = await loadSeedingChoices();
+    expect(choices.map((c) => c.id)).toContain(BUILTIN_ID);
+  });
+
+  it('leads with the provider policy when one is declared', async () => {
+    providerConfig.set({ policies: { seedingPolicy: DEEP_SEEDING } } as any);
+    const choices = await loadSeedingChoices();
+    expect(choices[0].id).toEqual(PROVIDER_POLICY_ID);
+    expect(choices[0].label).toEqual('Deep National');
+    // Declaring a policy without restricting the permission is a default, not a rule.
+    expect(choices.length).toBeGreaterThan(1);
+  });
+
+  it('offers the provider policy ALONE when canModifyPolicies is withheld', async () => {
+    providerConfig.set({
+      policies: { seedingPolicy: DEEP_SEEDING },
+      permissions: { canModifyPolicies: false },
+    } as any);
+    const choices = await loadSeedingChoices();
+    expect(choices.map((c) => c.id)).toEqual([PROVIDER_POLICY_ID]);
+  });
+
+  it('does not lock when the permission is withheld but no policy is declared', async () => {
+    providerConfig.set({ permissions: { canModifyPolicies: false } } as any);
+    expect(providerConfig.isSeedingPolicyLocked()).toEqual(false);
+    const choices = await loadSeedingChoices();
+    expect(choices.map((c) => c.id)).toEqual([BUILTIN_ID, NO_POLICY_ID]);
+  });
+
+  it('stamps an identity so the attached policy can be recognized later', async () => {
+    const choices = await loadSeedingChoices();
+    expect(choices[0].definition?.seeding.policyName).toEqual(BUILTIN_NAME);
+  });
+});
+
+describe('resolveAttachedChoiceId', () => {
+  it('matches on stamped identity', async () => {
+    const choices = await loadSeedingChoices();
+    const attached = { ...BUILTIN_SEEDING.policyData, policyName: BUILTIN_NAME };
+    expect(resolveAttachedChoiceId(attached, choices)).toEqual(BUILTIN_ID);
+  });
+
+  it('falls back to a structural compare for policies attached before stamping existed', async () => {
+    const choices = await loadSeedingChoices();
+    // No policyName, and key order differs from the catalog entry's.
+    const attached = { seedsCountThresholds: [{ seedsCount: 8, minimumParticipantCount: 24, drawSize: 32 }] };
+    expect(resolveAttachedChoiceId(attached, choices)).toEqual(BUILTIN_ID);
+  });
+
+  it('reports no match for a genuinely different policy', async () => {
+    const choices = await loadSeedingChoices();
+    expect(resolveAttachedChoiceId(DEEP_SEEDING, choices)).toEqual(null);
+  });
+
+  it('reports no match when nothing is attached', async () => {
+    expect(resolveAttachedChoiceId(null, await loadSeedingChoices())).toEqual(null);
+  });
+});
+
+describe('buildAttachedChoice', () => {
+  it('names an unmatched attached policy by its own policyName', () => {
+    const choice = buildAttachedChoice(DEEP_SEEDING, null);
+    expect(choice.id).toEqual(ATTACHED_POLICY_ID);
+    expect(choice.label).toEqual('Attached — Deep National');
+  });
+
+  it('falls back to Custom policy when the attached policy is anonymous', () => {
+    expect(buildAttachedChoice({ seedsCountThresholds: [] }, null).label).toEqual('Attached — Custom policy');
+  });
+});
+
+describe('describeThresholds', () => {
+  it('renders the seeding depth, which a policy name never states', () => {
+    expect(describeThresholds(DEEP_SEEDING)).toEqual(['16 → 8', '32 → 16']);
+  });
+
+  it('sorts by draw size regardless of how the policy was authored', () => {
+    const unsorted = {
+      seedsCountThresholds: [
+        { drawSize: 64, seedsCount: 32 },
+        { drawSize: 4, seedsCount: 2 },
+      ],
+    };
+    expect(describeThresholds(unsorted)).toEqual(['4 → 2', '64 → 32']);
+  });
+
+  it('says nothing for a policy with no thresholds', () => {
+    expect(describeThresholds({ seedingProfile: { positioning: 'CLUSTER' } })).toEqual([]);
+    expect(describeThresholds(null)).toEqual([]);
+  });
+});

--- a/src/services/policies/seedingPolicyChoices.ts
+++ b/src/services/policies/seedingPolicyChoices.ts
@@ -24,6 +24,7 @@ import { getBuiltinPolicies, loadUserPolicies } from 'pages/policies/policyBridg
 import type { PolicyCatalogItem } from 'courthive-components';
 import { providerConfig } from 'config/providerConfig';
 import { policyConstants } from 'tods-competition-factory';
+import { t } from 'i18n';
 
 const { POLICY_TYPE_SEEDING } = policyConstants;
 
@@ -92,8 +93,8 @@ export async function loadSeedingChoices(): Promise<SeedingPolicyChoice[]> {
     ? [
         {
           id: PROVIDER_POLICY_ID,
-          label: policyLabel(providerPolicy, 'Provider policy'),
-          definition: stamped(providerPolicy, policyLabel(providerPolicy, 'Provider policy')),
+          label: policyLabel(providerPolicy, t('settings.seedingPolicy.providerPolicy')),
+          definition: stamped(providerPolicy, policyLabel(providerPolicy, t('settings.seedingPolicy.providerPolicy'))),
           source: 'provider',
         },
       ]
@@ -117,7 +118,7 @@ export async function loadSeedingChoices(): Promise<SeedingPolicyChoice[]> {
     ...providerChoice,
     ...builtins.map(toChoice),
     ...userPolicies.map(toChoice),
-    { id: NO_POLICY_ID, label: 'None — factory default', definition: null, source: 'none' },
+    { id: NO_POLICY_ID, label: t('settings.seedingPolicy.none'), definition: null, source: 'none' },
   ];
 }
 
@@ -154,7 +155,9 @@ export function resolveAttachedChoiceId(
 export function buildAttachedChoice(attached: Record<string, any>, matchedLabel: string | null): SeedingPolicyChoice {
   return {
     id: ATTACHED_POLICY_ID,
-    label: `Attached — ${matchedLabel ?? policyLabel(attached, 'Custom policy')}`,
+    label: t('settings.seedingPolicy.attached', {
+      name: matchedLabel ?? policyLabel(attached, t('settings.seedingPolicy.custom')),
+    }),
     definition: { [POLICY_TYPE_SEEDING]: attached },
     source: 'attached',
   };

--- a/src/services/policies/seedingPolicyChoices.ts
+++ b/src/services/policies/seedingPolicyChoices.ts
@@ -1,0 +1,176 @@
+/**
+ * Seeding-policy selection for a tournament.
+ *
+ * A governing body's seeding rules are expressed as `seedsCountThresholds` — the factory's
+ * extension point for exactly this. The catalog can already hold such a policy: courthive-components
+ * ships a seeding editor that edits threshold rows, positioning profile, flags and per-drawType
+ * overrides, and the `/policies` page persists the result through `policyBridge`. What was missing
+ * was any way for one of those policies to reach a draw.
+ *
+ * It reaches one by being ATTACHED TO THE TOURNAMENT, not by being picked per draw. Compliance is a
+ * property of the sanctioned competition: every draw in it seeds by the same rule, a draw
+ * regenerated next week still does, and the add-draw form's existing "Inherited" option is already
+ * the path that reads it (`getDrawFormItems` looks for a seeding policy on the event and then on
+ * the tournamentRecord). A per-draw pick would let two draws in one event comply differently, which
+ * is not a thing compliance permits.
+ *
+ * Mirrors `schedulingPolicyChoices` deliberately, including identity stamping — a `policyName`
+ * carried in the policy body so a later re-open can recognize what is attached without depending on
+ * structural equality.
+ *
+ * Authoring and editing policies is out of scope here; that lives on `/policies`.
+ */
+import { getBuiltinPolicies, loadUserPolicies } from 'pages/policies/policyBridge';
+import type { PolicyCatalogItem } from 'courthive-components';
+import { providerConfig } from 'config/providerConfig';
+import { policyConstants } from 'tods-competition-factory';
+
+const { POLICY_TYPE_SEEDING } = policyConstants;
+
+/** Sentinel id for the synthetic entry representing the policy already on the tournamentRecord. */
+export const ATTACHED_POLICY_ID = '__attached__';
+/** Sentinel id for the provider's declared policy. */
+export const PROVIDER_POLICY_ID = '__provider__';
+/** Sentinel id for "no seeding policy attached" — draws fall back to the factory default. */
+export const NO_POLICY_ID = '__none__';
+
+export type SeedingPolicySource = 'provider' | 'builtin' | 'user' | 'attached' | 'none';
+
+export interface SeedingPolicyChoice {
+  id: string;
+  label: string;
+  /** `attachPolicies({ policyDefinitions })` input shape: `{ seeding: {...} }`. */
+  definition: Record<string, any> | null;
+  source: SeedingPolicySource;
+}
+
+/** Identity and volatile keys ignored when comparing two policies structurally. */
+const IGNORED_KEYS = new Set(['policyName']);
+
+function normalizedFingerprint(policy: Record<string, any> | null | undefined): string {
+  if (!policy || typeof policy !== 'object') return '';
+  const stable = (value: any): any => {
+    if (Array.isArray(value)) return value.map(stable);
+    if (value && typeof value === 'object') {
+      return Object.keys(value)
+        .filter((key) => !IGNORED_KEYS.has(key))
+        .sort((a, b) => a.localeCompare(b))
+        .reduce((acc: Record<string, any>, key) => {
+          acc[key] = stable(value[key]);
+          return acc;
+        }, {});
+    }
+    return value;
+  };
+  return JSON.stringify(stable(policy));
+}
+
+/** Stamp the choice's label as `policyName` so the identity travels with the tournamentRecord. */
+function stamped(policy: Record<string, any>, name: string): Record<string, any> {
+  return { [POLICY_TYPE_SEEDING]: { ...policy, policyName: policy.policyName || name } };
+}
+
+function toChoice(item: PolicyCatalogItem): SeedingPolicyChoice {
+  return {
+    id: item.id,
+    label: item.name,
+    definition: stamped(item.policyData, item.name),
+    source: item.source === 'builtin' ? 'builtin' : 'user',
+  };
+}
+
+/**
+ * Every seeding policy a tournament could be given, most authoritative first.
+ *
+ * When the provider declares one it leads the list, and when
+ * `providerConfig.isSeedingPolicyLocked()` it is the ONLY entry — a provider that both declares a
+ * seeding policy and withholds `canModifyPolicies` is stating a rule, not a default.
+ */
+export async function loadSeedingChoices(): Promise<SeedingPolicyChoice[]> {
+  const providerPolicy = providerConfig.getSeedingPolicy();
+  const providerChoice: SeedingPolicyChoice[] = providerPolicy
+    ? [
+        {
+          id: PROVIDER_POLICY_ID,
+          label: policyLabel(providerPolicy, 'Provider policy'),
+          definition: stamped(providerPolicy, policyLabel(providerPolicy, 'Provider policy')),
+          source: 'provider',
+        },
+      ]
+    : [];
+
+  if (providerPolicy && providerConfig.isSeedingPolicyLocked()) return providerChoice;
+
+  const builtins = getBuiltinPolicies().filter((policy) => policy.policyType === POLICY_TYPE_SEEDING);
+
+  let userPolicies: PolicyCatalogItem[] = [];
+  try {
+    const all = await loadUserPolicies();
+    userPolicies = all.filter((policy) => policy.policyType === POLICY_TYPE_SEEDING);
+  } catch (err) {
+    // IndexedDB unavailable (private browsing, quota) must not empty the list — the builtins and
+    // the provider policy are still perfectly usable without it.
+    console.error('loadUserPolicies failed', err);
+  }
+
+  return [
+    ...providerChoice,
+    ...builtins.map(toChoice),
+    ...userPolicies.map(toChoice),
+    { id: NO_POLICY_ID, label: 'None — factory default', definition: null, source: 'none' },
+  ];
+}
+
+function policyLabel(policy: Record<string, any>, fallback: string): string {
+  return typeof policy?.policyName === 'string' && policy.policyName ? policy.policyName : fallback;
+}
+
+/**
+ * Which choice, if any, equals the policy already attached to the tournament.
+ * Identity (`policyName`) first, normalized structural compare as the fallback for policies
+ * attached before identity stamping existed.
+ */
+export function resolveAttachedChoiceId(
+  attached: Record<string, any> | null | undefined,
+  choices: SeedingPolicyChoice[],
+): string | null {
+  if (!attached) return null;
+
+  const attachedName = typeof attached.policyName === 'string' ? attached.policyName : '';
+  if (attachedName) {
+    const byName = choices.find((choice) => choice.definition?.[POLICY_TYPE_SEEDING]?.policyName === attachedName);
+    if (byName) return byName.id;
+  }
+
+  const attachedFingerprint = normalizedFingerprint(attached);
+  if (!attachedFingerprint) return null;
+  const byShape = choices.find(
+    (choice) => normalizedFingerprint(choice.definition?.[POLICY_TYPE_SEEDING]) === attachedFingerprint,
+  );
+  return byShape?.id ?? null;
+}
+
+/** A first-class entry for the attached policy, so re-selecting it is a no-op rather than a re-attach. */
+export function buildAttachedChoice(attached: Record<string, any>, matchedLabel: string | null): SeedingPolicyChoice {
+  return {
+    id: ATTACHED_POLICY_ID,
+    label: `Attached — ${matchedLabel ?? policyLabel(attached, 'Custom policy')}`,
+    definition: { [POLICY_TYPE_SEEDING]: attached },
+    source: 'attached',
+  };
+}
+
+/**
+ * The seed counts a policy produces, as `drawSize → seedsCount` pairs.
+ *
+ * The whole point of attaching a federation's policy is a different depth of seeding, and that
+ * difference is invisible in a policy's name. Surfacing the table is what lets an operator see that
+ * the thing they just attached actually seeds 16 in a 32 draw.
+ */
+export function describeThresholds(policy: Record<string, any> | null | undefined): string[] {
+  const thresholds = policy?.seedsCountThresholds;
+  if (!Array.isArray(thresholds) || !thresholds.length) return [];
+  return [...thresholds]
+    .sort((a, b) => (a?.drawSize ?? 0) - (b?.drawSize ?? 0))
+    .map((threshold) => `${threshold?.drawSize ?? '?'} → ${threshold?.seedsCount ?? 0}`);
+}


### PR DESCRIPTION
Stacked on #1432(TMX) — **review that one first**; this PR targets its branch so the diff stays honest. Retarget to `main` once #1432(TMX) merges.

National seeding rules differ in **depth** — how many seeds a draw of a given size gets. `seedsCountThresholds` is the factory's extension point for saying so, and everything needed to author such a policy already shipped:

- courthive-components has a seeding editor (`editors/seeding/`) that edits threshold rows, positioning profile, flags and per-drawType overrides
- TMX's `/policies` page mounts it and persists the result through `policyBridge`
- `POLICY_TYPE_SEEDING` is already a first-class catalog type

Nothing bound one of those policies to a tournament. So the two positioning presets in the draw form were the only seeding any draw could get — and both encode the same `drawSize / 4` progression, which is exactly the depth national rules disagree about.

## The blocker was worse than a missing menu entry

`attachPolicies` writes to the **`appliedPolicies` extension** — it goes through `addExtension` and never writes a `policyDefinitions` property. The draw form was reading exactly that non-existent property:

```ts
const existingTournamentPolicy = (tournamentRecord as any)?.policyDefinitions?.[POLICY_TYPE_SEEDING];
```

So `hasExistingPolicy` was always false, "Inherited" never appeared, and the form defaulted to a positioning preset. A preset is submitted as `policyDefinitions` — which the factory **prefers over the attached policy**:

```ts
// validateAndDeriveDrawValues.ts
const seedingPolicy = policyDefinitions?.[POLICY_TYPE_SEEDING] ?? appliedPolicies?.[POLICY_TYPE_SEEDING];
```

A tournament carrying its governing body's seeding rules would have had them silently overridden by every draw generated from this form. The read now goes through `getPolicyDefinitions`, which is extension-aware. **An e2e journey found this**, after the unit tests were already green — which is the argument for having one here.

## Why the tournament, not the draw

Compliance is a property of the sanctioned competition. Every draw seeds by the same rule; a draw regenerated next week still does; and no two draws in one event can comply differently. The draw form's existing "Inherited" option is already the path that defers to it — it just needed to be able to see one.

## What's added

| | |
|---|---|
| `services/policies/seedingPolicyChoices` | The catalog's seeding policies as selectable choices. Mirrors `schedulingPolicyChoices` including identity stamping, so a re-open recognizes what is attached without depending on structural equality. Plus a threshold summary — a policy's *name* never says how deeply it seeds, and that is the one thing an operator needs to see before attaching it. |
| Settings-tab panel | Attach or remove the tournament's seeding policy. |
| `providerConfig.getSeedingPolicy()` / `isSeedingPolicyLocked()` | `ProviderPolicyDefaults.seedingPolicy` has existed all along and nothing read it — TMX reads `allowedMatchUpFormats`, `allowedCategories` and `allowedTierSystems` off that same object. |

Locked **only** when a provider both declares a policy *and* withholds `canModifyPolicies` — declaring one alone is a default, which is how every other `policies.*` field behaves. When locked the draw form collapses to a single choice, and submit sends the provider policy explicitly rather than trusting that someone visited settings first: a draw created before they did would generate silently non-compliant, which is the one failure mode a locked policy exists to prevent.

Authoring policies stays on `/policies`. This is only the binding.

## Verification

1822 unit tests (`TZ=UTC`), `eslint src e2e` clean, prettier, `tsc --noEmit`, and 71 Playwright journeys across every draw-form spec plus the new journey 119. Journey 119 asserts the policy reaches the record through the extension and that "Inherited" then appears in the draw form — the two halves that were disconnected.