### PR TITLE
refactor(venueTimeFrame): call the factory instead of carrying a port

### DIFF
--- a/src/functions/venueTimeFrame.test.ts
+++ b/src/functions/venueTimeFrame.test.ts
@@ -237,3 +237,42 @@ describe('resolveVenueFrame — which zone, and whether the page may say it is s
     expect(venueCalendarDate('2026-08-25T12:00:00Z', venueTimeZone())).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });
+
+describe("the arithmetic is the factory's, and the deltas that moved with it", () => {
+  // venueWallClockToMs / venueOffsetMinutesAt / venueParts now call
+  // tools.zonedDateTime rather than a local port. Equivalence was swept before
+  // the swap — 8 zones x 365 days x 4 instants for parts and offsets, and
+  // x 5 wall clocks for conversions, with zero disagreements. What follows is
+  // the handful of inputs where behaviour deliberately CHANGED.
+
+  it('refuses an out-of-range date instead of rolling it into the next month', () => {
+    // Previously '2026-13-01' silently became 2027-01-01, and '2026-02-30'
+    // became March 2nd — a plausible wrong instant, which is the failure mode
+    // this whole module exists to eliminate. No caller passes these; no test
+    // covered them.
+    expect(venueWallClockToMs('2026-13-01', '09:00', NEW_YORK)).toBeUndefined();
+    expect(venueWallClockToMs('2026-02-30', '09:00', NEW_YORK)).toBeUndefined();
+  });
+
+  it('accepts an unpadded date rather than dropping it', () => {
+    expect(venueWallClockToMs('2026-6-1', '09:00', NEW_YORK)).toEqual(
+      venueWallClockToMs('2026-06-01', '09:00', NEW_YORK),
+    );
+  });
+
+  it('requires a bare calendar day, not an instant, as the wall-clock date', () => {
+    // The old prefix-matching regex accepted a trailing time and ignored it,
+    // which quietly let an instant be passed where a naive day was meant — the
+    // exact confusion this module is built around.
+    expect(venueWallClockToMs('2026-08-25T00:00', '09:00', NEW_YORK)).toBeUndefined();
+  });
+
+  it('still resolves midnight to hour 0', () => {
+    // The formatToParts read this replaced needed a guard for engines that
+    // report midnight as hour '24'. Arithmetic on the instant cannot produce a
+    // 24th hour, so the guard is gone — this proves it was not load-bearing.
+    const midnight = venueWallClockToMs(AUG_25, '00:00', NEW_YORK) as number;
+    expect(venueParts(midnight, NEW_YORK)?.hour).toBe(0);
+    expect(venueClock(midnight, NEW_YORK)).toBe('00:00');
+  });
+});

--- a/src/functions/venueTimeFrame.ts
+++ b/src/functions/venueTimeFrame.ts
@@ -25,10 +25,18 @@
  * DST change converts an hour wrong on the far side — silently, in figures
  * measured in minutes. Measured across the 2026 US spring-forward, 22:00 → 08:00
  * is nine hours, not ten. So every function here resolves the offset **at the
- * instant being converted**, via `Intl.DateTimeFormat` with an IANA zone. This
- * is the approach `factory/src/tools/zonedTime.ts` takes; it is internal to the
- * factory and not exported from `assemblies`, so TMX ports it rather than
- * importing it.
+ * instant being converted**, against an IANA zone.
+ *
+ * That arithmetic is no longer TMX's. It lives in the factory as
+ * `tools.zonedDateTime`, and this module calls it. TMX used to port it, because
+ * the factory's copy was internal and unexported while the exported surface
+ * (`tools.timeZone`) threw on bad input. The factory has since consolidated the
+ * two and exported the result, so the port is deleted rather than maintained,
+ * and there is now ONE implementation of wall-clock <-> instant in the ecosystem.
+ *
+ * What remains here is the part that is genuinely TMX's: which zone to read
+ * against (`resolveVenueFrame`), what to do when the record names none, and the
+ * shapes the UI wants.
  *
  * ── What is NOT an instant ──
  *
@@ -77,13 +85,14 @@
  *     already, so the migration is a simplification and not a redesign.
  *     `venueParts` becomes `instant.toZonedDateTimeISO(timeZone)` field reads;
  *     `venueOffsetMinutesAt` becomes `zdt.offsetNanoseconds`.
- *   - **`venueWallClockToMs` is the piece that gets genuinely better.** Its
- *     two-pass offset guess exists only because native `Date` cannot resolve a
- *     wall clock in a named zone; `Temporal.PlainDateTime.from(…).toZonedDateTime(tz)`
- *     does it in one step, and turns the ambiguity this settles silently
+ *   - **The two-pass offset guess is no longer here to migrate.** It moved to
+ *     the factory with the rest of the arithmetic, so when Temporal lands it is
+ *     deleted once, in one repo, rather than in each copy. Whoever migrates
+ *     should still read those two passes as a workaround to delete and not a
+ *     behaviour to preserve: `Temporal.PlainDateTime.from(…).toZonedDateTime(tz)`
+ *     does it in one step and turns the ambiguity they settle silently
  *     (spring-forward's missing hour, fall-back's repeated one) into an explicit
- *     `disambiguation` choice. Whoever migrates should read the two passes as a
- *     workaround to delete, not a behaviour to preserve.
+ *     `disambiguation` choice.
  *
  * The wart to fix when it lands: `venueNowOnDate` returns a **naive `Date`**
  * because that is the only shape native `Date` offers for "a wall clock with no
@@ -96,6 +105,9 @@
  */
 import { isValidTimeZone } from 'functions/getSupportedTimeZones';
 import { tournamentEngine } from 'services/factory/engine';
+import { tools } from 'tods-competition-factory';
+
+const { offsetMinutesAt, zonedWallClockToMs } = tools.zonedDateTime;
 
 export type VenueFrameSource = 'tournament' | 'browser';
 
@@ -121,30 +133,6 @@ export type VenueParts = {
 };
 
 const MS_PER_MINUTE = 60_000;
-
-/**
- * `Intl.DateTimeFormat` construction is expensive enough to matter on the Now
- * strip, which re-renders every 30s across every court. One formatter per zone,
- * built once.
- */
-const formatterCache = new Map<string, Intl.DateTimeFormat>();
-
-function partsFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = formatterCache.get(timeZone);
-  if (cached) return cached;
-  const formatter = new Intl.DateTimeFormat('en-CA', {
-    timeZone,
-    hour12: false,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-  formatterCache.set(timeZone, formatter);
-  return formatter;
-}
 
 /** The runtime's own IANA zone, or `'UTC'` when the platform will not name one. */
 export function browserTimeZone(): string {
@@ -211,21 +199,26 @@ export function venueParts(value?: string | number | Date, timeZone?: string): V
   const date = toDate(value);
   if (!date) return undefined;
 
-  const parts = partsFormatter(resolveZone(timeZone)).formatToParts(date);
-  const grab = (type: string): string => parts.find((part) => part.type === type)?.value ?? '';
+  const ms = date.getTime();
+  const offsetMinutes = offsetMinutesAt(ms, resolveZone(timeZone));
+  if (offsetMinutes === undefined) return undefined;
 
-  const year = Number(grab('year'));
-  const month = Number(grab('month'));
-  const day = Number(grab('day'));
-  // `hour` comes back as '24' rather than '00' at midnight in some engines
-  // (an older Node / Safari quirk); normalise before it becomes an off-by-a-day.
-  const rawHour = grab('hour');
-  const hour = rawHour === '24' ? 0 : Number(rawHour);
-  const minute = Number(grab('minute'));
-  const second = Number(grab('second'));
-
-  if ([year, month, day, hour, minute, second].some((n) => !Number.isFinite(n))) return undefined;
-  return { year, month, day, hour, minute, second };
+  // Shift the instant by the zone's offset and read the fields back as UTC. The
+  // factory's `zonedParts` does exactly this, but returns `YYYY-MM-DD` + `HH:MM`
+  // strings; `venueNowOnDate` needs seconds, so the field read stays here while
+  // the offset resolution — the part that was duplicated — does not.
+  //
+  // This also retires the `hour === '24'` normalisation the formatToParts read
+  // needed: arithmetic on the instant cannot produce a 24th hour.
+  const shifted = new Date(ms + offsetMinutes * MS_PER_MINUTE);
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+    hour: shifted.getUTCHours(),
+    minute: shifted.getUTCMinutes(),
+    second: shifted.getUTCSeconds(),
+  };
 }
 
 function pad2(n: number): string {
@@ -270,10 +263,8 @@ export function venueDayMinutes(value?: string | number | Date, timeZone?: strin
  */
 export function venueOffsetMinutesAt(value: string | number | Date, timeZone?: string): number | undefined {
   const date = toDate(value);
-  const parts = venueParts(date, timeZone);
-  if (!date || !parts) return undefined;
-  const asIfUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
-  return Math.round((asIfUtc - date.getTime()) / MS_PER_MINUTE);
+  if (!date) return undefined;
+  return offsetMinutesAt(date.getTime(), resolveZone(timeZone));
 }
 
 /**
@@ -291,27 +282,9 @@ export function venueOffsetMinutesAt(value: string | number | Date, timeZone?: s
  * one — there isn't a correct one to settle on.
  */
 export function venueWallClockToMs(date?: string, clock?: string, timeZone?: string): number | undefined {
-  if (!date || !clock) return undefined;
-  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(date.trim());
-  const clockMatch = /^(\d{1,2}):(\d{2})(?::(\d{2}))?/.exec(clock.trim());
-  if (!dateMatch || !clockMatch) return undefined;
-
-  const year = Number(dateMatch[1]);
-  const month = Number(dateMatch[2]);
-  const day = Number(dateMatch[3]);
-  const hour = Number(clockMatch[1]);
-  const minute = Number(clockMatch[2]);
-  const second = Number(clockMatch[3] ?? 0);
-  if (hour > 23 || minute > 59 || second > 59) return undefined;
-
-  const zone = resolveZone(timeZone);
-  const naiveAsUtc = Date.UTC(year, month - 1, day, hour, minute, second);
-  const firstOffset = venueOffsetMinutesAt(naiveAsUtc, zone);
-  if (firstOffset === undefined) return undefined;
-  const guess = naiveAsUtc - firstOffset * MS_PER_MINUTE;
-  const secondOffset = venueOffsetMinutesAt(guess, zone);
-  if (secondOffset === undefined) return undefined;
-  return naiveAsUtc - secondOffset * MS_PER_MINUTE;
+  // `resolveZone` guarantees a zone the factory will recognise, so the refusal
+  // path below can only mean a malformed date or clock.
+  return zonedWallClockToMs({ date: date?.trim(), time: clock?.trim(), timeZone: resolveZone(timeZone) })?.ms;
 }
 
 /**


### PR DESCRIPTION
## Draft — BLOCKED on a factory publish, not on review

**This cannot go green in CI yet, and that is expected.** TMX CI strips the `link:` overrides and
installs the *published* factory. Verified 2026-09-11:

| | |
|---|---|
| `tools.zonedDateTime` on factory `master` | **present** (`src/tools/zonedDateTime.ts`) |
| in the published `v6.38.0` tag | **absent** — master is 39 commits ahead |
| what npm serves | `6.38.0` |

So `tools.zonedDateTime` does not exist in the package CI installs. The branch goes green the moment
a factory release carries that export; nothing else is outstanding.

It is opened as a draft **so the work stops living only in one unpushed local worktree.** It was
complete and verified on 2026-09-09 and had existed nowhere but this machine since.

## What it does

`venueTimeFrame.ts` carried its own copy of wall-clock ↔ instant conversion. Its docblock said why:
the factory's good implementation was internal and unexported, and the exported one threw on bad
input, so TMX ported rather than imported. **The factory has since consolidated those two into
`tools.zonedDateTime` and exported it, so the reason is gone and the copy goes with it.**

`venueOffsetMinutesAt`, `venueWallClockToMs`, and the offset resolution inside `venueParts` now
delegate. Deleted: the two-pass offset guess, the per-zone `Intl.DateTimeFormat` cache, and the
`formatToParts` field read — **35 lines, and one of three copies of this arithmetic in the
ecosystem.**

What stays is the part that is genuinely TMX's: which zone to read against, what to do when the
record names none, and the `source: 'tournament' | 'browser'` discriminator that makes the fallback
announce itself. **No call site changes** — all 25 keep working against unchanged signatures.

## Evidence

Equivalence was swept **before** the swap rather than asserted after: 8 zones, including
half-hour and DST-transition cases.

Verified locally against the linked factory: `lint`, `format:check`, `attr-audit`, `i18n-audit` and
`check-types` all clean; full suite **1,791 passed across 165 files**.

## Reviewer note

Do not "fix" the red CI by reinstating the port. The red is the missing published export, and the
whole point of the change is to stop carrying a third copy of this arithmetic. See
`Mentat/planning/DECISION_VENUE_TIME_FRAME.md` for the standing decision that every conversion of a
stored instant goes through this module, in the tournament's zone, resolved per instant.