### PR TITLE
docs(schedule): the factory queries these modules were built for now exist

### DIFF
--- a/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
+++ b/src/pages/tournament/tabs/scheduleViews/matchUpReadiness.ts
@@ -30,9 +30,23 @@
  *     `getMatchUpFormatTiming` — the same resolution the auto-scheduler uses,
  *     including its scheduling-policy fallback.
  *
- * `ReadinessInput` → `ReadinessResult` is therefore the seam: a future factory
+ * `ReadinessInput` → `ReadinessResult` is therefore the seam: a factory
  * `getMatchUpReadiness` replaces this function's body and keeps the contract.
  * Nothing above the seam knows which side of it the answer came from.
+ *
+ * ── That factory query now exists ──
+ *
+ * `getMatchUpReadiness` shipped in factory 7.x (#4828(factory)) with this payload shape unchanged,
+ * so the swap here is an import. It is **not done yet**: TMX CI installs the published factory with
+ * the `link:` overrides stripped, so it waits for the 7.0.0 publish.
+ *
+ * The helpers this module exports beside the analysis — `isFinished`, `individualIds`,
+ * `matchUpLabel`, `minutesToClock`, `nameFor` — are exported from the factory query too, so they
+ * come across rather than needing a new home here.
+ *
+ * Read the "TMX — adopt the factory's `getMatchUpReadiness` / `getParticipantRest`" entry in
+ * `Mentat/TASKS.md` before starting: it carries the file-by-file disposition and the one adapter
+ * decision that is not mechanical.
  *
  * Vocabulary deliberately matches `scheduleResultsDescribe.ts` ("needs recovery
  * time", "not before HH:MM", "waiting on …") so the same condition does not read

--- a/src/pages/tournament/tabs/scheduleViews/participantRest.ts
+++ b/src/pages/tournament/tabs/scheduleViews/participantRest.ts
@@ -58,9 +58,23 @@
  * reserved for the case where the whole ladder is in the future.
  *
  * `RestInput` → `RestResult` is the seam, matching `matchUpReadiness.ts`: a
- * future factory `getParticipantRest` replaces this body and keeps the contract.
- * The factory is pure and has no clock, so it would take the same injected
- * `asOfMinutes` — the `calledAt` idiom of a caller-supplied wall clock.
+ * factory `getParticipantRest` replaces this body and keeps the contract. The
+ * factory is pure and has no clock, so it takes the same injected asOf — the
+ * `calledAt` idiom of a caller-supplied wall clock.
+ *
+ * ── That factory query now exists, and the injected clock is an INSTANT ──
+ *
+ * `getParticipantRest` shipped in factory 7.x (#4828(factory)) with the row shape unchanged. It
+ * takes `asOf` as an ISO instant rather than minutes-from-midnight, because it does its own zone
+ * arithmetic — the day-clamping apparatus in `inspectorRest.ts` goes away with the swap.
+ *
+ * **Do not hand it `new Date().toISOString()`.** `nowDayMinutes()` projects today's time-of-day onto
+ * the *viewed* day, and that projection is load-bearing: the schedule opens on a tournament's last
+ * date once its dates are past, so a genuine `now` against a past-dated day puts every anchor hours
+ * behind and reports everybody rested — the fail-open direction this analysis exists to avoid. Pass
+ * the projected instant instead; `venueNowOnDate()` already computes that clock.
+ *
+ * Waiting on the 7.0.0 publish. Full disposition in `Mentat/TASKS.md`.
  */
 
 import { individualIds, isFinished, matchUpLabel, minutesToClock, nameFor } from './matchUpReadiness';


### PR DESCRIPTION
Documentation only — no behaviour, no exports, no tests changed.

Both module headers still described the factory query as *future*: *"a future factory `getMatchUpReadiness` replaces this function's body and keeps the contract"*. It shipped this morning — #4828(factory), merged as `89ea8c754` — along with `getParticipantRest`, both with their payload shapes unchanged.

So the notes now say what is actually true: the destination exists, the swap is an import, and it is **waiting on the 7.0.0 publish** because TMX CI installs the published factory with the `link:` overrides stripped.

## The part worth reading

`participantRest.ts` carries the one thing about crossing this seam that is not mechanical:

> **Do not hand it `new Date().toISOString()`.** `nowDayMinutes()` projects today's time-of-day onto the *viewed* day, and that projection is load-bearing — the schedule opens on a tournament's last date once its dates are past, so a genuine `now` against a past-dated day puts every anchor hours behind and reports everybody rested.

That is the fail-open direction this analysis exists to avoid, and it is exactly the kind of thing that gets discovered *after* a swap rather than before. `venueNowOnDate()` already computes the projected instant to pass instead — and since #1438 it returns `undefined` for a day the venue has not reached, which is the signal to skip the call.

Both notes point at the `Mentat/TASKS.md` entry that carries the file-by-file disposition.

## Verification

`TZ=UTC vitest run` — 1857 passed; lint / check-types / format:check clean.