### PR TITLE
feat(schedule): a legend for the marks the scheduling page makes

### DIFF
--- a/e2e/journeys/121-schedule-legend.spec.ts
+++ b/e2e/journeys/121-schedule-legend.spec.ts
@@ -1,0 +1,87 @@
+import { initDevBridge, resetState, waitForAppReady } from '../helpers/dev-bridge';
+import { test, expect, type Page } from '@playwright/test';
+import { TournamentPage } from '../pages/TournamentPage';
+import { todayLocal } from '../helpers/dates';
+
+/**
+ * Journey 121 — the scheduling page's legend
+ *
+ * The page has grown a vocabulary nobody is told: rest badge states, the
+ * daily-limit marker, the Inspector's provenance suffixes and "Could not read"
+ * line, check-in counts, annotation pills. The footer's info icon opens a
+ * legend for all of it.
+ *
+ * The unit test owns the CONTENT — that every mark has an entry, in the same
+ * words the page uses. What only a browser can show is that the affordance is
+ * reachable: the icon is in the footer, clicking it opens the popover, and the
+ * popover is dismissible. A legend nobody can open is not an affordance.
+ */
+
+const LEGEND_BUTTON = 'button.tmx-legend-button';
+const LEGEND = '.tmx-legend';
+
+async function seedScheduledTournament(page: Page): Promise<string> {
+  const today = todayLocal();
+  return page.evaluate(async (date) => {
+    await dev.tmx2db.initDB();
+    const { tournamentRecord } = dev.factory.mocksEngine.generateTournamentRecord({
+      nonRandom: 1,
+      setState: true,
+      tournamentName: 'E2E Schedule Legend',
+      tournamentAttributes: { tournamentId: 'e2e-schedule-legend', startDate: date, endDate: date },
+      drawProfiles: [{ eventName: 'Legend Singles', drawSize: 8, drawType: 'SINGLE_ELIMINATION' }],
+      venueProfiles: [{ courtsCount: 2, venueName: 'Legend Venue' }],
+    });
+    await dev.tmx2db.addTournament(dev.factory.tournamentEngine.getTournament().tournamentRecord);
+    return tournamentRecord.tournamentId as string;
+  }, today);
+}
+
+test.describe('Journey 121 — scheduling page legend', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await initDevBridge(page);
+    await resetState(page);
+  });
+
+  test('the footer info icon opens a legend of the page vocabulary', async ({ page }) => {
+    const tournamentId = await seedScheduledTournament(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToScheduling();
+
+    const button = page.locator(LEGEND_BUTTON);
+    await expect(button).toBeVisible();
+    // Closed until asked for: an orientation affordance must not occupy the
+    // page for the operators who already know the vocabulary.
+    await expect(page.locator(LEGEND)).toHaveCount(0);
+
+    await button.click();
+    const legend = page.locator(LEGEND);
+    await expect(legend).toBeVisible();
+
+    // Spot-check the two ends of the content: the badge word an operator is
+    // most likely to be puzzled by, and a section heading.
+    await expect(legend).toContainText('on court');
+    await expect(legend).toContainText('Rest badge');
+    // Every row carries both halves; the unit test asserts this over the model,
+    // this asserts the renderer actually emitted both.
+    const rows = legend.locator('.tmx-legend-row');
+    expect(await rows.count()).toBeGreaterThanOrEqual(9);
+    await expect(rows.first().locator('.tmx-legend-meaning')).not.toBeEmpty();
+  });
+
+  test('the legend dismisses on an outside click', async ({ page }) => {
+    const tournamentId = await seedScheduledTournament(page);
+    const tournament = new TournamentPage(page);
+    await tournament.goto(tournamentId);
+    await tournament.navigateToScheduling();
+
+    await page.locator(LEGEND_BUTTON).click();
+    await expect(page.locator(LEGEND)).toBeVisible();
+
+    await page.mouse.click(5, 5);
+    await expect(page.locator(LEGEND)).toBeHidden();
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1052,6 +1052,23 @@
     "byeScheduledBody": "This match already has scheduling information. Assigning a BYE will leave the court slot occupied unless you remove it.",
     "byeKeepScheduling": "Keep scheduling",
     "byeRemoveScheduling": "Remove scheduling",
+    "legend": {
+      "title": "What the marks on this page mean",
+      "restBadge": "Rest badge (on a match card)",
+      "restOnCourt": "A player is still in an earlier match",
+      "restDurationSample": "41m",
+      "restDuration": "How long the least-rested player has had off",
+      "restUnknown": "The prior match has no recorded finish, so rest cannot be measured",
+      "restNone": "Nobody on this card has played yet today",
+      "restLimit": "Which match of the day this would be for that player",
+      "inspector": "Inspector rest rows",
+      "estimatedSample": "(est.)",
+      "estimated": "The finish was inferred, not recorded — a projection, not a measurement",
+      "discarded": "A recorded stamp was rejected as unreadable, and the next best one was used",
+      "cellMarks": "On a scheduled cell",
+      "checkIn": "Participants who have not yet presented at the desk",
+      "annotations": "Notes a director has pinned to the match"
+    },
     "venueFrame": {
       "notice": "Times in {{timeZone}} — venue zone not set",
       "noticeTitle": "This tournament has no time zone set, so times are shown in this device’s zone ({{timeZone}}). Set the venue’s time zone so every operator reads the same clock."

--- a/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridActionBar.ts
@@ -12,6 +12,7 @@
 import { buildVenueFrameNotice } from 'components/notices/venueFrameNotice';
 import tippy, { Instance as TippyInstance } from 'tippy.js';
 import { providerConfig } from 'config/providerConfig';
+import { buildLegendButton } from './scheduleLegend';
 import { t } from 'i18n';
 import { ScheduleIssue } from 'courthive-components';
 import { buildStepper } from './stepperControl';
@@ -164,6 +165,10 @@ export function buildGridActionBar(params: GridActionBarParams): GridActionBar {
   if (onClearSchedule) {
     bar.appendChild(buildClearButton(bulkMode, onClearSchedule));
   }
+  // Last in the right cluster, and unconditional: it is the one control here
+  // that explains the others, so it must not be the one that disappears with a
+  // capability or an empty state.
+  bar.appendChild(buildLegendButton());
 
   return { element: bar, setIssues, setTimingAvailable, setDatePublished, setVenueFrame };
 }

--- a/src/pages/tournament/tabs/scheduleViews/scheduleLegend.test.ts
+++ b/src/pages/tournament/tabs/scheduleViews/scheduleLegend.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The legend's job is to have an entry for every mark the page can show, and to
+ * name each one in the words the page actually uses. These tests hold it to
+ * both — the sample text must come from the SAME i18n keys the real marks are
+ * rendered from, so a reworded badge cannot leave a stale sample behind here.
+ *
+ * Content only. The nodes are built in `buildSchedulePopoverLegend`, and TMX
+ * covers DOM construction in Playwright rather than a simulated document.
+ */
+import { legendSections } from './scheduleLegend';
+import { describe, expect, it } from 'vitest';
+import { t } from 'i18n';
+
+const rows = () => legendSections().flatMap((section) => section.rows);
+const samples = () => rows().map((row) => row.sample);
+
+describe('the schedule legend explains the badge vocabulary', () => {
+  it.each([['schedule.card.rest.onCourt'], ['schedule.card.rest.unknown'], ['schedule.card.rest.none']])(
+    'carries the real %s badge text as a sample',
+    (key) => {
+      expect(samples()).toContain(t(key));
+    },
+  );
+
+  it('carries the daily-limit marker in the form the badge renders it', () => {
+    expect(samples()).toContain(t('schedule.card.rest.limit', { ordinal: 3 }));
+  });
+
+  it('carries the discarded-rung line in the form the Inspector renders it', () => {
+    const rung = t('schedule.inspector.rest.discardedName.scoredTime');
+    expect(samples()).toContain(t('schedule.inspector.rest.discarded', { rungs: rung }));
+  });
+
+  it('explains every sample it carries', () => {
+    // A row with a sample and no meaning is a mark named but not explained,
+    // which is the failure this affordance exists to prevent.
+    expect(rows().length).toBeGreaterThanOrEqual(9);
+    for (const row of rows()) {
+      expect(row.sample.trim()).toBeTruthy();
+      expect(row.meaning.trim()).toBeTruthy();
+    }
+  });
+
+  it('gives every section a heading and at least one row', () => {
+    const sections = legendSections();
+    expect(sections.length).toBeGreaterThanOrEqual(3);
+    for (const section of sections) {
+      expect(section.heading.trim()).toBeTruthy();
+      expect(section.rows.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders no untranslated key paths', () => {
+    // `t()` echoes the key when it resolves to nothing, so a missing entry would
+    // show the operator a dotted path.
+    const text = legendSections()
+      .flatMap((section) => [section.heading, ...section.rows.flatMap((row) => [row.sample, row.meaning])])
+      .join(' ');
+    expect(text).not.toMatch(/schedule\.legend\.|checkIn\./);
+  });
+});

--- a/src/pages/tournament/tabs/scheduleViews/scheduleLegend.ts
+++ b/src/pages/tournament/tabs/scheduleViews/scheduleLegend.ts
@@ -1,0 +1,195 @@
+/**
+ * Schedule2 — the legend behind the footer's info icon.
+ *
+ * The scheduling page has grown a vocabulary nobody is told. A card can say
+ * `on court`, `41m`, `rest unknown` or `no prior match`, and carry a `#3`
+ * riding the badge; an Inspector row can end in `(est.)` or in
+ * `Could not read: score entry`; a cell can wear a check-in count or an
+ * annotation pill. Every one of those is legible once explained and opaque
+ * until then, and none of them has anywhere to explain itself — a tooltip
+ * expands the value, not the vocabulary.
+ *
+ * So: one popover, reachable from the footer, that lists the marks and says
+ * what each one means. Deliberately a legend and not documentation — it names
+ * what is on screen and stops. Anything that needs a paragraph belongs in the
+ * Inspector, which already has the room for it.
+ *
+ * **The sample chips are rendered from the same `t()` keys the real ones use.**
+ * A legend that hard-codes its own copy of "on court" is a second source of
+ * truth for the word, and drifts the first time either side is reworded. The
+ * explanation beside each is the only new copy here.
+ */
+import tippy, { Instance as TippyInstance } from 'tippy.js';
+import { t } from 'i18n';
+
+const LEGEND_ROW_GAP = '8px';
+
+export interface LegendRow {
+  /** The mark as it appears on the page. */
+  sample: string;
+  /** What it tells the operator. */
+  meaning: string;
+  /** Rendered as a chip rather than plain text — true for the badge vocabulary. */
+  chip?: boolean;
+}
+
+export interface LegendSection {
+  heading: string;
+  rows: LegendRow[];
+}
+
+/**
+ * The legend as data, with no DOM anywhere near it.
+ *
+ * Separated from the rendering for the reason the rest badge is: the content is
+ * the part worth testing, and TMX tests DOM construction in Playwright rather
+ * than in a simulated document (the ecosystem's no-happy-dom rule). This shape
+ * is assertable in a unit test; the nodes below are covered by a journey.
+ */
+export function legendSections(): LegendSection[] {
+  return [
+    {
+      heading: t('schedule.legend.restBadge'),
+      rows: [
+        { sample: t('schedule.card.rest.onCourt'), meaning: t('schedule.legend.restOnCourt'), chip: true },
+        { sample: t('schedule.legend.restDurationSample'), meaning: t('schedule.legend.restDuration'), chip: true },
+        { sample: t('schedule.card.rest.unknown'), meaning: t('schedule.legend.restUnknown'), chip: true },
+        { sample: t('schedule.card.rest.none'), meaning: t('schedule.legend.restNone'), chip: true },
+        {
+          sample: t('schedule.card.rest.limit', { ordinal: 3 }),
+          meaning: t('schedule.legend.restLimit'),
+          chip: true,
+        },
+      ],
+    },
+    {
+      heading: t('schedule.legend.inspector'),
+      rows: [
+        { sample: t('schedule.legend.estimatedSample'), meaning: t('schedule.legend.estimated') },
+        {
+          sample: t('schedule.inspector.rest.discarded', {
+            rungs: t('schedule.inspector.rest.discardedName.scoredTime'),
+          }),
+          meaning: t('schedule.legend.discarded'),
+        },
+      ],
+    },
+    {
+      heading: t('schedule.legend.cellMarks'),
+      rows: [
+        { sample: t('checkIn.badgePartial', { count: 1 }), meaning: t('schedule.legend.checkIn'), chip: true },
+        { sample: t('schedule.annotations'), meaning: t('schedule.legend.annotations') },
+      ],
+    },
+  ];
+}
+
+function buildChip(text: string): HTMLElement {
+  const chip = document.createElement('span');
+  chip.className = 'tmx-legend-chip';
+  chip.textContent = text;
+  return chip;
+}
+
+function buildRow(row: LegendRow): HTMLElement {
+  const element = document.createElement('div');
+  element.className = 'tmx-legend-row';
+
+  const sample = document.createElement('div');
+  sample.className = 'tmx-legend-sample';
+  if (row.chip) sample.appendChild(buildChip(row.sample));
+  else sample.textContent = row.sample;
+
+  const meaning = document.createElement('div');
+  meaning.className = 'tmx-legend-meaning';
+  meaning.textContent = row.meaning;
+
+  element.append(sample, meaning);
+  return element;
+}
+
+const LEGEND_STYLE_ID = 'tmx-schedule-legend-style';
+
+/**
+ * Injected once rather than written inline on every node: the popover has ~9
+ * rows and the chip needs a pseudo-free but themed box, and `--tmx-*` tokens
+ * resolve the same in a stylesheet as they do inline while staying readable.
+ * Every colour is a theme token, so light and dark both follow the page.
+ */
+function ensureLegendStyle(): void {
+  if (document.getElementById(LEGEND_STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = LEGEND_STYLE_ID;
+  style.textContent = [
+    `.tmx-legend{padding:8px;max-height:60vh;overflow-y:auto;min-width:300px;max-width:380px}`,
+    `.tmx-legend-heading{font-weight:700;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.04em;`,
+    `color:var(--tmx-text-secondary);margin:10px 0 4px}`,
+    `.tmx-legend-heading:first-child{margin-top:0}`,
+    `.tmx-legend-row{display:flex;gap:${LEGEND_ROW_GAP};align-items:baseline;padding:3px 0}`,
+    `.tmx-legend-sample{flex:0 0 40%;font-size:0.75rem;color:var(--tmx-text-primary)}`,
+    `.tmx-legend-meaning{flex:1;font-size:0.75rem;color:var(--tmx-text-secondary)}`,
+    `.tmx-legend-chip{display:inline-block;padding:1px 6px;border-radius:10px;font-size:0.6875rem;`,
+    `background:var(--tmx-bg-tertiary);border:1px solid var(--tmx-border-primary);color:var(--tmx-text-primary);`,
+    `white-space:nowrap}`,
+  ].join('');
+  document.head.appendChild(style);
+}
+
+/** The popover body. Exported for the unit test, which asserts every row is explained. */
+export function buildSchedulePopoverLegend(): HTMLElement {
+  ensureLegendStyle();
+  const container = document.createElement('div');
+  container.className = 'tmx-legend';
+
+  for (const section of legendSections()) {
+    const heading = document.createElement('div');
+    heading.className = 'tmx-legend-heading';
+    heading.textContent = section.heading;
+    container.appendChild(heading);
+    for (const row of section.rows) container.appendChild(buildRow(row));
+  }
+
+  return container;
+}
+
+/**
+ * The footer's info icon. Built on the same tippy-on-click shape as the issues
+ * button beside it, so the two read as one family of footer affordances.
+ */
+export function buildLegendButton(): HTMLElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'tmx-legend-button';
+  btn.title = t('schedule.legend.title');
+  btn.setAttribute('aria-label', t('schedule.legend.title'));
+  btn.style.cssText = [
+    'font-size: 0.875rem',
+    'padding: 4px 8px',
+    'border-radius: 6px',
+    'border: 1px solid var(--tmx-border-primary)',
+    'background: var(--tmx-bg-primary)',
+    'cursor: pointer',
+    'color: var(--tmx-text-secondary)',
+    'display: inline-flex',
+    'align-items: center',
+  ].join('; ');
+  btn.innerHTML = '<i class="fa-solid fa-circle-info"></i>';
+
+  let instance: TippyInstance | undefined;
+  requestAnimationFrame(() => {
+    instance = tippy(btn, {
+      // Built per open: the rows are `t()` calls, so a language change between
+      // opens must be picked up rather than baked in at construction.
+      content: () => buildSchedulePopoverLegend(),
+      trigger: 'click',
+      interactive: true,
+      placement: 'top-end',
+      theme: 'light-border',
+      appendTo: () => document.body,
+      maxWidth: 400,
+    });
+    void instance; //NOSONAR
+  });
+
+  return btn;
+}


### PR DESCRIPTION
The 🟢 LOW "scheduling page needs an orientation affordance (info icon)" entry in `Mentat/TASKS.md` — raised 2026-08-24, deprioritised 2026-08-25 behind two correctness items on the same surface. One of those closed today (#1437), so this came up the queue.

## The problem, in the entry's own words

> The scheduling page has grown a vocabulary nobody is told: rest badge states (`on court` / a duration / `rested` / `rest unknown`), the daily-limit marker riding the badge, the provenance suffixes on Inspector rest rows ("from score entry (est.)" vs "projected from scheduled time (est.)"), the new "Could not read: …" line, check-in badges, and the annotation pills. All of it is legible once explained and opaque until then.

A tooltip expands the *value* — "Nassar — still on court" — not the *vocabulary*. There was nowhere to learn what the words mean.

## What this adds

An info icon at the end of the footer's right cluster, opening a popover on the same tippy-on-click shape as the Issues button beside it, so the two read as one family of footer affordances. Three sections — rest badge, Inspector rest rows, cell marks — each row pairing the mark as the page renders it with one line of meaning.

It is a legend, not documentation: it names what is on screen and stops. Anything needing a paragraph belongs in the Inspector, which has the room.

## The part worth reviewing

**The samples come from the same `t()` keys the real marks are rendered from.** A legend that hard-codes its own "on court" is a second source of truth for the word and drifts the first time either side is reworded. The unit test asserts that relationship rather than matching literals, so a rewording either updates both or fails.

Content is a pure `legendSections()`; the DOM is a separate renderer. That split is the house rule — TMX tests DOM construction in Playwright, not in a simulated document — and it is why the unit test covers the content and journey 121 covers the affordance.

## Verification

- `TZ=UTC vitest run` — **1840 passed** (8 new)
- e2e `TEST_PROD=1` journey 121 — **2 passed**: the icon is in the footer, the legend is closed until asked for, it opens with every row carrying both halves, and it dismisses on an outside click
- lint / check-types / format:check clean; attr-audit + i18n-audit exit 0 with nothing to say about the new keys
- Rendered and read in dark theme before shipping; every colour is a `--tmx-*` token, chip contrast raised to `--tmx-bg-tertiary` after looking at it