### PR TITLE
fix(mutations): resetMatchUpLineUps was misspelled, so lineup reset never worked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
       - name: i18n-audit
         run: pnpm i18n-audit --ci
 
+      # mutationConstants map 1:1 to factory engine methods, and that mapping had drifted: a typo
+      # sent `resetMatchUpLinesUps`, the engine answered METHOD_NOT_FOUND, and two UI actions did
+      # nothing. TypeScript cannot see it — the constant is just a string.
+      - name: mutation-constant drift
+        run: pnpm mutation-drift
+
       # Type-checks src/ against the PUBLISHED factory, because the link:
       # overrides are stripped above. This is the only gate that can catch a
       # call into sibling work that exists locally but has not been published —

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "electron:package": "electron-builder --config electron-builder.json5",
     "attr-audit": "node scripts/attr-audit.mjs",
     "i18n-audit": "node scripts/i18n-audit.mjs",
+    "mutation-drift": "node scripts/mutation-constant-drift.mjs",
     "check-types:electron": "tsc --noEmit --project electron/tsconfig.json",
     "test:electron": "pnpm electron:build && playwright test --config e2e/playwright.electron.config.ts",
     "test:electron:ui": "playwright test --config e2e/playwright.electron.config.ts --ui"

--- a/scripts/mutation-constant-drift.mjs
+++ b/scripts/mutation-constant-drift.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Every mutation constant must name a real factory engine method.
+ *
+ * WHY THIS EXISTS
+ *
+ * `RESET_MATCHUP_LINEUPS` was `'resetMatchUpLinesUps'` — "LinesUps". The factory method is
+ * `resetMatchUpLineUps`. Two live UI actions dispatched it: the scorecard overlay's lineup reset and
+ * the draw action menu's. The async engine answers an unknown method name with
+ * `{ error: METHOD_NOT_FOUND }`, so the feature had never worked, and nothing anywhere said so.
+ *
+ * Nothing could have caught it. The constant is a string, so TypeScript is satisfied; the method name
+ * only fails at the far side of a socket, inside the server's engine. `mutationConstants.ts` is
+ * documented as mapping 1:1 to factory engine methods, and that mapping had drifted with no gate.
+ *
+ * The check reads the ENGINE ITSELF from the installed package rather than a generated list, so it
+ * measures what the server will actually find. It therefore works the same whether the factory is
+ * resolved through the `link:` override or from npm.
+ */
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const CONSTANTS = path.join(ROOT, 'src', 'constants', 'mutationConstants.ts');
+
+const { tournamentEngine } = require('tods-competition-factory');
+const available = new Set(Object.keys(tournamentEngine));
+
+const source = fs.readFileSync(CONSTANTS, 'utf8');
+const declared = [...source.matchAll(/export const (\w+) = '([^']+)';/g)].map(([, name, value]) => ({ name, value }));
+
+if (!declared.length) {
+  console.error('[mutation-drift] parsed no constants — the file shape changed, and this check would pass vacuously');
+  process.exit(2);
+}
+
+const missing = declared.filter(({ value }) => !available.has(value));
+
+console.log(`[mutation-drift] ${declared.length} constants checked against ${available.size} engine methods`);
+
+if (missing.length) {
+  console.error(`\n[mutation-drift] ${missing.length} constant(s) name no engine method:\n`);
+  for (const { name, value } of missing) console.error(`  ${name}  ->  '${value}'`);
+  console.error(
+    '\nThe engine answers an unknown name with METHOD_NOT_FOUND, so any UI dispatching one of these\n' +
+      'silently does nothing. Check for a typo first; otherwise the method may have been renamed or\n' +
+      'removed in the factory, or may never have been registered through a governor.',
+  );
+  process.exit(1);
+}
+
+console.log('[mutation-drift] OK — every mutation constant resolves to an engine method');

--- a/src/constants/mutationConstants.ts
+++ b/src/constants/mutationConstants.ts
@@ -86,7 +86,7 @@ export const REMOVE_STRUCTURE = 'removeStructure';
 export const MODIFY_DRAW_NAME = 'modifyDrawName';
 export const RENAME_STRUCTURES = 'renameStructures';
 export const RESET_DRAW_DEFINITION = 'resetDrawDefinition';
-export const RESET_MATCHUP_LINEUPS = 'resetMatchUpLinesUps';
+export const RESET_MATCHUP_LINEUPS = 'resetMatchUpLineUps';
 export const RESET_SCORECARD = 'resetScorecard';
 export const SET_MATCHUP_CALLED_AT = 'setMatchUpCalledAt';
 // Per-matchUp check-in — a participant presenting at the desk for THIS match. Distinct from


### PR DESCRIPTION
## A broken feature, silently

`RESET_MATCHUP_LINEUPS` was `'resetMatchUpLinesUps'` — **"LinesUps"**. The factory method is `resetMatchUpLineUps`.

Two live UI actions dispatch it:

- `components/overlays/scorecard/scorecard.ts:220` — the scorecard's lineup reset
- `pages/tournament/tabs/eventsTab/renderDraws/getActionOptions.ts:244` — the draw action menu

The async engine answers an unknown method name with `{ error: METHOD_NOT_FOUND }` (`asyncEngineInvoke.ts:34`), so **both have never worked**, surfacing only as a generic unsuccessful mutation.

## Why nothing caught it

The constant is a `string`, so TypeScript is satisfied. The name only fails at the far side of a socket, inside the server's engine. `mutationConstants.ts` is documented as mapping 1:1 to factory engine methods — and that mapping had drifted with no gate on it.

This is the same shape as the reachability gaps fixed in the factory this week: a thing that is correct on its own terms and wrong at the boundary, where no test looks.

## The gate

`pnpm mutation-drift`, wired into the `lint` job beside `attr-audit` and `i18n-audit`.

It reads the **engine itself** from the installed package rather than a generated list, so it measures what the server will actually find — and behaves identically whether the factory resolves through the `link:` override or from npm. It also refuses to pass vacuously: parsing zero constants is exit 2, not success.

Reproducing the original bug:

```
[mutation-drift] 1 constant(s) name no engine method:

  RESET_MATCHUP_LINEUPS  ->  'resetMatchUpLinesUps'

The engine answers an unknown name with METHOD_NOT_FOUND, so any UI dispatching one of these
silently does nothing. Check for a typo first; otherwise the method may have been renamed or
removed in the factory, or may never have been registered through a governor.
```

Fixed: `[mutation-drift] 116 constants checked against 732 engine methods — OK`.

## How it was found

By comparing all 115 mutation constants against the factory's 728 engine methods while looking into something else. **It was the only drift** — which is the argument for checking continuously rather than once, since the next rename in the factory reintroduces the class for free.

## Verification

`lint`, `format:check`, `attr-audit`, `i18n-audit`, `mutation-drift`, `tsc --noEmit` all pass. 1822 unit tests.