### PR TITLE
fix(schedule): do not project today's clock forward onto a future schedule day

### DIFF
--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.test.ts
@@ -3,6 +3,7 @@ import {
   describeRest,
   instantLocalDate,
   normalizeTimes,
+  nowDayMinutes,
   restDateFor,
   toDayMinutesFromClock,
   toDayMinutesFromInstant,
@@ -239,6 +240,94 @@ describe('end to end: a real score entry against a past-dated schedule day', () 
   it('projects a readyAt from the anchor it actually used', () => {
     // 10:38 + 60 minutes of recovery.
     expect(analyze().rows.find((row) => row.participantId === 'p-alice')?.readyAt).toBe('11:38');
+  });
+});
+
+/**
+ * The future-day half of the projection rule. Reported from production on BOBOCA
+ * `a4e439fa-…`: the schedule page for the next day, opened the evening before,
+ * badged a 07:45 singles card "on court" in a tournament that had no courts and
+ * no results — because the same player's 15:00 doubles read as already under way
+ * against a clock projected from the operator's evening.
+ *
+ * Written against the runner's own zone rather than a named one, like the rest of
+ * this file: the assertion is about the DAY offset, which no zone changes.
+ */
+describe('nowDayMinutes — the projection runs backwards in time, never forwards', () => {
+  /** 22:51 local on 2026-09-11 — the evening the production report came from. */
+  const EVENING = new Date('2026-09-11T22:51:00');
+  const EVENING_MINUTES = 22 * 60 + 51;
+
+  it('projects onto today unchanged', () => {
+    expect(nowDayMinutes(undefined, '2026-09-11', EVENING)).toBe(EVENING_MINUTES);
+  });
+
+  it('projects onto a past day unchanged, which is what a past-dated tournament needs', () => {
+    expect(nowDayMinutes(undefined, '2026-09-08', EVENING)).toBe(EVENING_MINUTES);
+  });
+
+  it('places "now" before midnight of a future day, by a whole day per day ahead', () => {
+    expect(nowDayMinutes(undefined, '2026-09-12', EVENING)).toBe(EVENING_MINUTES - 1440);
+    expect(nowDayMinutes(undefined, '2026-09-14', EVENING)).toBe(EVENING_MINUTES - 3 * 1440);
+  });
+
+  it('falls back to the bare time of day when no day is named or the day is unparseable', () => {
+    expect(nowDayMinutes(undefined, null, EVENING)).toBe(EVENING_MINUTES);
+    expect(nowDayMinutes(undefined, UNPARSEABLE, EVENING)).toBe(EVENING_MINUTES);
+  });
+});
+
+/**
+ * The defect end to end: two matchUps on tomorrow's card sharing one player, no
+ * scores, no courts. Before the fix the earlier one reported its shared player
+ * `onCourt`, because the later one's scheduledTime sat behind a projected clock.
+ */
+describe('a future schedule day: nobody is on court yet', () => {
+  const TOMORROW = '2026-09-12';
+  const EVENING = new Date('2026-09-11T22:51:00');
+  const TIMING = { averageMinutes: 90, recoveryMinutes: 60 };
+
+  const singles: ReadinessMatchUp = {
+    matchUpId: 'm-singles',
+    matchUpType: 'SINGLES',
+    matchUpStatus: 'TO_BE_PLAYED',
+    sides: [{ participantId: 'p-nassar', participantName: 'Caden-Chady Nassar' }, { participantId: 'p-soares' }],
+    schedule: { scheduledDate: TOMORROW, scheduledTime: '07:45' },
+  };
+  const doubles: ReadinessMatchUp = {
+    matchUpId: 'm-doubles',
+    matchUpType: 'DOUBLES',
+    matchUpStatus: 'TO_BE_PLAYED',
+    sides: [
+      { participant: { participantId: 'pair-a', individualParticipantIds: ['p-livson', 'p-nassar'] } },
+      { participant: { participantId: 'pair-b', individualParticipantIds: ['p-x', 'p-y'] } },
+    ],
+    schedule: { scheduledDate: TOMORROW, scheduledTime: '15:00' },
+  };
+
+  function analyze(asOfMinutes: number) {
+    const result = analyzeParticipantRest({
+      matchUpId: 'm-singles',
+      matchUps: [singles, doubles],
+      scheduledDate: TOMORROW,
+      asOfMinutes,
+      timingFor: () => TIMING,
+      timesFor: (matchUp) => normalizeTimes(matchUp, TOMORROW),
+    });
+    if (!result.evaluated) throw new Error('expected evaluation');
+    return result;
+  }
+
+  it('reports no prior match for every player', () => {
+    const rows = analyze(nowDayMinutes(undefined, TOMORROW, EVENING)).rows;
+    expect(rows.every((row) => row.status === 'none')).toBe(true);
+  });
+
+  it('would badge the shared player "on court" under the projected evening clock', () => {
+    // The defect, pinned: the same data with today's time-of-day projected onto
+    // tomorrow puts the 15:00 doubles behind the clock and the player on court.
+    const rows = analyze(22 * 60 + 51).rows;
+    expect(rows.find((row) => row.participantId === 'p-nassar')?.status).toBe('onCourt');
   });
 });
 

--- a/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/inspectorRest.ts
@@ -27,10 +27,11 @@
  * ── The frame every value ends up in: the VIEWED DAY'S wall clock ──
  *
  * `nowDayMinutes()` projects today's time-of-day onto whichever day is on
- * screen, and the three wall-clock fields are already read against that day. So
- * the instants have to land in the same frame, and `toDayMinutesFromInstant`
- * puts them there: local time-of-day, plus a full day for a genuine midnight
- * crossing, and NOT the raw elapsed interval from the viewed day's midnight.
+ * screen — forward onto a past day only, never back onto a future one — and the
+ * three wall-clock fields are already read against that day. So the instants
+ * have to land in the same frame, and `toDayMinutesFromInstant` puts them there:
+ * local time-of-day, plus a full day for a genuine midnight crossing, and NOT
+ * the raw elapsed interval from the viewed day's midnight.
  *
  * The distinction is invisible while the viewed day is the operator's own
  * calendar today, and decisive the moment it isn't — which is not an exotic
@@ -50,9 +51,9 @@
  * to be the browser's, which read every figure on this page off by the offset
  * between the operator's laptop and the venue, silently and plausibly.
  *
- * The frame is captured **once** per evaluator pass, alongside `asOfMinutes` and
- * for the same reason: every badge in a tick must agree about what time it is,
- * and re-resolving per row would let them disagree.
+ * The frame is captured **once** per evaluator pass, alongside the instant that
+ * "now" is read from, and for the same reason: every badge in a tick must agree
+ * about what time it is, and re-resolving per row would let them disagree.
  *
  * The pure functions take the zone as a trailing argument rather than reaching
  * for it, so they stay testable without an engine — and so this file's one
@@ -172,13 +173,40 @@ export function normalizeTimes(
 }
 
 /**
- * "Now" as minutes from midnight of the viewed day. When the operator is looking
- * at another date, today's time-of-day is projected onto it — the same thing
- * `venueNowOnDate()` does for the Now strip, so the two agree — both in the
- * venue's zone.
+ * "Now" as minutes from midnight of the viewed day, in the venue's zone.
+ *
+ * For today and for any day already past, today's time-of-day is projected onto
+ * the viewed day — the same thing `venueNowOnDate()` does for the Now strip, so
+ * the two agree. That projection is what keeps the feature working for an
+ * operator running a past-dated tournament in real time, which is the permanent
+ * state of anyone whose tournament dates have gone by (see the header note).
+ *
+ * A **future** day is the one direction the projection must not be applied to.
+ * Nothing on tomorrow has happened yet, and projecting this evening's clock onto
+ * it asserts the opposite: every matchUp scheduled before the current
+ * time-of-day reads as already under way, so `analyzeParticipantRest` reports a
+ * player entered in two of tomorrow's matches as *on court now* — in a
+ * tournament with no courts and no results. Reported from production on
+ * BOBOCA `a4e439fa-…`, whose 07:45 singles card was badged "on court" the
+ * evening before play, because the same player's 15:00 doubles read as started.
+ *
+ * So a day ahead of today is offset by the whole days between them, putting
+ * "now" *before* that day's midnight. Every anchor on it is then in the future,
+ * which is exactly what it is; `collectPriorMatchUps` admits nothing, and the
+ * rest rows report `none` rather than a fiction. The asymmetry is the point: a
+ * past day is one the operator may genuinely be working through, a future day is
+ * one nobody can have played on yet.
+ *
+ * `now` is a parameter so a whole evaluator pass can share one reading of the
+ * clock — and so this stays testable without mocking the global clock.
  */
-export function nowDayMinutes(timeZone?: string): number {
-  return venueDayMinutes(new Date(), timeZone) ?? 0;
+export function nowDayMinutes(timeZone?: string, viewedDate?: string | null, now: Date = new Date()): number {
+  const timeOfDay = venueDayMinutes(now, timeZone) ?? 0;
+  if (!viewedDate) return timeOfDay;
+  const today = venueCalendarDate(now, timeZone);
+  const daysAhead = today ? dayDelta(today, viewedDate) : undefined;
+  if (daysAhead === undefined || daysAhead <= 0) return timeOfDay;
+  return timeOfDay - daysAhead * MINUTES_PER_DAY;
 }
 
 /** Tournament daily limits, or undefined when no scheduling policy is attached — never a substituted default. */
@@ -222,9 +250,12 @@ export function restDateFor(matchUp: ReadinessMatchUp | undefined, viewedDate: s
  * ticker re-reads every visible card on a timer — that is N engine passes every
  * 30 seconds for a screen that has not changed.
  *
- * `asOfMinutes` is captured once too, so every badge in a tick agrees about what
- * time it is. Reading the clock per badge would let a pass that straddles a
- * minute boundary render two cards a minute apart.
+ * The clock is read once too, so every badge in a tick agrees about what time it
+ * is. Reading it per badge would let a pass that straddles a minute boundary
+ * render two cards a minute apart. The *minutes* figure is still derived per
+ * matchUp, because it is measured from the midnight of whichever day that
+ * matchUp is being rested against, and `restDateFor` may name a different one
+ * for each.
  */
 export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | null) => RestResult {
   const { matchUps } = getCachedAllMatchUps();
@@ -234,7 +265,11 @@ export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | nu
   // One frame for the whole pass — see the header note on why this is captured
   // here rather than read per row.
   const { timeZone } = resolveVenueFrame();
-  const asOfMinutes = nowDayMinutes(timeZone);
+  // One reading of the clock for the whole pass — see the note above. The
+  // minutes figure is derived per matchUp because it is relative to the day that
+  // matchUp is being measured on, and `restDateFor` can name a different day for
+  // each; the instant it is derived from does not move.
+  const now = new Date();
 
   return (matchUpId, viewedDate) => {
     const restDate = restDateFor(
@@ -245,7 +280,7 @@ export function makeRestEvaluator(): (matchUpId: string, viewedDate: string | nu
       matchUpId,
       matchUps: hydrated,
       scheduledDate: restDate ?? '',
-      asOfMinutes,
+      asOfMinutes: nowDayMinutes(timeZone, restDate, now),
       timesFor: (matchUp) => normalizeTimes(matchUp, restDate, timeZone),
       dailyLimits,
       timingFor,


### PR DESCRIPTION
## The report

BOBOCA (`a4e439fa-…`), schedule page for **2026-09-12**, opened the evening of 09-11: a 07:45 singles card carried an **"on court"** chip — in a tournament with **no courts and no results at all**.

## The cause

The chip is the rest badge, and it has nothing to do with courts: `analyzeParticipantRest` reports a player `onCourt` when another matchUp of theirs on the same day reads as already under way.

`nowDayMinutes()` projected **today's time-of-day onto whichever day is on screen**. That is deliberate and load-bearing for a *past* day — the schedule opens on a tournament's last date once its dates have gone by, so anyone running a past-dated event in real time lives in that case permanently. Applied to a **future** day it invents a clock: at 22:51 the evaluator believed it was 22:51 on the 12th, so `isUnderWay()` read every matchUp scheduled before that as started.

The reported player is entered in both the 07:45 singles and the 15:00 doubles, so his earlier card reported him still on court in the later one. Every player with two matchUps that day was badged the same way, and "Start all" would have raised a spurious *"still on court in an earlier match"* confirm (it warns, never blocks).

Nothing in the tournament record is wrong.

## The fix

A day ahead of today is offset by the whole days between them, putting "now" *before* that day's midnight. Every anchor on it is then in the future — which is what it is — so `collectPriorMatchUps` admits nothing, the rows report `none`, and `shouldRender` drops the badge entirely. Today and any past day are unchanged; the asymmetry is the point.

The evaluator captures one instant per pass as before, so every badge in a tick still agrees about what time it is. The *minutes* figure moves to per-matchUp, because it is measured from the midnight of whichever day that matchUp is rested against and `restDateFor` may name a different one for each card.

## Not touched

`src/functions/venueTimeFrame.ts` — claimed by #1436(TMX). `venueNowOnDate()` there has the same forward projection, and `gridView` uses it to mark court blocks active; that follow-up lands on top of #1436 rather than conflicting with it.

## Verification

- `pnpm lint`, `pnpm check-types`, `pnpm format:check` clean; `attr-audit` / `i18n-audit` exit 0
- `TZ=UTC vitest run` — **1793 passed**
- New tests: the day-offset rule in both directions, the end-to-end future-day case, and the defect itself pinned against the projected clock