### PR TITLE
fix(dates): a date range was a day early for every operator east of UTC

### DIFF
--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -11,6 +11,7 @@
 import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
 import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { competitionEngine } from 'services/factory/engine';
+import { plainDateRange } from 'functions/plainDateRange';
 import { context } from 'services/context';
 import { t } from 'i18n';
 
@@ -31,18 +32,6 @@ function formatDateLabel(iso: string): string {
   const d = new Date(`${iso}T00:00:00`);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
-}
-
-function dateRange(start?: string, end?: string): string[] {
-  if (!start || !end) return [];
-  const dates: string[] = [];
-  const current = new Date(`${start}T00:00:00`);
-  const last = new Date(`${end}T00:00:00`);
-  while (current <= last) {
-    dates.push(current.toISOString().slice(0, 10));
-    current.setDate(current.getDate() + 1);
-  }
-  return dates;
 }
 
 export function getMatchUpDateFilter(table: any): {
@@ -91,7 +80,7 @@ export function getMatchUpDateFilter(table: any): {
   const { startDate, endDate } = competitionEngine.getCompetitionDateRange() ?? {};
   const activeDates: string[] = tournamentInfo?.activeDates?.length
     ? tournamentInfo.activeDates
-    : dateRange(startDate, endDate);
+    : plainDateRange(startDate, endDate);
   const sortedDates = [...activeDates].sort((a, b) => a.localeCompare(b));
 
   const allLabel = t('pages.matchUps.allDates');

--- a/src/functions/plainDateRange.test.ts
+++ b/src/functions/plainDateRange.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ⚠️ The assertions that matter here are the ones run under a zone EAST of UTC.
+ *
+ * `pnpm test` pins `TZ=UTC`, and every developer machine in this ecosystem sits
+ * at UTC or west of it. The defect this function exists to end — local-midnight
+ * in, UTC-day out — is *invisible* in all of those: at UTC-4 a local midnight
+ * round-trips through UTC to the same calendar day. So a suite that only ever
+ * runs west of Greenwich is structurally incapable of expressing it, which is
+ * exactly how it survived in two files for as long as it did.
+ *
+ * Rather than ask CI for a second TZ leg, the zone is applied per-assertion:
+ * `withTimeZone` sets `process.env.TZ`, which V8 honours for `Date` from the
+ * next construction onward. The zone therefore travels with the test rather
+ * than with the runner, and the east-of-UTC case cannot be lost by someone
+ * reconfiguring a workflow.
+ */
+import { plainDateRange } from './plainDateRange';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+/** Run `fn` with the process clock reading `timeZone`. */
+function withTimeZone<T>(timeZone: string, fn: () => T): T {
+  process.env.TZ = timeZone;
+  return fn();
+}
+
+const FIRST_DAY = '2026-09-12';
+const LAST_DAY = '2026-09-15';
+const SEPT = [FIRST_DAY, '2026-09-13', '2026-09-14', LAST_DAY];
+const AUCKLAND = 'Pacific/Auckland';
+const NEW_YORK = 'America/New_York';
+
+describe('plainDateRange — the same days in every zone', () => {
+  /**
+   * Auckland (+12/+13) and Berlin (+1/+2) are the cases the old walk got wrong,
+   * both by exactly one day: it offered the day BEFORE the tournament started
+   * and never offered its last day. UTC and New York are the cases that always
+   * passed, and they are here to prove the fix did not simply move the error.
+   */
+  it.each(['UTC', NEW_YORK, 'Europe/Berlin', AUCKLAND])('walks 2026-09-12..15 identically under %s', (timeZone) => {
+    expect(withTimeZone(timeZone, () => plainDateRange(FIRST_DAY, LAST_DAY))).toEqual(SEPT);
+  });
+
+  it('starts on startDate and ends on endDate, east of UTC', () => {
+    // Stated separately from the equality above because these two are the
+    // operator-visible symptoms: a date chip for a day before play, and a
+    // missing chip for the final day.
+    const dates = withTimeZone(AUCKLAND, () => plainDateRange(FIRST_DAY, LAST_DAY));
+    expect(dates.at(0)).toBe(FIRST_DAY);
+    expect(dates.at(-1)).toBe(LAST_DAY);
+  });
+
+  it('crosses a spring-forward transition without skipping or duplicating a day', () => {
+    // US DST begins 2026-03-08. A walk that added 24h of wall clock would land
+    // twice on the same day here; UTC days are always 24 hours.
+    const dates = withTimeZone(NEW_YORK, () => plainDateRange('2026-03-07', '2026-03-10'));
+    expect(dates).toEqual(['2026-03-07', '2026-03-08', '2026-03-09', '2026-03-10']);
+  });
+
+  it('crosses a fall-back transition the same way', () => {
+    const dates = withTimeZone(NEW_YORK, () => plainDateRange('2026-10-31', '2026-11-02'));
+    expect(dates).toEqual(['2026-10-31', '2026-11-01', '2026-11-02']);
+  });
+
+  it('crosses a month and a year boundary', () => {
+    expect(plainDateRange('2026-12-30', '2027-01-02')).toEqual([
+      '2026-12-30',
+      '2026-12-31',
+      '2027-01-01',
+      '2027-01-02',
+    ]);
+  });
+
+  it('includes the single day of a one-day range', () => {
+    expect(plainDateRange(FIRST_DAY, FIRST_DAY)).toEqual([FIRST_DAY]);
+  });
+});
+
+describe('plainDateRange — a range that does not exist is empty, not guessed', () => {
+  it('returns nothing when a bound is missing', () => {
+    expect(plainDateRange(undefined, LAST_DAY)).toEqual([]);
+    expect(plainDateRange(FIRST_DAY, undefined)).toEqual([]);
+    expect(plainDateRange()).toEqual([]);
+  });
+
+  it('returns nothing when a bound is not a calendar date', () => {
+    // An instant is the specific wrong input worth naming: it is what a caller
+    // reaches for when it has a stamp rather than a day, and the prefix-match
+    // that would accept it is how a zone-less day and an instant get confused.
+    expect(plainDateRange('2026-09-12T00:00:00Z', LAST_DAY)).toEqual([]);
+    expect(plainDateRange('not-a-date', LAST_DAY)).toEqual([]);
+    expect(plainDateRange('2026-9-12', LAST_DAY)).toEqual([]);
+  });
+
+  it('returns nothing when the end precedes the start', () => {
+    expect(plainDateRange(LAST_DAY, FIRST_DAY)).toEqual([]);
+  });
+});

--- a/src/functions/plainDateRange.ts
+++ b/src/functions/plainDateRange.ts
@@ -1,0 +1,86 @@
+/**
+ * Every calendar day from `startDate` to `endDate`, inclusive, as `YYYY-MM-DD`.
+ *
+ * A **plain date** in the Temporal sense — a day on a calendar, with no zone
+ * and no instant behind it. Named for that concept deliberately: the ecosystem
+ * is standardising the vocabulary ahead of the factory's Temporal migration, so
+ * this becomes a `Temporal.PlainDate` walk rather than a rename.
+ *
+ * ── Why this is not three lines inline ──
+ *
+ * It was, in three places, and two of them were wrong the same way:
+ *
+ * ```ts
+ * const current = new Date(`${start}T00:00:00`);   // LOCAL midnight
+ * dates.push(current.toISOString().slice(0, 10));  // the UTC day
+ * ```
+ *
+ * A zone-less datetime string parses as local midnight, and `toISOString()`
+ * then reports the day in UTC. **East of UTC those are different days.**
+ * Measured across four zones for `2026-09-12`..`2026-09-15`:
+ *
+ * | TZ | emitted |
+ * |---|---|
+ * | `UTC` | 09-12 09-13 09-14 09-15 |
+ * | `America/New_York` | 09-12 09-13 09-14 09-15 |
+ * | `Europe/Berlin` | **09-11** 09-12 09-13 **09-14** |
+ * | `Pacific/Auckland` | **09-11** 09-12 09-13 **09-14** |
+ *
+ * So for an operator east of UTC the schedule's date selector offered a day
+ * before the tournament started and never offered its last day. Every developer
+ * machine and CI runner in this ecosystem sits at UTC or west of it, which is
+ * why a green board has never once expressed it — see the calendar-day-intents
+ * entry in `Mentat/TASKS.md`.
+ *
+ * The arithmetic below is the version `maybeNudgeActiveDates` already had
+ * right: components in, `Date.UTC` throughout, components out. Nothing here
+ * touches a wall clock, so nothing here can be moved by a zone or by a DST
+ * transition — a UTC day is always exactly 24 hours, which is the property the
+ * `setDate()` walk was relying on and did not have.
+ *
+ * NOT a substitute for `venueTimeFrame`. That module answers "what day is it at
+ * the venue", which needs a zone and an instant. This one walks days that are
+ * already days.
+ */
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MS_PER_DAY = 86_400_000;
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * The UTC components of an instant this module built at UTC midnight.
+ *
+ * Written out rather than `toISOString().slice(0, 10)` — which would be
+ * *correct* here, since the instant is a UTC midnight by construction, and
+ * would still be the one expression the ecosystem is trying to stop reading
+ * past. Saying "UTC components" in the code costs three lines and leaves
+ * nothing for the next reader, or the planned lint rule, to adjudicate.
+ */
+function toPlainDate(date: Date): string {
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`;
+}
+
+/**
+ * Inclusive of both ends. Empty when either bound is missing or unreadable, or
+ * when `endDate` precedes `startDate` — an empty range is the honest answer to
+ * a range that does not exist, and every caller here already renders "no dates"
+ * for it.
+ */
+export function plainDateRange(startDate?: string, endDate?: string): string[] {
+  const start = ISO_DATE.exec(startDate?.trim() ?? '');
+  const end = ISO_DATE.exec(endDate?.trim() ?? '');
+  if (!start || !end) return [];
+
+  const cursor = Date.UTC(Number(start[1]), Number(start[2]) - 1, Number(start[3]));
+  const last = Date.UTC(Number(end[1]), Number(end[2]) - 1, Number(end[3]));
+  if (Number.isNaN(cursor) || Number.isNaN(last) || last < cursor) return [];
+
+  const dates: string[] = [];
+  for (let day = cursor; day <= last; day += MS_PER_DAY) {
+    dates.push(toPlainDate(new Date(day)));
+  }
+  return dates;
+}

--- a/src/pages/tournament/maybeNudgeActiveDates.ts
+++ b/src/pages/tournament/maybeNudgeActiveDates.ts
@@ -2,6 +2,7 @@ import { openEditDatesModal } from './tabs/overviewTab/editDatesModal';
 import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
+import { plainDateRange } from 'functions/plainDateRange';
 import { t } from 'i18n';
 
 // Module-scoped set tracking which tournamentIds have already triggered the
@@ -17,19 +18,6 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 /** Today at the venue — compared against tournament dates, which are venue calendar days. */
 function todayLocalIso(): string {
   return venueCalendarDate();
-}
-
-function* dateRangeInclusive(startIso: string, endIso: string): Generator<string> {
-  // UTC math so DST transitions don't skip or duplicate a day. We're only
-  // comparing date strings; nothing here depends on wall-clock hours.
-  const [sy, sm, sd] = startIso.split('-').map(Number);
-  const [ey, em, ed] = endIso.split('-').map(Number);
-  const cur = new Date(Date.UTC(sy, sm - 1, sd));
-  const last = new Date(Date.UTC(ey, em - 1, ed));
-  while (cur.getTime() <= last.getTime()) {
-    yield cur.toISOString().slice(0, 10);
-    cur.setUTCDate(cur.getUTCDate() + 1);
-  }
 }
 
 function scheduledDateOf(matchUp: any): string | null {
@@ -92,7 +80,7 @@ export function maybeNudgeActiveDates({ tournamentRecord }: { tournamentRecord?:
   if (scheduledDates.size === 0) return undefined;
 
   let emptyDaysBeforeToday = 0;
-  for (const iso of dateRangeInclusive(startDate, today)) {
+  for (const iso of plainDateRange(startDate, today)) {
     if (!scheduledDates.has(iso)) {
       emptyDaysBeforeToday += 1;
       if (emptyDaysBeforeToday >= 2) break;

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -23,6 +23,7 @@ import { readUserMinCourtWidth, writeUserMinCourtWidth } from 'services/schedule
 import { buildGridDropMethods, shouldRejectStripDrop, type GridDropPayload } from './gridDropMethods';
 import { isScheduleLocked, lockedInDrop, scheduleLockReason } from './scheduleLocks';
 import { openScheduleLockMenu } from './scheduleLockActions';
+import { plainDateRange } from 'functions/plainDateRange';
 import {
   readScheduleDisplayConfig,
   writeScheduleDisplayConfig,
@@ -596,7 +597,7 @@ export function renderGridView(
   // onMutationApplied subscription.
   function confirmTogglePublish(): void {
     const publishState = getOrderOfPlayPublishState();
-    const fullRange = dateRange(
+    const fullRange = plainDateRange(
       getCachedCompetitionDateRange().startDate ?? '',
       getCachedCompetitionDateRange().endDate ?? '',
     );
@@ -3402,7 +3403,7 @@ export function buildScheduleDates(selectedDate: string): ScheduleDate[] {
   const { startDate, endDate } = getCachedCompetitionDateRange();
   const { tournamentInfo } = getCachedTournamentInfo();
   const activeDates = tournamentInfo?.activeDates;
-  const dates = activeDates?.length ? [...activeDates].sort() : dateRange(startDate ?? '', endDate ?? '');
+  const dates = activeDates?.length ? [...activeDates].sort() : plainDateRange(startDate ?? '', endDate ?? '');
 
   const { matchUps } = getCachedAllMatchUps();
   const dateCounts = new Map<string, number>();
@@ -3673,17 +3674,6 @@ export function buildIssues(selectedDate: string): ScheduleIssue[] {
 }
 
 // ── Helpers ──
-
-function dateRange(start: string, end: string): string[] {
-  const dates: string[] = [];
-  const current = new Date(start + 'T00:00:00');
-  const last = new Date(end + 'T00:00:00');
-  while (current <= last) {
-    dates.push(current.toISOString().slice(0, 10));
-    current.setDate(current.getDate() + 1);
-  }
-  return dates;
-}
 
 /**
  * Both catalog card badges, composed into the single element `renderCardExtra` accepts.


### PR DESCRIPTION
Found while surveying `Mentat/TASKS.md` for TMX work during the factory-7.0.0 wait. It is the TMX half of the **calendar-day-intents** item (🔴 HIGH) — specifically the part that is *not* sequenced behind the factory's Temporal migration, because it is a wrong-output bug rather than a which-helper-do-we-adopt question.

## The defect

Two copies of a day-walk parsed **local** midnight and emitted the **UTC** day:

```ts
const current = new Date(`${start}T00:00:00`);   // local midnight
dates.push(current.toISOString().slice(0, 10));  // the UTC day
```

Measured, `2026-09-12`..`2026-09-15`:

| TZ | emitted |
|---|---|
| `UTC` | 09-12 09-13 09-14 09-15 |
| `America/New_York` | 09-12 09-13 09-14 09-15 |
| `Europe/Berlin` | **09-11** 09-12 09-13 **09-14** |
| `Pacific/Auckland` | **09-11** 09-12 09-13 **09-14** |

East of Greenwich the range offers a day *before* the tournament starts and never offers its *last* day.

## Where it reached

- **`buildScheduleDates`** — falls back to the range whenever `activeDates` is empty, which is the common case (BOBOCA's record carries `activeDates: []`), so the schedule page's whole date selector was shifted.
- **matchUps-tab date filter** — the same list, shifted the same way.
- **`confirmTogglePublish`** — builds its full range this way and feeds it to `buildOrderOfPlayDateToggleMethods`, so this one reaches a **mutation**: publishing an order of play could act on the wrong set of dates.

Nothing caught it because every developer machine and CI runner in this ecosystem sits at UTC or west of it, where a local midnight round-trips through UTC to the same calendar day. The suite was structurally incapable of expressing the defect — which is the claim the TASKS.md entry makes generally, and this is a concrete instance of it.

## The fix

`maybeNudgeActiveDates` **already had the correct walk** — components in, `Date.UTC` throughout, components out, with a comment explaining that UTC days cannot be shortened by a DST transition. That is what is hoisted, as `functions/plainDateRange`, and all three call sites converge on it. The name follows the Temporal vocabulary the ecosystem is standardising on, so the eventual migration is a type change rather than a rename.

The helper formats UTC components explicitly instead of reading past `toISOString()`, so the lint rule that item proposes will find nothing to adjudicate here.

## Verification

- **Falsified.** With the old walk restored, Berlin and Auckland fail and UTC + New York stay green — 3 failed / 9 passed. A detector that has never reported dirty is not evidence.
- Zone is set **per assertion**, not per CI leg, so the east-of-UTC case travels with the test and cannot be lost by someone reconfiguring a workflow.
- `TZ=UTC vitest run` — **1844 passed**; lint / check-types / format:check clean; attr-audit + i18n-audit exit 0
- e2e `TEST_PROD=1` on the affected surfaces (journeys 54, 59, 78) — **4 passed**