### PR TITLE
refactor(venueTimeFrame): ask for "now" by name instead of by omission

### DIFF
--- a/src/components/modals/printFactSheet.ts
+++ b/src/components/modals/printFactSheet.ts
@@ -3,8 +3,8 @@
  */
 import { generateFactSheet, listFactSheetTemplates } from 'pdf-factory';
 import { openPDF, savePDF } from 'services/pdf/export/pdfExport';
-import { venueCalendarDate } from 'functions/venueTimeFrame';
 import { tournamentEngine } from 'services/factory/engine';
+import { venueToday } from 'functions/venueTimeFrame';
 import { renderForm } from 'courthive-components';
 import { openModal } from './baseModal/baseModal';
 import { t } from 'i18n';
@@ -42,7 +42,7 @@ export function printFactSheet(): void {
     const safeName = tournamentName.replaceAll(/[^a-zA-Z0-9-_ ]/g, '').replaceAll(/\s+/g, '-');
     // `toISOString()` is the UTC day, so west of Greenwich an evening print
     // stamps the filename with tomorrow. Same class of bug as #1352.
-    const date = venueCalendarDate();
+    const date = venueToday();
     const filename = `fact-sheet-${safeName}-${date}.pdf`;
 
     if (action === 'open') {

--- a/src/components/tables/common/filters/matchUpDateFilter.ts
+++ b/src/components/tables/common/filters/matchUpDateFilter.ts
@@ -9,7 +9,7 @@
  *   - '__none__' — matchUps with no scheduledDate
  */
 import { whenTableBuilt } from 'components/tables/common/whenTableBuilt';
-import { venueCalendarDate } from 'functions/venueTimeFrame';
+import { venueToday } from 'functions/venueTimeFrame';
 import { competitionEngine } from 'services/factory/engine';
 import { context } from 'services/context';
 import { t } from 'i18n';
@@ -24,7 +24,7 @@ const NO_DATE_TOKEN = '__none__';
  * same day, and the schedule keys on the venue. See `functions/venueTimeFrame`.
  */
 export function isoToday(): string {
-  return venueCalendarDate();
+  return venueToday();
 }
 
 function formatDateLabel(iso: string): string {

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.test.ts
@@ -47,9 +47,12 @@ describe('scheduleStatusFormatter reads the venue clock, never the browser`s', (
     expect(code).toContain('venueTimeFrame');
     // `calledAt` is an instant and must go through `venueClock`; `scheduledDate`
     // / `scheduledTime` are bare venue wall clocks compared against "now", which
-    // is why the module needs both the day and the clock.
+    // is why the module needs both the day and the clock. "Now" is asked for by
+    // name — `venueToday` / `venueNowClock` — since the converters stopped
+    // substituting it for a missing argument.
     expect(code).toContain('venueClock');
-    expect(code).toContain('venueCalendarDate');
+    expect(code).toContain('venueToday');
+    expect(code).toContain('venueNowClock');
   });
 });
 
@@ -61,11 +64,16 @@ describe('scheduleStatusFormatter reads the venue clock, never the browser`s', (
  * before its start date showed its entire draw called to court, all at the same
  * clock, ticking forward on each redraw.
  *
- * The cause is that `venueClock` DEFAULTS TO NOW for empty input, so the
- * formatter's own `if (!clock) return ''` is unreachable for an absent stamp.
+ * The cause was that `venueClock` DEFAULTED TO NOW for empty input, so the
+ * formatter's own `if (!clock) return ''` was unreachable for an absent stamp.
  * That is a value fact, not a which-imports-does-it-use fact, so it needs a
  * value test — hence `calledAtClock`, extracted purely so this can exist without
  * a DOM.
+ *
+ * The default is gone and the converters now require an instant, so the
+ * compiler refuses the original mistake. These assertions stay anyway: the cell
+ * value reaches `calledAtClock` as `any` from Tabulator, which is precisely
+ * where the type system has nothing to say.
  */
 describe('calledAtClock renders nothing for a matchUp that was never called', () => {
   it.each([

--- a/src/components/tables/common/formatters/scheduleStatusFormatter.ts
+++ b/src/components/tables/common/formatters/scheduleStatusFormatter.ts
@@ -1,15 +1,15 @@
-import { venueCalendarDate, venueClock } from 'functions/venueTimeFrame';
+import { venueNowClock, venueClock, venueToday } from 'functions/venueTimeFrame';
 import { t } from 'i18n';
 
 // `scheduledDate` / `scheduledTime` are bare venue wall-clock values, so the
 // "now" they are compared against must be the venue's clock too — otherwise a
 // match reads as past or future purely because of where the laptop is.
 function todayYmd(): string {
-  return venueCalendarDate();
+  return venueToday();
 }
 
 function nowHm(): string {
-  return venueClock();
+  return venueNowClock();
 }
 
 type Status = 'future' | 'past' | 'none';
@@ -82,12 +82,19 @@ export function scheduleLockFormatter(cell: any): HTMLSpanElement | string {
 // printed the operator's.
 //
 // The empty-value guard below is load-bearing, and dropping it is the regression
-// #1364 shipped. `venueClock` DEFAULTS TO NOW when handed nothing, so a matchUp
-// that has never been called rendered the current venue clock — every uncalled
-// row showing the same time, advancing on each redraw, and a tournament that had
-// not started yet reading as though its whole draw had been called to court.
-// `if (!clock)` cannot catch that: "now" is a perfectly valid clock string. The
-// only place the absence can be detected is before the conversion.
+// #1364 shipped. `venueClock` used to DEFAULT TO NOW when handed nothing, so a
+// matchUp that had never been called rendered the current venue clock — every
+// uncalled row showing the same time, advancing on each redraw, and a
+// tournament that had not started yet reading as though its whole draw had been
+// called to court. `if (!clock)` cannot catch that: "now" is a perfectly valid
+// clock string. The only place the absence can be detected is before the
+// conversion.
+//
+// `venueClock` now REQUIRES an instant, so that class of mistake is a type
+// error rather than a plausible wrong time. This guard stays regardless: the
+// value arrives from a Tabulator cell as `any`, which is exactly where the
+// compiler cannot help, and returning `''` for an absent stamp is this
+// function's contract rather than a workaround for the old default.
 export function calledAtClock(value?: string | number | Date | null): string {
   if (!value) return '';
   return venueClock(value);

--- a/src/functions/venueTimeFrame.test.ts
+++ b/src/functions/venueTimeFrame.test.ts
@@ -15,7 +15,9 @@ import {
   venueCalendarDate,
   venueDayMinutes,
   venueNowOnDate,
+  venueNowClock,
   venueTimeZone,
+  venueToday,
   venueParts,
   venueClock,
 } from './venueTimeFrame';
@@ -192,7 +194,46 @@ describe('venueNowOnDate — a day the venue has not reached has no "now"', () =
   });
 
   it('takes the same exit for a date it cannot read', () => {
-    expect(venueNowOnDate('not-a-date', KOLKATA)).toBeUndefined();
+    expect(venueNowOnDate(UNPARSEABLE, KOLKATA)).toBeUndefined();
+  });
+});
+
+/**
+ * The A10 footgun, closed.
+ *
+ * `venueClock()` / `venueCalendarDate()` / `venueDayMinutes()` used to
+ * substitute `new Date()` for a missing instant, which put the CURRENT clock in
+ * the Called column of every matchUp that had never been called (#1387). The
+ * argument is now required, so that mistake is a type error — and the two sites
+ * that genuinely mean "now" ask for it by name.
+ *
+ * A required argument cannot be tested by calling without one (it would not
+ * compile, which is the point), so what is asserted here is the pair of named
+ * helpers and the fact that an UNREADABLE instant still yields a missing value
+ * rather than a substituted one — the same failure mode arriving by a different
+ * door, and the one the compiler cannot close.
+ */
+describe('"now" is asked for by name, and a bad instant is never quietly replaced', () => {
+  it('venueToday agrees with venueCalendarDate on the current instant', () => {
+    expect(venueToday(KOLKATA)).toBe(venueCalendarDate(new Date(), KOLKATA));
+  });
+
+  it('venueNowClock agrees with venueClock on the current instant', () => {
+    // Both read the same clock a moment apart, so compare the hour rather than
+    // the minute-precise string, which can tick between the two calls.
+    expect(venueNowClock(KOLKATA).slice(0, 2)).toBe(venueClock(new Date(), KOLKATA).slice(0, 2));
+  });
+
+  it('reads "now" against the VENUE zone, not the runner zone', () => {
+    // Under TZ=UTC these differ for five and a half hours of every day, which is
+    // the only thing that makes this assertion worth writing.
+    expect(venueNowClock(KOLKATA)).not.toBe(venueNowClock('UTC'));
+  });
+
+  it.each([[UNPARSEABLE], ['']])('returns empty for the unreadable instant %o rather than now', (value) => {
+    expect(venueCalendarDate(value, KOLKATA)).toBe('');
+    expect(venueClock(value, KOLKATA)).toBe('');
+    expect(venueDayMinutes(value, KOLKATA)).toBeUndefined();
   });
 });
 

--- a/src/functions/venueTimeFrame.ts
+++ b/src/functions/venueTimeFrame.ts
@@ -233,6 +233,39 @@ function pad2(n: number): string {
 }
 
 /**
+ * ── "Now" is asked for by name ──
+ *
+ * The three converters below take a **required** instant. They used to default
+ * a missing one to `new Date()`, and that shipped a production bug: an uncalled
+ * matchUp has no `calledAt`, so `venueClock(matchUp.schedule.calledAt)`
+ * rendered the *current* clock as its call time — identical on every row of a
+ * tournament whose first day had not arrived, and advancing on each redraw
+ * ([#1387(TMX)](https://github.com/CourtHive/TMX/pull/1387)). The formatter's own
+ * `if (!clock) return ''` could not catch it, because "now" is a valid clock
+ * string.
+ *
+ * The module already knew better and said so about `venueParts`:
+ *
+ * > *Returns `undefined` for unparseable input rather than a substituted
+ * > default — a wrong time is worse than a missing one everywhere this is used.*
+ *
+ * Its own wrappers then substituted a default. That is `architectural-standards`
+ * **A3 — open defaults are fail-open**, and `coding-standards`' *"a default is
+ * not a detection"*, in the module those standards most need to hold.
+ *
+ * An `arguments.length` check would have been the cheap fix and the wrong one:
+ * it breaks **forwarding wrappers**, which always pass one argument whether or
+ * not their own caller did. `signInPresence.venueCalendarDay(value?)` was
+ * exactly that, and would have started returning `''` for `officialsTab`'s bare
+ * call — a silent regression rather than a compiler error.
+ *
+ * So the sites that genuinely mean "now" say so — `venueToday()`,
+ * `venueNowClock()` — and everywhere else the compiler now requires an instant.
+ * The next `venueClock(possiblyMissingStamp)` is a type error at the keyboard
+ * instead of a plausible wrong time in production.
+ */
+
+/**
  * The calendar day an instant falls on **at the venue**, as `YYYY-MM-DD`.
  *
  * Never `toISOString().slice(0, 10)`: that reports the UTC day, so west of
@@ -240,26 +273,43 @@ function pad2(n: number): string {
  * Florida it already says tomorrow. Shipping that once (#1352, fixed in #1355)
  * made every official read "available" every evening.
  *
- * Defaults to now, which is the "what day is it?" every schedule surface asks.
+ * Empty string when the instant is unreadable — and `''` is falsy, so a caller
+ * that forgets to check gets a missing day rather than a wrong one.
  */
-export function venueCalendarDate(value?: string | number | Date, timeZone?: string): string {
-  const parts = venueParts(value ?? new Date(), timeZone);
+export function venueCalendarDate(value: string | number | Date, timeZone?: string): string {
+  const parts = venueParts(value, timeZone);
   if (!parts) return '';
   return `${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
 }
 
-/** An instant as a `HH:MM` venue wall clock. Defaults to now. Empty string when unparseable. */
-export function venueClock(value?: string | number | Date, timeZone?: string): string {
-  const parts = venueParts(value ?? new Date(), timeZone);
+/** An instant as a `HH:MM` venue wall clock. Empty string when unparseable. */
+export function venueClock(value: string | number | Date, timeZone?: string): string {
+  const parts = venueParts(value, timeZone);
   if (!parts) return '';
   return `${pad2(parts.hour)}:${pad2(parts.minute)}`;
 }
 
-/** An instant as minutes from venue midnight (`14:20` → `860`). Defaults to now. */
-export function venueDayMinutes(value?: string | number | Date, timeZone?: string): number | undefined {
-  const parts = venueParts(value ?? new Date(), timeZone);
+/** An instant as minutes from venue midnight (`14:20` → `860`). */
+export function venueDayMinutes(value: string | number | Date, timeZone?: string): number | undefined {
+  const parts = venueParts(value, timeZone);
   if (!parts) return undefined;
   return parts.hour * 60 + parts.minute;
+}
+
+/**
+ * Today's calendar day **at the venue**, `YYYY-MM-DD`.
+ *
+ * The "what day is it?" every schedule surface asks. Named rather than reached
+ * by omitting an argument, so that asking for today and forgetting to pass a
+ * stamp stop looking identical in the source.
+ */
+export function venueToday(timeZone?: string): string {
+  return venueCalendarDate(new Date(), timeZone);
+}
+
+/** The current venue wall clock, `HH:MM`. The named form of "now" — see `venueToday`. */
+export function venueNowClock(timeZone?: string): string {
+  return venueClock(new Date(), timeZone);
 }
 
 /**

--- a/src/pages/tournament/maybeNudgeActiveDates.ts
+++ b/src/pages/tournament/maybeNudgeActiveDates.ts
@@ -1,5 +1,5 @@
 import { openEditDatesModal } from './tabs/overviewTab/editDatesModal';
-import { venueCalendarDate } from 'functions/venueTimeFrame';
+import { venueToday } from 'functions/venueTimeFrame';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
 import { t } from 'i18n';
@@ -16,7 +16,7 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /** Today at the venue — compared against tournament dates, which are venue calendar days. */
 function todayLocalIso(): string {
-  return venueCalendarDate();
+  return venueToday();
 }
 
 function* dateRangeInclusive(startIso: string, endIso: string): Generator<string> {

--- a/src/pages/tournament/tabs/matchUpsTab/abandonMatchUpsAction.ts
+++ b/src/pages/tournament/tabs/matchUpsTab/abandonMatchUpsAction.ts
@@ -11,7 +11,7 @@ import { ABANDON_TOURNAMENT_MATCHUPS } from 'constants/mutationConstants';
 import { getRepublishRankingsOption } from 'pages/tournament/tabs/matchUpsTab/republishRankingsAction';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
 import { mutationRequest } from 'services/mutation/mutationRequest';
-import { venueCalendarDate } from 'functions/venueTimeFrame';
+import { venueToday } from 'functions/venueTimeFrame';
 import { tmxToast } from 'services/notifications/tmxToast';
 import { tournamentEngine } from 'services/factory/engine';
 import { RIGHT } from 'constants/tmxConstants';
@@ -26,12 +26,12 @@ import { t } from 'i18n';
 // abandon action a day early or late for anyone running the event from another
 // zone. The previous `dayjs().format('YYYY-MM-DD')` fixed the UTC half of this
 // (#1352's bug class) and left the operator-vs-venue half, which is what
-// `venueCalendarDate()` closes.
+// `venueToday()` closes.
 function onOrPastLastDate(): boolean {
   const { tournamentRecord } = tournamentEngine.getTournament() ?? {};
   const endDate = tournamentRecord?.endDate;
   if (!endDate) return false;
-  return venueCalendarDate() >= String(endDate).slice(0, 10);
+  return venueToday() >= String(endDate).slice(0, 10);
 }
 
 // Modal body: a one-line explanation plus a checkbox that relaxes the default

--- a/src/pages/tournament/tabs/officialsTab/officialsTab.ts
+++ b/src/pages/tournament/tabs/officialsTab/officialsTab.ts
@@ -17,7 +17,8 @@ import { getCachedAllMatchUps, invalidateMatchUpCaches } from 'pages/tournament/
 import { contactFormatter } from 'components/tables/common/formatters/contactFormatter';
 import { controlBar } from 'courthive-components';
 import { callSheet } from 'components/modals/callSheet';
-import { buildOfficialsBoard, venueCalendarDay, type OfficialRow } from 'services/officiating/officialsBoard';
+import { buildOfficialsBoard, type OfficialRow } from 'services/officiating/officialsBoard';
+import { venueToday } from 'functions/venueTimeFrame';
 import { onMutationApplied } from 'services/mutation/mutationObservers';
 import { tournamentEngine } from 'tods-competition-factory';
 import { TabulatorFull as Tabulator } from 'tabulator-tables';
@@ -39,7 +40,7 @@ let unsubscribe: (() => void) | null = null;
  * claiming it was "the tournament's own frame" was simply wrong.
  */
 function viewedDate(): string {
-  return venueCalendarDay();
+  return venueToday();
 }
 
 function rows(): OfficialRow[] {

--- a/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
+++ b/src/pages/tournament/tabs/participantTab/controlBar/closeTheDay.ts
@@ -15,9 +15,10 @@
  * no jsdom and a decision made here would get no coverage.
  */
 
-import { stillSignedInOnDate, venueCalendarDay } from 'services/presence/signInPresence';
+import { stillSignedInOnDate } from 'services/presence/signInPresence';
 import { mutationRequest } from 'services/mutation/mutationRequest';
 import { tournamentEngine } from 'services/factory/engine';
+import { venueToday } from 'functions/venueTimeFrame';
 import { participantConstants } from 'tods-competition-factory';
 import { confirmModal } from 'components/modals/baseModal/baseModal';
 import { tmxToast } from 'services/notifications/tmxToast';
@@ -35,7 +36,7 @@ const { SIGNED_OUT } = participantConstants;
  * which is the *latest* value and therefore true for anybody who ever signed in. The date-scoped read
  * is the whole reason (c) exists.
  */
-export function participantsToCloseOut(date = venueCalendarDay()): string[] {
+export function participantsToCloseOut(date = venueToday()): string[] {
   const { participants } = tournamentEngine.getParticipants({}) ?? {};
   return stillSignedInOnDate(participants, date);
 }

--- a/src/pages/tournament/tabs/scheduleViews/gridView.ts
+++ b/src/pages/tournament/tabs/scheduleViews/gridView.ts
@@ -35,7 +35,7 @@ import {
   openShiftCourtsModal,
   Schedule2NowContext,
 } from './schedule2CellActions';
-import { venueCalendarDate, venueClock, venueNowOnDate } from 'functions/venueTimeFrame';
+import { venueClock, venueNowClock, venueNowOnDate, venueToday } from 'functions/venueTimeFrame';
 import { getActiveRegistrationNamesByCourtId } from './practiceRegistrationStrip';
 import { competitionEngine, tournamentEngine } from 'services/factory/engine';
 import { printCourtMatchUpCards } from 'components/modals/printCourtCards';
@@ -2596,7 +2596,7 @@ function buildActiveStripData(date: string): ActiveStripPanelData {
  * surface that keys "today" has to give the same answer as this one.
  */
 function todayIso(): string {
-  return venueCalendarDate();
+  return venueToday();
 }
 
 function refreshActiveStrip(date: string): void {
@@ -3088,7 +3088,7 @@ function buildStartOnDropMethods(matchUpId: string, drawId: string): any[] {
 
   // `startTime` is stored as a bare venue wall clock, so it must be read off the
   // venue's clock rather than the operator's.
-  const startTime = venueClock();
+  const startTime = venueNowClock();
   return [
     {
       method: BULK_SCHEDULE_MATCHUPS,

--- a/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
+++ b/src/pages/tournament/tabs/scheduleViews/schedule2CellActions.ts
@@ -24,7 +24,7 @@ import { destroyTipster } from 'components/popovers/tipster';
 import { competitionEngine } from 'services/factory/engine';
 import { evaluateRest, formatDuration } from './inspectorRest';
 import { timePicker } from 'components/modals/timePicker';
-import { venueClock } from 'functions/venueTimeFrame';
+import { venueNowClock } from 'functions/venueTimeFrame';
 import { Datepicker } from 'vanillajs-datepicker';
 import tippy, { type Instance } from 'tippy.js';
 import { i18next, t } from 'i18n';
@@ -318,7 +318,7 @@ function showMatchUpCellMenu(e: MouseEvent, ctx: Schedule2CellContext): void {
   const startMatch = () => {
     const drawId = matchUp?.drawId || cellData.drawId;
     if (!drawId) return;
-    const startTime = venueClock();
+    const startTime = venueNowClock();
     executeMethods(
       [
         {
@@ -712,7 +712,7 @@ export function handleSchedule2RowClick(e: MouseEvent, ctx: Schedule2RowContext)
   };
 
   const shotgunStart = () => {
-    const startTime = venueClock();
+    const startTime = venueNowClock();
     const startableIds = startableMatchUps.map((m: any) => m.matchUpId);
     executeMethods(
       [
@@ -819,7 +819,7 @@ function nowCellLabel(cell: NowStripCell): string {
  * time for anyone not sitting in the operator's zone.
  */
 function currentClockTime(): string {
-  return venueClock();
+  return venueNowClock();
 }
 
 /**

--- a/src/services/presence/signInPresence.ts
+++ b/src/services/presence/signInPresence.ts
@@ -35,7 +35,7 @@ const SIGNED_IN = 'SIGNED_IN';
  * surface in TMX moved to together (see `Mentat/planning/DECISION_VENUE_TIME_FRAME.md`). This function
  * must keep agreeing with `gridView.todayIso`; both now do, because both ask the same resolver.
  */
-export function venueCalendarDay(value?: string | Date): string {
+export function venueCalendarDay(value: string | Date): string {
   return venueCalendarDate(value);
 }
 


### PR DESCRIPTION
Punch-list **A10** — the 🟠 MED `venueTimeFrame`'s-wrappers-default-to-NOW entry in `Mentat/TASKS.md`, raised 2026-08-29 and NOT STARTED since. The entry says it "wanted its own session rather than a ride-along on a production fix"; this is that session.

## The footgun

`venueClock()`, `venueCalendarDate()` and `venueDayMinutes()` substituted `new Date()` for a missing instant:

```ts
export function venueClock(value?: string | number | Date, timeZone?: string): string {
  const parts = venueParts(value ?? new Date(), timeZone);   // ← absent input becomes NOW
```

So `venueClock(matchUp.schedule.calledAt)` on an *uncalled* matchUp returned the current clock. In production that rendered a call time against **every** matchUp of a tournament whose first day had not arrived — identical on every row, advancing on each redraw (#1387). The formatter's own `if (!clock) return ''` could not catch it: "now" is a valid clock string.

The module already knew better, and said so about `venueParts`:

> *Returns `undefined` for unparseable input rather than a substituted default — a wrong time is worse than a missing one everywhere this is used.*

Its own wrappers then substituted a default. `architectural-standards.md` **A3 — open defaults are fail-open**, and `coding-standards.md`'s *"a default is not a detection"*, in the module those standards most need to hold.

## Why not `arguments.length`

The entry called this out and it holds up: it breaks **forwarding wrappers**, which always pass one argument whether or not their own caller did. `signInPresence.venueCalendarDay(value?)` was exactly that, so `officialsTab`'s bare `venueCalendarDay()` — which legitimately means "today" — would have started returning `''`. A silent regression instead of a compiler error.

## What this does

The instant is **required**, and the sites that genuinely mean now say so: `venueToday()` and `venueNowClock()`. The compiler found all twelve and nothing else — the same list the entry predicted:

`matchUpDateFilter` · `scheduleStatusFormatter` ×2 · `printFactSheet` · `maybeNudgeActiveDates` · `abandonMatchUpsAction` · `gridView` ×2 · `schedule2CellActions` ×3 · `officialsTab` and `closeTheDay` (both via `venueCalendarDay`, whose argument is now required too)

One site deliberately keeps `venueClock(now)`: `gridView`'s auto-call pass needs the clock and the `calledAt` stamp to come from **one** instant, and passing it explicitly is what says so.

Two narratives that had gone stale are updated rather than left contradicting the code: `scheduleStatusFormatter`'s comment about the default, and its source-grep guard, which now checks for `venueToday` / `venueNowClock`. The `calledAtClock` value tests stay exactly as they are — the cell value arrives from Tabulator as `any`, which is precisely where the compiler has nothing to say.

## Verification

- `TZ=UTC vitest run` — **1837 passed** (5 new). A required argument cannot be tested by calling without one, so the new tests assert the named helpers agree with the explicit form, that "now" is read in the **venue** zone rather than the runner's, and that an *unreadable* instant still yields a missing value rather than a substituted one — the same failure mode by the door the compiler cannot close.
- e2e `TEST_PROD=1` across every touched surface — officials board (106, 116), sign-in (74), participant rest (98), call sheet (104), calledAt column (57), abandon actions (54), venue-frame notice (108): **26 passed**
- lint / check-types / format:check clean

## Sequencing

Touches the three wrappers; #1436(TMX) touches `venueParts` / `venueOffsetMinutesAt` / `venueWallClockToMs` and the header. Adjacent but not overlapping — whichever lands second takes a small rebase, no resolution.