### PR TITLE
fix(schedule): a date the venue has not reached has no "now" on it

### DIFF
--- a/src/functions/venueTimeFrame.test.ts
+++ b/src/functions/venueTimeFrame.test.ts
@@ -122,13 +122,21 @@ describe('venueWallClockToMs — a venue wall clock back to an absolute instant'
 
 describe('venueNowOnDate — "now" projected onto a viewed date, as a NAIVE Date', () => {
   /**
+   * A day that is already past at the venue, so the projection applies. Fixed
+   * rather than computed: a relative date would drift into "today" or "future"
+   * depending on when the suite runs, and those are different rules below.
+   */
+  const PAST_DAY = '2026-08-20';
+
+  /**
    * Naivety is load-bearing: this gets compared against court-block bounds,
    * which are zone-less `YYYY-MM-DDTHH:MM:SS` strings parsed the same way. The
    * browser's zone cancels on both sides; only the time-of-day has to be right.
    */
   it('carries the viewed date and the VENUE time-of-day', () => {
-    const projected = venueNowOnDate('2026-08-20', KOLKATA);
+    const projected = venueNowOnDate(PAST_DAY, KOLKATA) as Date;
     const nowParts = venueParts(new Date(), KOLKATA);
+    expect(projected).toBeInstanceOf(Date);
     expect(projected.getFullYear()).toBe(2026);
     expect(projected.getMonth()).toBe(7);
     expect(projected.getDate()).toBe(20);
@@ -137,11 +145,54 @@ describe('venueNowOnDate — "now" projected onto a viewed date, as a NAIVE Date
   });
 
   it('compares correctly against a naive court-block bound in the same frame', () => {
-    const projected = venueNowOnDate('2026-08-20', KOLKATA);
+    const projected = venueNowOnDate(PAST_DAY, KOLKATA) as Date;
     const blockStart = new Date('2026-08-20T00:00:00');
     const blockEnd = new Date('2026-08-21T00:00:00');
     expect(projected >= blockStart).toBe(true);
     expect(projected < blockEnd).toBe(true);
+  });
+});
+
+/**
+ * The projection runs backwards in time only. Onto a future day it would not
+ * describe a clock but invent one, marking every block painted before the
+ * current time-of-day as in effect on a day nobody has reached — which is the
+ * court-block twin of the rest badge that read "on court" in a tournament with
+ * no courts.
+ *
+ * Dated off the venue's own today rather than a literal, because "future" is
+ * the one property a fixed date cannot keep.
+ */
+describe('venueNowOnDate — a day the venue has not reached has no "now"', () => {
+  /** `YYYY-MM-DD`, `offset` days from the venue's today. Parsed as UTC, so no DST can shorten a day. */
+  function venueDayOffsetBy(offset: number, timeZone: string): string {
+    const today = venueCalendarDate(new Date(), timeZone);
+    const shifted = new Date(Date.parse(`${today}T00:00:00Z`) + offset * 86_400_000);
+    return shifted.toISOString().slice(0, 10);
+  }
+
+  it('returns undefined for tomorrow, and for any day beyond it', () => {
+    expect(venueNowOnDate(venueDayOffsetBy(1, KOLKATA), KOLKATA)).toBeUndefined();
+    expect(venueNowOnDate(venueDayOffsetBy(30, KOLKATA), KOLKATA)).toBeUndefined();
+  });
+
+  it('still answers for today and for yesterday', () => {
+    expect(venueNowOnDate(venueDayOffsetBy(0, KOLKATA), KOLKATA)).toBeInstanceOf(Date);
+    expect(venueNowOnDate(venueDayOffsetBy(-1, KOLKATA), KOLKATA)).toBeInstanceOf(Date);
+  });
+
+  /**
+   * The boundary is the VENUE's day, not the operator's. Under `TZ=UTC` the
+   * runner and Kolkata disagree about the date for five and a half hours every
+   * night; asking about the venue's own today must be answerable throughout.
+   */
+  it('reads the boundary against the venue day rather than the runner day', () => {
+    expect(venueNowOnDate(venueDayOffsetBy(0, KOLKATA), KOLKATA)).toBeInstanceOf(Date);
+    expect(venueNowOnDate(venueDayOffsetBy(0, LOS_ANGELES), LOS_ANGELES)).toBeInstanceOf(Date);
+  });
+
+  it('takes the same exit for a date it cannot read', () => {
+    expect(venueNowOnDate('not-a-date', KOLKATA)).toBeUndefined();
   });
 });
 

--- a/src/functions/venueTimeFrame.ts
+++ b/src/functions/venueTimeFrame.ts
@@ -317,6 +317,8 @@ export function venueWallClockToMs(date?: string, clock?: string, timeZone?: str
 /**
  * "Now", projected onto the venue wall clock of `stripDate`, as a **naive**
  * Date — i.e. one whose raw `getHours()` accessors read back the venue clock.
+ * `undefined` when `stripDate` is still ahead of the venue's today, because
+ * there is no such instant.
  *
  * That naivety is deliberate and load-bearing. The values this gets compared
  * against (court block `start`/`end`) are themselves naive `YYYY-MM-DDTHH:MM:SS`
@@ -329,9 +331,29 @@ export function venueWallClockToMs(date?: string, clock?: string, timeZone?: str
  * exotic case: the schedule opens on a tournament's last date once its dates are
  * past, so anyone running a past-dated tournament in real time is in it
  * permanently.
+ *
+ * **That projection only runs backwards.** Onto a future day it does not
+ * describe a clock, it invents one: at 22:51 the evening before, every court
+ * block painted on tomorrow before 22:51 reads as in effect *right now*, and a
+ * match dropped onto tomorrow's Now strip is warned about a block that has not
+ * happened. The same assumption, one module over, badged a player "on court" in
+ * a tournament with no courts — see `nowDayMinutes()` in
+ * `pages/tournament/tabs/scheduleViews/inspectorRest.ts`, which takes the
+ * matching position for rest.
+ *
+ * So a future date returns `undefined` rather than a fabricated Date. Callers
+ * must decide what "there is no now on that day" means for them; they cannot
+ * accidentally compare against a time nobody has reached yet. A malformed
+ * `stripDate` takes the same exit — it sorts after any real date, and an
+ * Invalid Date was never a useful answer either.
  */
-export function venueNowOnDate(stripDate: string, timeZone?: string): Date {
+export function venueNowOnDate(stripDate: string, timeZone?: string): Date | undefined {
   const parts = venueParts(new Date(), timeZone);
   if (!parts) return new Date(`${stripDate}T00:00:00`);
+  // `YYYY-MM-DD` sorts lexicographically, so no parsing is needed to order two
+  // of them — and the comparison is made on the venue's today, never the
+  // browser's, which is the whole point of this module.
+  const todayAtVenue = `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
+  if (stripDate.slice(0, 10) > todayAtVenue) return undefined;
   return new Date(`${stripDate}T${pad2(parts.hour)}:${pad2(parts.minute)}:${pad2(parts.second)}`);
 }

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -2470,6 +2470,10 @@ function buildCurrentCourtBlocks(date: string): Record<string, ActiveStripCourtB
   // date (e.g. tournament startDate) still surface as active when the
   // operator is working at the matching time-of-day.
   const now = venueNowOnDate(date);
+  // A date the venue has not reached has no "now" on it, so nothing painted on
+  // it is in effect. Without this the evening before an event marks every block
+  // earlier than the current time-of-day as active on tomorrow's strip.
+  if (!now) return {};
   const courtBlocks: Record<string, ActiveStripCourtBlock> = {};
   const activeRegsByCourtId = getActiveRegistrationNamesByCourtId({
     tournamentRecord,
@@ -3199,6 +3203,12 @@ function checkBlockInterruption(matchUp: any, courtId: string): BlockInterruptio
   if (!blocks.length) return undefined;
 
   const now = venueNowOnDate(currentDate);
+  // The whole check is anchored on "now" — an active block overlapping it, or
+  // the next one arriving before the matchUp could finish. A future date has no
+  // now to anchor on, so there is no conflict to report: take the same exit as
+  // missing block data, where the caller's documented behaviour is that the
+  // original drop stands.
+  if (!now) return undefined;
 
   // First: is a non-SCHEDULED block currently active on this court?
   for (const block of blocks) {


### PR DESCRIPTION
The court-block twin of #1437(TMX) — same assumption, one module over. That PR fixed the rest badge that reported **"on court"** in a tournament with no courts; this one fixes the surfaces that ask `venueNowOnDate()` the same question.

## The cause

`venueNowOnDate()` projected today's time-of-day onto whichever date was asked about. **Backwards** that is deliberate and load-bearing: the schedule opens on a tournament's last date once its dates have gone by, so anyone running a past-dated event in real time lives in that case permanently. **Forwards** it does not describe a clock, it invents one — at 22:51 the evening before an event:

- every court block painted on tomorrow before 22:51 reads as in effect *right now* on tomorrow's strip (`activeStripCourtBlocks`);
- a match dropped onto tomorrow's Now strip is warned about a block that has not happened yet, or measured against one it has already passed (`checkBlockInterruption`).

## The fix

A future date returns `undefined` rather than a fabricated Date, so no caller can accidentally compare against a time nobody has reached. The type change makes the two call sites decide explicitly — and `tsc` confirms there are only two:

- `activeStripCourtBlocks` → no block is active on a day the venue has not reached.
- `checkBlockInterruption` → takes the same exit it already takes for missing block data, where the caller's documented behaviour is that the original drop stands.

A malformed date takes the same exit: it sorts after any real date, and an Invalid Date was never a useful answer either. The boundary is read against the **venue's** today, never the browser's, which is the whole point of the module it lives in.

## Relationship to #1436(TMX)

`venueNowOnDate` is the one function in `venueTimeFrame.ts` that #1436 does not touch (verified against its head: the diff is header docs, `venueParts`, `venueOffsetMinutesAt`, `venueWallClockToMs`). These two land in either order without conflicting.

## Verification

- `pnpm lint`, `pnpm check-types`, `pnpm format:check` clean; `attr-audit` / `i18n-audit` exit 0
- `TZ=UTC vitest run` — **1791 passed**
- e2e, `TEST_PROD=1`, the journeys that touch the strip and the venue frame (39, 59, 77, 86, 108) — **11 passed**
- New tests date themselves off the venue's own today, since "future" is the one property a fixed literal cannot keep, and assert the boundary is the venue day rather than the runner day